### PR TITLE
Issue #62: make AST nodes always Node subclasses

### DIFF
--- a/qiskit/qasm/_node/__init__.py
+++ b/qiskit/qasm/_node/__init__.py
@@ -1,5 +1,6 @@
 from ._barrier import Barrier
 from ._binaryop import BinaryOp
+from ._binaryoperator import BinaryOperator
 from ._cnot import Cnot
 from ._creg import Creg
 from ._customunitary import CustomUnitary
@@ -21,5 +22,6 @@ from ._program import Program
 from ._qreg import Qreg
 from ._real import Real
 from ._reset import Reset
+from ._unaryoperator import UnaryOperator
 from ._universalunitary import UniversalUnitary
 from ._nodeexception import NodeException

--- a/qiskit/qasm/_node/_binaryop.py
+++ b/qiskit/qasm/_node/_binaryop.py
@@ -19,13 +19,12 @@
 Node for an OPENQASM binary operation expression.
 """
 from ._node import Node
-from ._nodeexception import NodeException
 
 
 class BinaryOp(Node):
     """Node for an OPENQASM binary operation expression.
 
-    children[0] is the operation, as a character.
+    children[0] is the operation, as a binary operator node.
     children[1] is the left expression.
     children[2] is the right expression.
     """
@@ -36,29 +35,19 @@ class BinaryOp(Node):
 
     def qasm(self, prec=15):
         """Return the corresponding OPENQASM string."""
-        return "(" + self.children[1].qasm(prec) + self.children[0] + \
+        return "(" + self.children[1].qasm(prec) + self.children[0].value + \
                self.children[2].qasm(prec) + ")"
 
     def latex(self, prec=15, nested_scope=None):
         """Return the corresponding math mode latex string."""
         return "(" + self.children[1].latex(prec, nested_scope) + \
-            self.children[0] + \
+            self.children[0].value + \
             self.children[2].latex(prec, nested_scope) + ")"
 
     def real(self, nested_scope=None):
         """Return the correspond floating point number."""
-        operation = self.children[0]
+        operation = self.children[0].operation()
         lhs = self.children[1].real(nested_scope)
         rhs = self.children[2].real(nested_scope)
-        if operation == '+':
-            return lhs + rhs
-        elif operation == '-':
-            return lhs - rhs
-        elif operation == '*':
-            return lhs * rhs
-        elif operation == '/':
-            return lhs / rhs
-        elif operation == '^':
-            return lhs ** rhs
-        else:
-            raise NodeException("internal error: undefined binary op")
+
+        return operation(lhs, rhs)

--- a/qiskit/qasm/_node/_binaryoperator.py
+++ b/qiskit/qasm/_node/_binaryoperator.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+"""
+Node for an OPENQASM binary operator.
+"""
+import operator
+
+from ._node import Node
+from ._nodeexception import NodeException
+
+
+VALID_OPERATORS = {
+    '+': operator.add,
+    '-': operator.sub,
+    '*': operator.mul,
+    '/': operator.truediv,
+    '^': operator.pow
+}
+
+
+class BinaryOperator(Node):
+    """Node for an OPENQASM binary operator.
+
+    This node has no children. The data is in the value field.
+    """
+    def __init__(self, operation):
+        """Create the operator node."""
+        Node.__init__(self, 'operator', None, None)
+        self.value = operation
+
+    def operation(self):
+        """
+        Return the operator as a function f(left, right).
+        """
+        try:
+            return VALID_OPERATORS[self.value]
+        except KeyError:
+            raise NodeException("internal error: undefined operator '%s'" %
+                                self.value)
+
+    def qasm(self, prec=15):
+        return self.value

--- a/qiskit/qasm/_node/_if.py
+++ b/qiskit/qasm/_node/_if.py
@@ -25,7 +25,7 @@ class If(Node):
     """Node for an OPENQASM if statement.
 
     children[0] is an id node.
-    children[1] is an integer.
+    children[1] is an integer node.
     children[2] is quantum operation node, including U, CX, custom_unitary,
     measure, reset, (and BUG: barrier, if).
     """
@@ -37,5 +37,5 @@ class If(Node):
     def qasm(self, prec=15):
         """Return the corresponding OPENQASM string."""
         return "if(" + self.children[0].qasm(prec) + "==" \
-               + str(self.children[1]) + ") " + \
+               + str(self.children[1].value) + ") " + \
                self.children[2].qasm(prec)

--- a/qiskit/qasm/_node/_indexedid.py
+++ b/qiskit/qasm/_node/_indexedid.py
@@ -25,7 +25,7 @@ class IndexedId(Node):
     """Node for an OPENQASM indexed id.
 
     children[0] is an id node.
