### PR TITLE
Combine results, apply controlled gates and measure to whole registers

### DIFF
--- a/qiskit/_quantumcircuit.py
+++ b/qiskit/_quantumcircuit.py
@@ -132,7 +132,7 @@ class QuantumCircuit(object):
                 self.regs[register.name] = register
             else:
                 raise QISKitError("register name \"%s\" already exists"
-                                      % register.name)
+                                  % register.name)
 
     def _check_qreg(self, register):
         """Raise exception if r is not in this circuit or not qreg."""
@@ -174,10 +174,17 @@ class QuantumCircuit(object):
 
     def measure(self, qubit, cbit):
         """Measure quantum bit into classical bit (tuples)."""
-        self._check_qubit(qubit)
-        self._check_creg(cbit[0])
-        cbit[0].check_range(cbit[1])
-        return self._attach(Measure(qubit, cbit, self))
+        if isinstance(qubit, QuantumRegister) and \
+           isinstance(cbit, ClassicalRegister) and len(qubit) == len(cbit):
+            instructions = InstructionSet()
+            for i in range(qubit.size):
+                instructions.add(self.measure((qubit, i), (cbit, i)))
+            return instructions
+        else:
+            self._check_qubit(qubit)
+            self._check_creg(cbit[0])
+            cbit[0].check_range(cbit[1])
+            return self._attach(Measure(qubit, cbit, self))
 
     def reset(self, quantum_register):
         """Reset q."""

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1192,6 +1192,9 @@ class Result(object):
             The current object with appended results.
         """
         if self.__qobj['config'] == other.__qobj['config']:
+            if isinstance(self.__qobj['id'], str):
+                self.__qobj['id'] = [self.__qobj['id']]
+            self.__qobj['id'].append(other.__qobj['id'])
             self.__qobj['circuits'] += other.__qobj['circuits']
             self.__result['result'] += other.__result['result']
             return self

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -26,6 +26,7 @@ import json
 import os
 import string
 import re
+import copy
 
 # use the external IBMQuantumExperience Library
 from IBMQuantumExperience.IBMQuantumExperience import IBMQuantumExperience
@@ -1181,6 +1182,36 @@ class Result(object):
             the status of the results.
         """
         return self.__result['status']
+
+    def __iadd__(self, other):
+        """Append a Result object to current Result object.
+
+        Arg:
+            other (Result): a Result object to append.
+        Returns:
+            The current object with appended results.
+        """
+        if self.__qobj['config'] == other.__qobj['config']:
+            self.__qobj['circuits'] += other.__qobj['circuits']
+            self.__result['result'] += other.__result['result']
+            return self
+        else:
+            raise QISKitError('Result objects have different configs and cannot be combined.')
+
+    def __add__(self, other):
+        """Combine Result objects.
+
+        Note that the qobj id of the returned result will be the same as the
+        first result.
+
+        Arg:
+            other (Result): a Result object to combine.
+        Returns:
+            A new Result object consisting of combined objects.
+        """
+        ret = copy.deepcopy(self)
+        ret += other
+        return ret
 
     def get_error(self):
         if self.__result['status'] == 'ERROR':

--- a/qiskit/extensions/standard/ch.py
+++ b/qiskit/extensions/standard/ch.py
@@ -22,7 +22,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
-
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 class CHGate(Gate):
     """controlled-H gate."""
@@ -49,10 +50,18 @@ class CHGate(Gate):
 
 def ch(self, ctl, tgt):
     """Apply CH from ctl to tgt."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CHGate(ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.ch((ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CHGate(ctl, tgt, self))
 
 
 QuantumCircuit.ch = ch

--- a/qiskit/extensions/standard/crz.py
+++ b/qiskit/extensions/standard/crz.py
@@ -22,7 +22,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
-
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 class CrzGate(Gate):
     """controlled-rz gate."""
@@ -51,10 +52,18 @@ class CrzGate(Gate):
 
 def crz(self, theta, ctl, tgt):
     """Apply crz from ctl to tgt with angle theta."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CrzGate(theta, ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.crz(theta, (ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CrzGate(theta, ctl, tgt, self))
 
 
 QuantumCircuit.crz = crz

--- a/qiskit/extensions/standard/cx.py
+++ b/qiskit/extensions/standard/cx.py
@@ -22,6 +22,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 
 class CnotGate(Gate):
@@ -49,10 +51,18 @@ class CnotGate(Gate):
 
 def cx(self, ctl, tgt):
     """Apply CNOT from ctl to tgt."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CnotGate(ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.cx((ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CnotGate(ctl, tgt, self))
 
 
 QuantumCircuit.cx = cx

--- a/qiskit/extensions/standard/cy.py
+++ b/qiskit/extensions/standard/cy.py
@@ -22,7 +22,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
-
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 class CyGate(Gate):
     """controlled-Y gate."""
@@ -49,10 +50,18 @@ class CyGate(Gate):
 
 def cy(self, ctl, tgt):
     """Apply CY to circuit."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CyGate(ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.cy((ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CyGate(ctl, tgt, self))
 
 
 QuantumCircuit.cy = cy

