### PR TITLE
Fixed measure and cgates to work on registers + bug fixes and tests for tools.qi

### DIFF
--- a/qiskit/_quantumcircuit.py
+++ b/qiskit/_quantumcircuit.py
@@ -132,7 +132,7 @@ class QuantumCircuit(object):
                 self.regs[register.name] = register
             else:
                 raise QISKitError("register name \"%s\" already exists"
-                                      % register.name)
+                                  % register.name)
 
     def _check_qreg(self, register):
         """Raise exception if r is not in this circuit or not qreg."""
@@ -174,10 +174,17 @@ class QuantumCircuit(object):
 
     def measure(self, qubit, cbit):
         """Measure quantum bit into classical bit (tuples)."""
-        self._check_qubit(qubit)
-        self._check_creg(cbit[0])
-        cbit[0].check_range(cbit[1])
-        return self._attach(Measure(qubit, cbit, self))
+        if isinstance(qubit, QuantumRegister) and \
+           isinstance(cbit, ClassicalRegister) and len(qubit) == len(cbit):
+            instructions = InstructionSet()
+            for i in range(qubit.size):
+                instructions.add(self.measure((qubit, i), (cbit, i)))
+            return instructions
+        else:
+            self._check_qubit(qubit)
+            self._check_creg(cbit[0])
+            cbit[0].check_range(cbit[1])
+            return self._attach(Measure(qubit, cbit, self))
 
     def reset(self, quantum_register):
         """Reset q."""

--- a/qiskit/extensions/standard/ch.py
+++ b/qiskit/extensions/standard/ch.py
@@ -22,7 +22,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
-
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 class CHGate(Gate):
     """controlled-H gate."""
@@ -49,10 +50,18 @@ class CHGate(Gate):
 
 def ch(self, ctl, tgt):
     """Apply CH from ctl to tgt."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CHGate(ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.ch((ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CHGate(ctl, tgt, self))
 
 
 QuantumCircuit.ch = ch

--- a/qiskit/extensions/standard/crz.py
+++ b/qiskit/extensions/standard/crz.py
@@ -22,7 +22,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
-
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 class CrzGate(Gate):
     """controlled-rz gate."""
@@ -51,10 +52,18 @@ class CrzGate(Gate):
 
 def crz(self, theta, ctl, tgt):
     """Apply crz from ctl to tgt with angle theta."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CrzGate(theta, ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.crz(theta, (ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CrzGate(theta, ctl, tgt, self))
 
 
 QuantumCircuit.crz = crz

--- a/qiskit/extensions/standard/cx.py
+++ b/qiskit/extensions/standard/cx.py
@@ -22,6 +22,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 
 class CnotGate(Gate):
@@ -49,10 +51,18 @@ class CnotGate(Gate):
 
 def cx(self, ctl, tgt):
     """Apply CNOT from ctl to tgt."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CnotGate(ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.cx((ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CnotGate(ctl, tgt, self))
 
 
 QuantumCircuit.cx = cx

--- a/qiskit/extensions/standard/cy.py
+++ b/qiskit/extensions/standard/cy.py
@@ -22,7 +22,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
-
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 class CyGate(Gate):
     """controlled-Y gate."""
@@ -49,10 +50,18 @@ class CyGate(Gate):
 
 def cy(self, ctl, tgt):
     """Apply CY to circuit."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CyGate(ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.cy((ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CyGate(ctl, tgt, self))
 
 
 QuantumCircuit.cy = cy

--- a/qiskit/extensions/standard/cz.py
+++ b/qiskit/extensions/standard/cz.py
@@ -21,7 +21,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
-
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 class CzGate(Gate):
     """controlled-Z gate."""