-    children[1] is an integer (not a node).
+    children[1] is an Int node.
     """
 
     def __init__(self, children):
@@ -35,7 +35,7 @@ class IndexedId(Node):
         self.name = self.id.name
         self.line = self.id.line
         self.file = self.id.file
-        self.index = children[1]
+        self.index = children[1].value
 
     def to_string(self, indent):
         """Print with indent."""

--- a/qiskit/qasm/_node/_magic.py
+++ b/qiskit/qasm/_node/_magic.py
@@ -24,7 +24,7 @@ from ._node import Node
 class Magic(Node):
     """Node for an OPENQASM file identifier/version statement ("magic number").
 
-    children[0] is a floating point number (not a node).
+    children[0] is a Real node.
     """
 
     def __init__(self, children):
@@ -33,4 +33,4 @@ class Magic(Node):
 
     def qasm(self, prec=15):
         """Return the corresponding OPENQASM string."""
-        return "OPENQASM %.1f;" % self.children[0]
+        return "OPENQASM %.1f;" % self.children[0].value

--- a/qiskit/qasm/_node/_prefix.py
+++ b/qiskit/qasm/_node/_prefix.py
@@ -19,13 +19,12 @@
 Node for an OPENQASM prefix expression.
 """
 from ._node import Node
-from ._nodeexception import NodeException
 
 
 class Prefix(Node):
     """Node for an OPENQASM prefix expression.
 
-    children[0] is a prefix string such as '-'.
+    children[0] is a unary operator node.
     children[1] is an expression node.
     """
 
@@ -35,20 +34,16 @@ class Prefix(Node):
 
     def qasm(self, prec=15):
         """Return the corresponding OPENQASM string."""
-        return self.children[0] + "(" + self.children[1].qasm(prec) + ")"
+        return self.children[0].value + "(" + self.children[1].qasm(prec) + ")"
 
     def latex(self, prec=15, nested_scope=None):
         """Return the corresponding math mode latex string."""
-        return self.children[0] + "(" + \
+        return self.children[0].value + "(" + \
             self.children[1].latex(prec, nested_scope) + ")"
 
     def real(self, nested_scope=None):
         """Return the correspond floating point number."""
-        operation = self.children[0]
+        operation = self.children[0].operation()
         expr = self.children[1].real(nested_scope)
-        if operation == '+':
-            return expr
-        elif operation == '-':
-            return -expr
-        else:
-            raise NodeException("internal error: undefined prefix")
+
+        return operation(expr)

--- a/qiskit/qasm/_node/_unaryoperator.py
+++ b/qiskit/qasm/_node/_unaryoperator.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+"""
+Node for an OPENQASM unary operator.
+"""
+import operator
+
+from ._node import Node
+from ._nodeexception import NodeException
+
+
+VALID_OPERATORS = {
+    '+': operator.pos,
+    '-': operator.neg,
+}
+
+
+class UnaryOperator(Node):
+    """Node for an OPENQASM unary operator.
+
+    This node has no children. The data is in the value field.
+    """
+    def __init__(self, operation):
+        """Create the operator node."""
+        Node.__init__(self, 'unary_operator', None, None)
+        self.value = operation
+
+    def operation(self):
+        """
+        Return the operator as a function f(left, right).
+        """
+        try:
+            return VALID_OPERATORS[self.value]
+        except KeyError:
+            raise NodeException("internal error: undefined prefix '%s'" %
+                                self.value)
+
+    def qasm(self, prec=15):
+        return self.value

--- a/qiskit/qasm/_qasmlexer.py
+++ b/qiskit/qasm/_qasmlexer.py
@@ -76,7 +76,7 @@ class QasmLexer(object):
         self.lexer.input(self.data)
 
     # ---- Beginning of the PLY lexer ----
