### PR TITLE
fixes issue #17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-
 .PHONY: env env-dev lint test run doc
 
 # Dependencies need to be installed on the Anaconda virtual environment.
 env:
-	conda create -y -n QISKitenv python=3
-	bash -c "source activate QISKitenv;pip install -U -r requires.txt"
+	if test $(findstring QISKitenv, $(shell conda info --envs)); then \
+		bash -c "source activate QISKitenv;pip install -r requires.txt"; \
+	else \
+		conda create -y -n QISKitenv python=3; \
+		bash -c "source activate QISKitenv;pip install -r requires.txt"; \
+	fi;
 
 run:
 	bash -c "source activate QISKitenv;cd examples; cd jupyter;jupyter notebook"
@@ -30,7 +33,6 @@ lint:
 # TODO: Uncomment when the lint one passes.
 # test: lint
 test:
-	pip install -U -r requires.txt
 	python3 -m unittest discover -v
 
 profile:


### PR DESCRIPTION
This addresses an issue with installation of setuptools during initial 'make env'.

'make env' also tries to deal more gracefully with previous run of the target. Also, 'pip install' was removed from 'make test' since 'make env' now handles that.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
started new conda environment to test 'make env'.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.