--- a/qiskit/extensions/standard/cz.py
+++ b/qiskit/extensions/standard/cz.py
@@ -21,7 +21,8 @@ from qiskit import QuantumCircuit
 from qiskit import Gate
 from qiskit import CompositeGate
 from qiskit.extensions.standard import header
-
+from qiskit._quantumregister import QuantumRegister
+from qiskit._instructionset import InstructionSet
 
 class CzGate(Gate):
     """controlled-Z gate."""
@@ -48,10 +49,18 @@ class CzGate(Gate):
 
 def cz(self, ctl, tgt):
     """Apply CZ to circuit."""
-    self._check_qubit(ctl)
-    self._check_qubit(tgt)
-    self._check_dups([ctl, tgt])
-    return self._attach(CzGate(ctl, tgt, self))
+    if isinstance(ctl, QuantumRegister) and \
+       isinstance(tgt, QuantumRegister) and len(ctl) == len(tgt):
+        # apply cx to qubits between two registers
+        instructions = InstructionSet()
+        for i in range(ctl.size):
+            instructions.add(self.cz((ctl, i), (tgt, i)))
+        return instructions
+    else:
+        self._check_qubit(ctl)
+        self._check_qubit(tgt)
+        self._check_dups([ctl, tgt])
+        return self._attach(CzGate(ctl, tgt, self))
 
 
 QuantumCircuit.cz = cz

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -802,12 +802,8 @@ class TestQuantumProgram(unittest.TestCase):
         qc2.cx(qr[0], qr[1])
         qc2.cx(qr[0], qr[2])
         qc3.h(qr)
-        qc2.measure(qr[0], cr[0])
-        qc3.measure(qr[0], cr[0])
-        qc2.measure(qr[1], cr[1])
-        qc3.measure(qr[1], cr[1])
-        qc2.measure(qr[2], cr[2])
-        qc3.measure(qr[2], cr[2])
+        qc2.measure(qr, cr)
+        qc3.measure(qr, cr)
         circuits = ['qc2', 'qc3']
         shots = 1024  # the number of shots in the experiment.
         backend = 'local_qasm_simulator'
@@ -820,6 +816,29 @@ class TestQuantumProgram(unittest.TestCase):
         self.assertEqual(results3, {'001': 119, '111': 129, '110': 134,
                                     '100': 117, '000': 129, '101': 126,
                                     '010': 145, '011': 125})
+
+    def test_combine_results(self):
+        """Test run.
+
+        If all correct should the data.
+        """
+        QP_program = QuantumProgram()
+        qr = QP_program.create_quantum_register("qr", 1)
+        cr = QP_program.create_classical_register("cr", 1)
+        qc1 = QP_program.create_circuit("qc1", [qr], [cr])
+        qc2 = QP_program.create_circuit("qc2", [qr], [cr])
+        qc1.measure(qr[0], cr[0])
+        qc2.x(qr[0])
+        qc2.measure(qr[0], cr[0])
+        shots = 1024  # the number of shots in the experiment.
+        backend = 'local_qasm_simulator'
+        res1 = QP_program.execute(['qc1'], backend=backend, shots=shots)
+        res2 = QP_program.execute(['qc2'], backend=backend, shots=shots)
+        counts1 = res1.get_counts('qc1')
+        counts2 = res2.get_counts('qc2')
+        res1 += res2 # combine results
+        counts12 = [res1.get_counts('qc1'), res1.get_counts('qc2')]
+        self.assertEqual(counts12, [counts1, counts2])
 
     def test_local_qasm_simulator(self):
         """Test execute.


### PR DESCRIPTION
- Fixed measure and control gates to work on registers of qubits.
- Added magic methods to combine Result objects.

## Description
- `circuit.measure(qr, cr)` now will apply measure operations between all qubits in a quantum register and all bits in a classical register. If registers are not the same size it will raise an exception. Eg if both a size 2 it will return qasm `measure qr[0]->cr[0]; measure qr[1]->cr[1];`
- `circuit.cx(qr1, qr2)` will apply CNOT gates between each qubit in register `qr1` to each qubit in register `qr2`. If registers are not the same size it will raise an exception. Eg. if both a size 2 it will return qasm `cx(qr1[0], qr2[0]); cx(qr1[1], qr2[1]);`. The same change was made for `cz, cy, ch, crz, cu1, cu3`.
- Results may be combined using `+` and `+=`. Combining results with `+` returns a new Result object (using deepcopy), combining with `+=` appends the results from the second result to the first one. For results to be combined they must have the same `'config'` value in their qobj.

## How Has This Been Tested?
- All previous tests pass
- New unit test `test_combine_results` has been added to `test_quantumprogram.py`.
- Test `test_run_program` was updated to test for measurement between registers.

## Types of changes
- [x] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.