### PR TITLE
Fixing the documentation and use of wait and timeout parameters in _quantumprogram

### DIFF
--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -217,8 +217,8 @@ class JobProcessor():
         """Process/submit jobs
 
         Args:
-            wait (int): Wait time is how long to check if all jobs is completed
-            timeout (int): Time waiting for the results
+            wait (int): Time interval to wait between requests for results
+            timeout (int): Total time waiting for the results
             silent (bool): If true, prints out results
         """
         executor = self.executor_class(max_workers=self.max_workers)

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -941,8 +941,8 @@ class QuantumProgram(object):
 
         Args:
             qobj (dict): the dictionary of the quantum object to run.
-            wait (int): wait time is how long to check if the job is completed
-            timeout (int): is time until the execution stops
+            wait (int): Time interval to wait between requests for results
+            timeout (int): Total time to wait until the execution stops
             silent (bool): is an option to print out the running information or
             not
 
@@ -963,8 +963,8 @@ class QuantumProgram(object):
 
         Args:
             qobj_list (list(dict)): The list of quantum objects to run.
-            wait (int): Wait time is how long to check if all jobs is completed
-            timeout (int): Time until the execution stops
+            wait (int): Time interval to wait between requests for results
+            timeout (int): Total time to wait until the execution stops
             silent (bool): If true, prints out the running information
 
         Returns:
@@ -988,8 +988,8 @@ class QuantumProgram(object):
         Args:
             qobj(dict): the dictionary of the quantum object to
                 run or list of qobj.
-            wait (int): Wait time is how long to check if all jobs is completed
-            timeout (int): Time until the execution stops
+            wait (int): Time interval to wait between requests for results
+            timeout (int): Total time to wait until the execution stops
             silent (bool): If true, prints out the running information
             callback (fn(result)): A function with signature:
                     fn(result):
@@ -1011,8 +1011,8 @@ class QuantumProgram(object):
 
         Args:
             qobj_list (list(dict)): The list of quantum objects to run.
-            wait (int): Wait time is how long to check if all jobs is completed
-            timeout (int): Time until the execution stops
+            wait (int): Time interval to wait between requests for results
+            timeout (int): Total time to wait until the execution stops
             silent (bool): If true, prints out the running information
             callback (fn(results)): A function with signature:
                     fn(results):
@@ -1040,7 +1040,7 @@ class QuantumProgram(object):
 
         job_processor = JobProcessor(q_job_list, max_workers=5, api=self.__api,
                                      callback=self._jobs_done_callback)
-        job_processor.submit()
+        job_processor.submit(wait, timeout, silent)
 
 
     def _jobs_done_callback(self, jobs_results):
@@ -1084,8 +1084,8 @@ class QuantumProgram(object):
             backend (str): a string representing the backend to compile to
             config (dict): a dictionary of configurations parameters for the
                 compiler
-            wait (int): wait time is how long to check if the job is completed
-            timeout (int): is time until the execution stops
+            wait (int): Time interval to wait between requests for results
+            timeout (int): Total time to wait until the execution stops
             silent (bool): is an option to print out the compiling information
             or not
             basis_gates (str): a comma seperated string and are the base gates,

--- a/qiskit/mapper/_compiling.py
+++ b/qiskit/mapper/_compiling.py
@@ -19,7 +19,7 @@
 Methods to assist with compiling tasks.
 """
 import math
-from scipy.linalg import expm
+import scipy
 import numpy as np
 
 from ._mappererror import MapperError
@@ -237,7 +237,7 @@ def two_qubit_kak(unitary_matrix):
        np.linalg.norm(np.kron(V1, V2) - K2) > 1e-4:
         raise MapperError("compiling.two_qubit_kak: " +
                           "error in SU(2) x SU(2) part")
-    test = expm(1j*(alpha * xx + beta * yy + gamma * zz))
+    test = scipy.linalg.expm(1j*(alpha * xx + beta * yy + gamma * zz))
     if np.linalg.norm(A - test) > 1e-4:
         raise MapperError("compiling.two_qubit_kak: " +
                           "error in A part")

--- a/qiskit/mapper/_compiling.py
+++ b/qiskit/mapper/_compiling.py
@@ -19,7 +19,7 @@
 Methods to assist with compiling tasks.
 """
 import math
-import scipy
+from scipy.linalg import expm
 import numpy as np
 
 from ._mappererror import MapperError
@@ -237,7 +237,7 @@ def two_qubit_kak(unitary_matrix):
        np.linalg.norm(np.kron(V1, V2) - K2) > 1e-4:
         raise MapperError("compiling.two_qubit_kak: " +
                           "error in SU(2) x SU(2) part")
-    test = scipy.linalg.expm(1j*(alpha * xx + beta * yy + gamma * zz))
+    test = expm(1j*(alpha * xx + beta * yy + gamma * zz))
     if np.linalg.norm(A - test) > 1e-4:
         raise MapperError("compiling.two_qubit_kak: " +
                           "error in A part")


### PR DESCRIPTION
## Description
The function _run_internal in qiskit/_quantumprogram.py is not passing on the wait and timeout parameters to the jobprocessor. This PR fixes this issue.
Moreover, the documentation about the wait and timeout parameters for the functions run, run_async, run_batch, run_batch_async is a bit confusing. This PR also changes this.

## Motivation and Context
Clarifying the use of wait and timeout parameters.

## How Has This Been Tested?
The existing tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.