### PR TITLE
Rethrow IBMQuantumExperience RegisterSizeError exception

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -25,6 +25,7 @@ import copy
 
 # use the external IBMQuantumExperience Library
 from IBMQuantumExperience.IBMQuantumExperience import IBMQuantumExperience
+from IBMQuantumExperience.IBMQuantumExperience import RegisterSizeError
 
 # Stable Modules
 from . import QuantumRegister
@@ -1026,6 +1027,8 @@ class QuantumProgram(object):
             try:
                 output = self.__api.run_job(jobs, backend, shots=shots,
                                             max_credits=max_credits, seed=seed)
+            except RegisterSizeError:
+                raise
             except Exception as ex:
                 raise ConnectionError("Error trying to run the jobs online: {}"
                                   .format(ex))
@@ -1033,7 +1036,7 @@ class QuantumProgram(object):
                 raise ResultError(output['error'])
             if 'id' not in output:
                 raise ResultError('unexpected job results: {}'.format(output))
-                
+
             qobj_result = self._wait_for_job(output['id'], wait=wait,
                                              timeout=timeout, silent=silent)
         else:


### PR DESCRIPTION
We want to rethrow this exception so app developers can capture it.

## How Has This Been Tested?
There's a specific test: test_simulator_online_size()

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.