@@ -48,10 +49,18 @@ class CzGate(Gate):
 
 def cz(self, ctl, tgt):
     """Apply CZ to circuit."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CzGate(ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.cz((ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CzGate(ctl, tgt, self))
 
 
 QuantumCircuit.cz = cz

--- a/test/python/test_qi.py
+++ b/test/python/test_qi.py
@@ -23,6 +23,121 @@ import os
 import sys
 sys.path.append("../..")
 from tools.qi.pauli import Pauli, random_pauli, inverse_pauli, pauli_group, sgn_prod
+from tools.qi.qi import partial_trace, vectorize, devectorize, outer
+from tools.qi.qi import state_fidelity, purity, concurrence
+
+
+class TestQI(unittest.TestCase):
+    """Tests for qi.py"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.moduleName = os.path.splitext(__file__)[0]
+        cls.logFileName = cls.moduleName + '.log'
+        log_fmt = 'TestQI:%(levelname)s:%(asctime)s: %(message)s'
+        logging.basicConfig(filename=cls.logFileName, level=logging.INFO,
+                            format=log_fmt)
+
+    def test_partial_trace(self):
+        # reference
+        rho0 = [[0.5, 0.5], [0.5, 0.5]]
+        rho1 = [[1, 0], [0, 0]]
+        rho2 = [[0, 0], [0, 1]]
+        rho10 = np.kron(rho1, rho0)
+        rho20 = np.kron(rho2, rho0)
+        rho21 = np.kron(rho2, rho1)
+        rho210 = np.kron(rho21, rho0)
+        rhos = [rho0, rho1, rho2, rho10, rho20, rho21]
+
+        # test partial trace
+        tau0 = partial_trace(rho210, sys=[1, 2])
+        tau1 = partial_trace(rho210, sys=[0, 2])
+        tau2 = partial_trace(rho210, sys=[0, 1])
+
+        # test different dimensions
+        tau10 = partial_trace(rho210, dims=[4, 2], sys=[1])
+        tau20 = partial_trace(rho210, dims=[2, 2, 2], sys=[1])
+        tau21 = partial_trace(rho210, dims=[2, 4], sys=[0])
+        taus = [tau0, tau1, tau2, tau10, tau20, tau21]
+
+        all_pass = True
+        for i, j in zip(rhos, taus):
+            all_pass &= (np.linalg.norm(i-j) == 0)
+        self.assertTrue(all_pass)
+
+    def test_vectorize(self):
+        mat = [[1, 2], [3, 4]]
+        col = [1, 3, 2, 4]
+        row = [1, 2, 3, 4]
+        paul = [5, 5, -1j, -3]
+        test_pass = np.linalg.norm(vectorize(mat) - col) == 0 and \
+            np.linalg.norm(vectorize(mat, method='col') - col) == 0 and \
+            np.linalg.norm(vectorize(mat, method='row') - row) == 0 and \
+            np.linalg.norm(vectorize(mat, method='pauli') - paul) == 0
+        self.assertTrue(test_pass)
+
+    def test_devectorize(self):
+        mat = [[1, 2], [3, 4]]
+        col = [1, 3, 2, 4]
+        row = [1, 2, 3, 4]
+        paul = [5, 5, -1j, -3]
+        test_pass = np.linalg.norm(devectorize(col) - mat) == 0 and \
+            np.linalg.norm(devectorize(col, method='col') - mat) == 0 and \
+            np.linalg.norm(devectorize(row, method='row') - mat) == 0 and \
+            np.linalg.norm(devectorize(paul, method='pauli') - mat) == 0
+        self.assertTrue(test_pass)
+
+    def test_outer(self):
+        v_z = [1, 0]
+        v_y = [1, 1j]
+        rho_z = [[1, 0], [0, 0]]
+        rho_y = [[1, -1j], [1j, 1]]
+        op_zy = [[1, -1j], [0, 0]]
+        op_yz = [[1, 0], [1j, 0]]
+        test_pass = np.linalg.norm(outer(v_z) - rho_z) == 0 and \
+            np.linalg.norm(outer(v_y) - rho_y) == 0 and \
+            np.linalg.norm(outer(v_y, v_z) - op_yz) == 0 and \
+            np.linalg.norm(outer(v_z, v_y) - op_zy) == 0
+        self.assertTrue(test_pass)
+
+    def test_state_fidelity(self):
+        psi1 = [0.70710678118654746, 0, 0, 0.70710678118654746]
+        psi2 = [0., 0.70710678118654746, 0.70710678118654746, 0.]
+        rho1 = [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]]
+        mix = [[0.25, 0, 0, 0], [0, 0.25, 0, 0], [0, 0, 0.25, 0], [0, 0, 0, 0.25]]
+        test_pass = round(state_fidelity(psi1, psi1), 7) == 1.0 and \
+            round(state_fidelity(psi1, psi2), 8) == 0.0 and \
+            round(state_fidelity(psi1, rho1), 8) == 1.0 and \
+            round(state_fidelity(psi1, mix), 8) == 0.5 and \
+            round(state_fidelity(psi2, rho1), 8) == 0.0 and \
+            round(state_fidelity(psi2, mix), 8) == 0.5 and \
+            round(state_fidelity(rho1, rho1), 8) == 1.0 and \
+            round(state_fidelity(rho1, mix), 8) == 0.5 and \
+            round(state_fidelity(mix, mix), 8) == 1.0
+        self.assertTrue(test_pass)
+
+    def test_purity(self):
+        rho1 = [[1, 0], [0, 0]]
+        rho2 = [[0.5, 0], [0, 0.5]]
+        rho3 = 0.7 * np.array(rho1) + 0.3 * np.array(rho2)
+        test_pass = purity(rho1) == 1.0 and \
+            purity(rho2) == 0.5 and \
+            round(purity(rho3), 10) == 0.745
+        self.assertTrue(test_pass)
+
+    def test_concurrence(self):
+        psi1 = [1, 0, 0, 0]
+        rho1 = [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]]
+        rho2 = [[0, 0, 0, 0], [0, 0.5, -0.5j, 0], [0, 0.5j, 0.5, 0], [0, 0, 0, 0]]
+        rho3 = 0.5 * np.array(rho1) + 0.5 * np.array(rho2)
+        rho4 = 0.75 * np.array(rho1) + 0.25 * np.array(rho2)
+        test_pass = concurrence(psi1) == 0.0 and \
+            concurrence(rho1) == 1.0 and \
+            concurrence(rho2) == 1.0 and \
+            concurrence(rho3) == 0.0 and \
+            concurrence(rho4) == 0.5
+        self.assertTrue(test_pass)
+
 
 class TestPauli(unittest.TestCase):
     """Tests for Pauli class"""


