### PR TITLE
Fix ids starting with reserved word tokenizing #82

### DIFF
--- a/qiskit/qasm/_qasmlexer.py
+++ b/qiskit/qasm/_qasmlexer.py
@@ -77,26 +77,28 @@ class QasmLexer(object):
 
     # ---- Beginning of the PLY lexer ----
     literals = r'=()[]{};<>,.+-/*^"'
-    tokens = (
+    reserved = {
+        'barrier': 'BARRIER',
+        'creg': 'CREG',
+        'gate': 'GATE',
+        'if': 'IF',
+        'measure': 'MEASURE',
+        'opaque': 'OPAQUE',
+        'qreg': 'QREG',
+        'pi': 'PI',
+        'reset': 'RESET',
+    }
+    tokens = [
         'NNINTEGER',
-        'BARRIER',
-        'OPAQUE',
-        'RESET',
-        'IF',
         'REAL',
-        'QREG',
-        'CREG',
-        'GATE',
-        'PI',
         'CX',
         'U',
-        'MEASURE',
         'MAGIC',
         'ASSIGN',
         'MATCHES',
         'ID',
         'STRING',
-    )
+    ] + list(reserved.values())
 
     def t_REAL(self, t):
         r'(([0-9]+|([0-9]+)?\.[0-9]+|[0-9]+\.)[eE][+-]?[0-9]+)|(([0-9]+)?\.[0-9]+|[0-9]+\.)'
@@ -109,44 +111,12 @@ class QasmLexer(object):
         t.value = int(t.value)
         return t
 
-    def t_QREG(self, t):
-        'qreg'
-        return t
-
-    def t_CREG(self, t):
-        'creg'
-        return t
-
-    def t_GATE(self, t):
-        'gate'
-        return t
-
-    def t_MEASURE(self, t):
-        'measure'
-        return t
-
-    def t_IF(self, t):
-        'if'
-        return t
-
-    def t_RESET(self, t):
-        'reset'
-        return t
-
     def t_ASSIGN(self, t):
         '->'
         return t
 
     def t_MATCHES(self, t):
         '=='
-        return t
-
-    def t_BARRIER(self, t):
-        'barrier'
-        return t
-
-    def t_OPAQUE(self, t):
-        'opaque'
         return t
 
     def t_STRING(self, t):
@@ -208,11 +178,9 @@ class QasmLexer(object):
     def t_ID(self, t):
         r'[a-z][a-zA-Z0-9_]*'
 
-        if t.value == 'pi':
-            t.type = 'PI'
-            return t
-
-        t.value = node.Id(t.value, self.lineno, self.filename)
+        t.type = self.reserved.get(t.value, 'ID')
+        if t.type == 'ID':
+            t.value = node.Id(t.value, self.lineno, self.filename)
         return t
 
     def t_newline(self, t):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revise the lexer to prevent that the identifiers that start with a reserved word are interpreted as other types of token instead of identifiers, following the [guideline on the Ply documentation](http://www.dabeaz.com/ply/ply.html) (Section 4.3).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix issue #82, which is a bit more general than initially reported - the parser mistakenly interprets identifiers that begin with a "reserved word" such as:
```
qreg qregister[2];
barrier ifthisisabarrier;
```
as if they were a token + an identifier (`qreg`:QREG `ister`:ID, `if`:IF `thisisabarrier`:ID), causing the syntax to be invalid. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`, plus also `make test` at the `QISKit/openqasm` repository to validate with the full list of examples.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.