-    literals = r'=()[]{};<>,.+-/*"'
+    literals = r'=()[]{};<>,.+-/*^"'
     tokens = (
         'NNINTEGER',
         'BARRIER',

--- a/qiskit/qasm/_qasmparser.py
+++ b/qiskit/qasm/_qasmparser.py
@@ -335,7 +335,7 @@ class QasmParser(object):
         if program[4] != ']':
             raise QasmError("Missing ']' in indexed ID; received",
                                 str(program[4].value))
-        program[0] = node.IndexedId([program[1], program[3]])
+        program[0] = node.IndexedId([program[1], node.Int(program[3])])
 
     # ----------------------------------------
     #  primary : id

--- a/qiskit/qasm/_qasmparser.py
+++ b/qiskit/qasm/_qasmparser.py
@@ -962,7 +962,7 @@ class QasmParser(object):
            prefix_expression : '+' prefix_expression
                              | '-' prefix_expression
         '''
-        program[0] = node.Prefix([program[1], program[2]])
+        program[0] = node.Prefix([node.UnaryOperator(program[1]), program[2]])
 
     def p_additive_expression_0(self, program):
         '''
@@ -975,7 +975,8 @@ class QasmParser(object):
             additive_expression : additive_expression '+' prefix_expression
                                 | additive_expression '-' prefix_expression
         '''
-        program[0] = node.BinaryOp([program[2], program[1], program[3]])
+        program[0] = node.BinaryOp([node.BinaryOperator(program[2]),
+                                    program[1], program[3]])
 
     def p_multiplicative_expression_0(self, program):
         '''
@@ -988,7 +989,8 @@ class QasmParser(object):
         multiplicative_expression : multiplicative_expression '*' additive_expression
                                   | multiplicative_expression '/' additive_expression
         '''
-        program[0] = node.BinaryOp([program[2], program[1], program[3]])
+        program[0] = node.BinaryOp([node.BinaryOperator(program[2]),
+                                    program[1], program[3]])
 
     def p_expression_0(self, program):
         '''

--- a/qiskit/qasm/_qasmparser.py
+++ b/qiskit/qasm/_qasmparser.py
@@ -875,7 +875,7 @@ class QasmParser(object):
         if program[7].type == 'barrier':
             raise QasmError("barrier not permitted in IF statement")
 
-        program[0] = node.If([program[3], program[5], program[7]])
+        program[0] = node.If([program[3], node.Int(program[5]), program[7]])
 
     # ----------------------------------------
     # These are all the things you can have outside of a gate declaration

--- a/qiskit/qasm/_qasmparser.py
+++ b/qiskit/qasm/_qasmparser.py
@@ -1002,7 +1002,8 @@ class QasmParser(object):
         '''
             expression : expression '^' multiplicative_expression
         '''
-        program[0] = node.BinaryOp([program[2], program[1], program[3]])
+        program[0] = node.BinaryOp([node.BinaryOperator(program[2]),
+                                    program[1], program[3]])
 
     # ----------------------------------------
     # exp_list : exp

--- a/qiskit/qasm/_qasmparser.py
+++ b/qiskit/qasm/_qasmparser.py
@@ -294,7 +294,7 @@ class QasmParser(object):
         '''
            magic : MAGIC REAL
         '''
-        program[0] = node.Magic([program[2]])
+        program[0] = node.Magic([node.Real(program[2])])
 
     def p_magic_0(self, program):
         '''

--- a/qiskit/unroll/_unroller.py
+++ b/qiskit/unroll/_unroller.py
@@ -243,7 +243,7 @@ class Unroller(object):
             self._process_measure(node)
 
         elif node.type == "magic":
-            self.version = float(node.children[0])
+            self.version = node.children[0].value
             self.backend.version(node.children[0])
 
         elif node.type == "barrier":

--- a/qiskit/unroll/_unroller.py
+++ b/qiskit/unroll/_unroller.py
@@ -171,7 +171,7 @@ class Unroller(object):
     def _process_if(self, node):
         """Process an if node."""
         creg = node.children[0].name
-        cval = node.children[1]
+        cval = node.children[1].value
         self.backend.set_condition(creg, cval)
         self._process_node(node.children[2])
         self.backend.drop_condition()

--- a/test/python/qasm/example_if.qasm
+++ b/test/python/qasm/example_if.qasm
@@ -1,0 +1,26 @@
+// Example file containing "if" instructions.
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg qr0[1];
+creg cr0[1];
+h qr0[0];
+measure qr0[0] -> cr0[0];
+if(cr0==0) x qr0[0];
+h qr0[0];
+reset qr0[0];
+measure qr0[0] -> cr0[0];
+h qr0[0];
+reset qr0[0];
+u1(0.562367489586523) qr0[0];
+measure qr0[0] -> cr0[0];
+reset qr0[0];
+reset qr0[0];
+reset qr0[0];
+h qr0[0];
+measure qr0[0] -> cr0[0];
+if(cr0==1) x qr0[0];
+h qr0[0];
+u1(0.083178154631269) qr0[0];
+h qr0[0];
+reset qr0[0];
+measure qr0[0] -> cr0[0];

--- a/test/python/test_qasm_parser.py
+++ b/test/python/test_qasm_parser.py
@@ -18,7 +18,8 @@
 
 import unittest
 
-import qiskit.qasm as Qasm
+from qiskit.qasm import Qasm, QasmError
+from qiskit.qasm._node._node import Node
 
 from .common import QiskitTestCase
 
@@ -29,7 +30,7 @@ def parse(file_path, prec=15):
       - file_path: Path to the OpenQASM file
       - prec: Precision for the returned string
     """
-    qasm = Qasm.Qasm(file_path)
+    qasm = Qasm(file_path)
     return qasm.parse().qasm(prec)
 
 
@@ -53,8 +54,19 @@ class TestParser(QiskitTestCase):
     def test_parser_fail(self):
         """should fail a for a  not valid circuit."""
 
-        self.assertRaisesRegex(Qasm.QasmError, "Perhaps there is a missing",
+        self.assertRaisesRegex(QasmError, "Perhaps there is a missing",
                                parse, file_path=self.QASM_FILE_PATH_FAIL)
+
+    def test_all_valid_nodes(self):
+        """Test that the tree contains only Node subclasses."""
+        def inspect(node):
+            for child in node.children:
+                self.assertTrue(isinstance(child, Node))
+                inspect(child)
+
+        qasm = Qasm(self.QASM_FILE_PATH)
+        res = qasm.parse()
+        inspect(res)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/test_qasm_parser.py
+++ b/test/python/test_qasm_parser.py
@@ -40,6 +40,8 @@ class TestParser(QiskitTestCase):
         self.QASM_FILE_PATH = self._get_resource_path('qasm/example.qasm')
         self.QASM_FILE_PATH_FAIL = self._get_resource_path(
             'qasm/example_fail.qasm')
+        self.QASM_FILE_PATH_IF = self._get_resource_path(
+            'qasm/example_if.qasm')
 
     def test_parser(self):
         """should return a correct response for a valid circuit."""
@@ -64,9 +66,15 @@ class TestParser(QiskitTestCase):
                 self.assertTrue(isinstance(child, Node))
                 inspect(child)
 
+        # Test the canonical example file.
         qasm = Qasm(self.QASM_FILE_PATH)
         res = qasm.parse()
         inspect(res)
+
+        # Test a file containing if instructions.
+        qasm_if = Qasm(self.QASM_FILE_PATH_IF)
+        res_if = qasm_if.parse()
+        inspect(res_if)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes for #62 and related issues:
* ensure that the following Nodes have children which are always a subclass of `Node`:
  * `IndexedId` (as noted in https://github.com/QISKit/qiskit-sdk-py/issues/62#issuecomment-328586459)
  * `BinOp` and `Prefix` (as noted in https://github.com/QISKit/qiskit-sdk-py/issues/62#issue-256569802). This involved introducing new nodes (`BinaryOperator` and `UnaryOperator`) to represent the children nodes.
  * `Magic` (discovered during testing).
* additionally fix the `^` operator, as it seems it produced a syntax error on the current version of the lexer as it was not considered a valid literal.

The operators are still considered plain `literal`s by the lexer - I'm not sure if it would be arguably cleaner to [consider them proper tokens](http://www.dabeaz.com/ply/ply.html#ply_nn11), and in the end I went with the option that seemed to fit into the current structure of the parser.

I would welcome a thorough review by the developers more involved in the parser, as while the tests are passing and I have introduced a new one for checking that the `qasm/example.qasm` file produces only `Node` subclasses, I'm not fully aware of potential side effects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #62.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`, and also `make test` on the OpenQASM repository.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.