### PR DESCRIPTION
- Fixed measure and control gates to work on registers of qubits.
- Fixed errors with concurrence and state_fidelity in tools.qi
- Added unit tests for tools.qi functions

## Description
- `circuit.measure(qr, cr)` now will apply measure operations between all qubits in a quantum register and all bits in a classical register. If registers are not the same size it will raise an exception. Eg if both a size 2 it will return qasm `measure qr[0]->cr[0]; measure qr[1]->cr[1];`
- `circuit.cx(qr1, qr2)` will apply CNOT gates between each qubit in register `qr1` to each qubit in register `qr2`. If registers are not the same size it will raise an exception. Eg. if both a size 2 it will return qasm `cx(qr1[0], qr2[0]); cx(qr1[1], qr2[1]);`. The same change was made for `cz, cy, ch, crz, cu1, cu3`.
- The `state_fidelity` function was returning `NaN` for pure state density matrices due to issues with `scipy.linalg.sqrtm`. I fixed this by adding a function `funm_svd` similar to the build in `scipy.linalg.funm` that applies a scalar function to the singular values of a matrix. The matrix square root for positive-semidefinite matrices is then computed using this function.
- The `concurrence` function was returning negative values for some states which should have zero concurrence (for example the maximally mixed two qubit state). This has been fixed.
- Fixed concurrence and purity to work for array_like input states (such as lists) by converting the input to a ndarray.
- Added `raise Exception` in place of print statements for input errors to several tools.qi functions.

## How Has This Been Tested?
All previous tests pass, and new unit tests have been added for functions in the `tools.qi` module.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.