### PR TITLE
user-friendly Qconfig

### DIFF
--- a/Qconfig/__init__.py
+++ b/Qconfig/__init__.py
@@ -1,0 +1,65 @@
+#Initialization file for Qconfig
+
+#Tries to import Qtoken and load parameters from there into Qconfig.
+#If unable to find Qtoken, prompts user for credentials and offers to save/install them in Qtoken
+
+#TO DO: Add methods to support additional features: display/update Qtoken info, switch between different Qtokens, specify additional parameters like default values for backend, shots, timeout
+
+#First try to import Qtoken
+try:
+    import Qtoken
+    config = Qtoken.config
+    APItoken = Qtoken.APItoken
+    #TO DO: consider adding optional "quiet" flag to Qtoken to suppress the following print statement
+    print('\nQconfig: loaded API token from %s for access to %s' % (Qtoken.__file__, config['url']))
+#If unable to load Qtoken, prompt user for API token and URL. Create Qtoken with this info if desired
+except ModuleNotFoundError:
+    import getpass
+    import os
+    import pip
+    print('\nQconfig: unable to find a token.')
+    DEFAULT_API_URL = 'https://quantumexperience.ng.bluemix.net/api'
+    print('\nPlease enter the API access URL below, or simply press enter to use the default URL for the IBM Quantum Experience, %s' % DEFAULT_API_URL)
+    actual_api_url = input()
+    if len(actual_api_url) == 0:
+        actual_api_url = DEFAULT_API_URL
+    config = dict()
+    config['url'] = actual_api_url
+    print('\nUsing API URL %s' % actual_api_url)
+    print('\nPlease paste your API token below. For security, your token will not be displayed. Any leading or trailing whitespace will be removed. IBM Quantum Experience users can obtained an API token from the "API Token" section of the page at https://quantumexperience.ng.bluemix.net/qx/account')
+    APItoken = getpass.getpass('').strip()
+    #TO DO: validate API URL and token before proceeding; if unable to validate, inform user and ask permission before proceeding
+    print('\nPlease indicate how you would like to use this URL and token:\n 0 (default) = Create Qtoken package and install in active environment (this option is recommended for most users)\n 1 = Create Qtoken.py file in current working directory (%s)\n 2 = Use these credentials for the current session only' % os.getcwd())
+    token_option = input()
+    if token_option != '2': #if option 2, no further action needed; otherwise, make a Qtoken.py file and possibly pip install it
+        #if installing Qtoken in current environment, create a folder for the Qtoken package. Otherwise just create a local Qtoken.py file.
+        if token_option == '1':
+            qt_file_loc = 'Qtoken.py'
+        else:
+            qt_file_loc = 'Qtoken/Qtoken/__init__.py'
+            if not os.path.exists('Qtoken'):
+                os.mkdir('Qtoken')
+            if not os.path.exists('Qtoken/Qtoken'):
+                os.mkdir('Qtoken/Qtoken')
+        if os.path.exists(qt_file_loc):
+            print('File %s exists; overwrite? (y/n)' % qt_file_loc)
+            overwrite = input()
+            if not 'y' in str.lower(overwrite):
+                print('Aborting Qconfig setup. Move the file at %s elsewhere before trying again, or choose a different Qconfig setup option' % qt_file_loc)
+                exit
+        with open(qt_file_loc,'w') as qt_file:
+            qt_file.write('APItoken = "%s"\n' % APItoken)
+            qt_file.write('config = {"url": "%s"}\n' % config['url'])
+        print('\nAPI parameters saved in %s. To update them, edit this file.' % qt_file_loc) #this is true even if the pip install option is 
+        #if option 1, we're done; otherwise add a setup.py file and run pip to install the Qtoken package
+        if token_option != '1':
+            #make a setup.py file in that folder
+            with open('Qtoken/setup.py','w') as qt_file:
+                qt_file.write('from setuptools import setup\n')
+                qt_file.write('setup(name="Qtoken",version="1.0",py_modules=["Qtoken"])')
+            #do the installation with pip
+            pip_result = pip.main(['install','-e','Qtoken'])
+            if pip_result == 0:
+                print('\nInstalled Qtoken package in current environment. This package remains linked to (and dependent on) the file at %s' % qt_file_loc)
+            else:
+                print('\nAn error occurred installing the Qtoken package.')

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ packages = ["qiskit",
             "qiskit.tools",
             "qiskit.tools.apps",
             "qiskit.tools.qcvv",
-            "qiskit.tools.qi"]
+            "qiskit.tools.qi",
+            "Qconfig"]
 
 requirements = ["IBMQuantumExperience>=1.8",
                 "requests>=2.18,<2.19",


### PR DESCRIPTION

## Description
Following up on a discussion with Jay and Erick, this code implements a user-friendly way of setting up the API token in a way that it can be used without needing to worry about creating a Qconfig.py file or putting it in the right place on the path. The Qconfig package, installed as part of qiskit, tries to import a module called Qtoken. If it succeeds, it puts the parameters from Qtoken into Qconfig; if it fails, it prompts the user for an API URL and token, and offers to either store these parameters in a Qtoken.py file in the current directory, or put them in a package and install them with pip so that they can be accessed from any directory. This update does not require any other code changes and should not affect users who have already set up Qconfig.py with their API token.

## Motivation and Context
This makes it easier for people to input their API token and solves the problem of needing to set the path to find the Qconfig.py file.

## How Has This Been Tested?
I'm running on Windows but I tested all three options that it presents when it can't find a Qtoken, I tested inputting the token from both Python and Jupyter, and I tested to make sure it behaves properly when a Qtoken is found.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.