### PR TITLE
Issue #88: use standard logging instead of print

### DIFF
--- a/doc/dev_introduction.rst
+++ b/doc/dev_introduction.rst
@@ -69,3 +69,54 @@ Several unroller backends and their outputs are summarized here:
 .. image:: ../images/unroller_backends.png
     :width: 600px
     :align: center
+
+
+Logging
+-------
+
+The SDK uses the `standard Python "logging" library
+<https://docs.python.org/3/library/logging.html>`_ for emitting several messages using the
+family of "`qiskit.*`" loggers, and abides by the standard convention for the log levels:
+
+.. tabularcolumns:: |l|L|
+
++--------------+----------------------------------------------+
+| Level        | When it's used                               |
++==============+==============================================+
+| ``DEBUG``    | Detailed information, typically of interest  |
+|              | only when diagnosing problems.               |
++--------------+----------------------------------------------+
+| ``INFO``     | Confirmation that things are working as      |
+|              | expected.                                    |
++--------------+----------------------------------------------+
+| ``WARNING``  | An indication that something unexpected      |
+|              | happened, or indicative of some problem in   |
+|              | the near future (e.g. 'disk space low').     |
+|              | The software is still working as expected.   |
++--------------+----------------------------------------------+
+| ``ERROR``    | Due to a more serious problem, the software  |
+|              | has not been able to perform some function.  |
++--------------+----------------------------------------------+
+| ``CRITICAL`` | A serious error, indicating that the program |
+|              | itself may be unable to continue running.    |
++--------------+----------------------------------------------+
+
+
+For convenience, :py:class:`QuantumProgram <qiskit.QuantumProgram>` provides two convenience
+methods (:py:func:`enable_logs() <qiskit.QuantumProgram.enable_logs>` and
+:py:func:`disable_logs() <qiskit.QuantumProgram.disable_logs>`) that modify the handlers
+and the level of the `qiskit` logger. Using these methods might interfer with the global
+logging setup of your environment - please take it into consideration if developing an
+application on top of the SDK.
+
+The convention for emitting log messages is declare a global variable in the module named
+**logger**, which contains the logger with that module's **__name__**, and use it for emitting
+the messages. For example, if the module is `qiskit/some/module.py`:
+
+.. code-block:: python
+
+   import logging
+
+   logger = logging.getLogger(__name__)  # logger for "qiskit.some.module"
+   ...
+   logger.info("This is an info message)

--- a/doc/dev_introduction.rst
+++ b/doc/dev_introduction.rst
@@ -105,7 +105,7 @@ family of "`qiskit.*`" loggers, and abides by the standard convention for the lo
 For convenience, :py:class:`QuantumProgram <qiskit.QuantumProgram>` provides two convenience
 methods (:py:func:`enable_logs() <qiskit.QuantumProgram.enable_logs>` and
 :py:func:`disable_logs() <qiskit.QuantumProgram.disable_logs>`) that modify the handlers
-and the level of the `qiskit` logger. Using these methods might interfer with the global
+and the level of the `qiskit` logger. Using these methods might interfere with the global
 logging setup of your environment - please take it into consideration if developing an
 application on top of the SDK.
 

--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -1,4 +1,6 @@
 from concurrent import futures
+import logging
+import pprint
 from threading import Lock
 import sys
 import time
@@ -9,6 +11,10 @@ from qiskit._resulterror import ResultError
 from qiskit import QISKitError
 from qiskit import _openquantumcompiler as openquantumcompiler
 from IBMQuantumExperience.IBMQuantumExperience import (IBMQuantumExperience)
+
+
+logger = logging.getLogger(__name__)
+
 
 def run_local_backend(qobj):
     """Run a program of compiled quantum circuits on the local machine.
@@ -40,7 +46,7 @@ def run_local_backend(qobj):
     backend = backendclass(qobj)
     return backend.run()
 
-def run_remote_backend(qobj, api, wait=5, timeout=60, silent=True):
+def run_remote_backend(qobj, api, wait=5, timeout=60):
     """
     Args:
         qobj (dict): quantum object dictionary
@@ -69,13 +75,13 @@ def run_remote_backend(qobj, api, wait=5, timeout=60, silent=True):
     if 'error' in output:
         raise ResultError(output['error'])
 
-    job_result = _wait_for_job(output['id'], api, wait=wait, timeout=timeout, silent=silent)
+    job_result = _wait_for_job(output['id'], api, wait=wait, timeout=timeout)
     job_result['name'] = qobj['id']
     job_result['backend'] = qobj['config']['backend']
     this_result = Result(job_result, qobj)
     return this_result
 
-def _wait_for_job(jobid, api, wait=5, timeout=60, silent=True):
+def _wait_for_job(jobid, api, wait=5, timeout=60):
     """Wait until all online ran circuits of a qobj are 'COMPLETED'.
 
     Args:
@@ -83,8 +89,6 @@ def _wait_for_job(jobid, api, wait=5, timeout=60, silent=True):
         api (IBMQuantumExperience): IBMQuantumExperience API connection
         wait (int):  is the time to wait between requests, in seconds
         timeout (int):  is how long we wait before failing, in seconds
-        silent (bool): is an option to print out the running information or
-            not
 
     Returns:
         A list of results that correspond to the jobids.
@@ -95,21 +99,20 @@ def _wait_for_job(jobid, api, wait=5, timeout=60, silent=True):
     timer = 0
     job_result = api.get_job(jobid)
     if 'status' not in job_result:
-        from pprint import pformat
-        raise QISKitError("get_job didn't return status: %s" % (pformat(job_result)))
+        raise QISKitError("get_job didn't return status: %s" %
+                          (pprint.pformat(job_result)))
 
     while job_result['status'] == 'RUNNING':
         if timer >= timeout:
             return {'status': 'ERROR', 'result': 'Time Out'}
         time.sleep(wait)
         timer += wait
-        if not silent:
-            print('status = %s (%d seconds)' % (job_result['status'], timer))
+        logger.info('status = %s (%d seconds)' % (job_result['status'], timer))
         job_result = api.get_job(jobid)
 
         if 'status' not in job_result:
-            from pprint import pformat
-            raise QISKitError("get_job didn't return status: %s" % (pformat(job_result)))
+            raise QISKitError("get_job didn't return status: %s" %
+                              (pprint.pformat(job_result)))
         if (job_result['status'] == 'ERROR_CREATING_JOB' or
                 job_result['status'] == 'ERROR_RUNNING_JOB'):
             return {'status': 'ERROR', 'result': job_result['status']}
@@ -201,19 +204,15 @@ class JobProcessor():
                 self.num_jobs -= 1
         # Call the callback when all jobs have finished
         if self.num_jobs == 0:
-            if not future.silent:
-                import pprint
-                pprint.pprint(result)
-                sys.stdout.flush()
+            logger.info(pprint.pformat(result))
             self.callback(self.jobs_results)
 
-    def submit(self, wait=5, timeout=120, silent=True):
+    def submit(self, wait=5, timeout=120):
         """Process/submit jobs
 
         Args:
             wait (int): Time interval to wait between requests for results
             timeout (int): Total time waiting for the results
-            silent (bool): If true, prints out results
         """
         executor = self.executor_class(max_workers=self.max_workers)
         for q_job in self.q_jobs:
@@ -223,9 +222,7 @@ class JobProcessor():
             elif self.online and q_job.backend in self._online_backends:
                 future = executor.submit(run_remote_backend,
                                          q_job.qobj,
-                                         self._api, wait=wait, timeout=timeout,
-                                         silent=silent)
-            future.silent = silent
+                                         self._api, wait=wait, timeout=timeout)
             future.qobj = q_job.qobj
             future.add_done_callback(self._job_done_callback)
             self.futures[future] = q_job.qobj

--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -107,7 +107,7 @@ def _wait_for_job(jobid, api, wait=5, timeout=60):
             return {'status': 'ERROR', 'result': 'Time Out'}
         time.sleep(wait)
         timer += wait
-        logger.info('status = %s (%d seconds)' % (job_result['status'], timer))
+        logger.info('status = %s (%d seconds)', job_result['status'], timer)
         job_result = api.get_job(jobid)
 
         if 'status' not in job_result:

--- a/qiskit/_logging.py
+++ b/qiskit/_logging.py
@@ -28,8 +28,8 @@ QISKIT_LOGGING_CONFIG = {
     },
     'handlers': {
         'h': {
-              'class': 'logging.StreamHandler',
-              'formatter': 'f'
+            'class': 'logging.StreamHandler',
+            'formatter': 'f'
         }
     },
     'loggers': {

--- a/qiskit/_logging.py
+++ b/qiskit/_logging.py
@@ -20,11 +20,24 @@ import logging
 from logging.config import dictConfig
 
 
+class SimpleInfoFormatter(logging.Formatter):
+    """Custom Formatter that uses a simple format for INFO."""
+    _style_info = logging._STYLES['%'][0]('%(message)s')
+
+    def formatMessage(self, record):
+        if record.levelno == logging.INFO:
+            return self._style_info.format(record)
+        return logging.Formatter.formatMessage(self, record)
+
+
 QISKIT_LOGGING_CONFIG = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
-        'f': {'format': '%(asctime)s:%(name)s:%(levelname)s:%(message)s'}
+        'f': {
+            '()': SimpleInfoFormatter,
+            'format': '%(asctime)s:%(name)s:%(levelname)s: %(message)s'
+        },
     },
     'handlers': {
         'h': {
@@ -45,8 +58,11 @@ def set_qiskit_logger():
     """Update 'qiskit' logger configuration using a SDK default one.
 
     Update the configuration of the 'qiskit' logger using the default SDK
-    configuration provided by `QISKIT_LOGGING_CONFIG` (console logging with a
-    custom format, level INFO).
+    configuration provided by `QISKIT_LOGGING_CONFIG`:
+
+    * console logging using a custom format for levels != INFO.
+    * console logging with simple format for level INFO.
+    * set logger level to INFO.
 
     Warning:
         This function modifies the configuration of the standard logging system

--- a/qiskit/_logging.py
+++ b/qiskit/_logging.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""Utilities for logging."""
+
+import logging
+from logging.config import dictConfig
+
+
+QISKIT_LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'f': {'format': '%(asctime)s:%(name)s:%(levelname)s:%(message)s'}
+    },
+    'handlers': {
+        'h': {
+              'class': 'logging.StreamHandler',
+              'formatter': 'f'
+        }
+    },
+    'loggers': {
+        'qiskit': {
+            'handlers': ['h'],
+            'level': logging.INFO,
+        },
+    }
+}
+
+
+def set_qiskit_logger():
+    """Update 'qiskit' logger configuration using a SDK default one.
+
+    Update the configuration of the 'qiskit' logger using the default SDK
+    configuration provided by `QISKIT_LOGGING_CONFIG` (console logging with a
+    custom format, level INFO).
+
+    Warning:
+        This function modifies the configuration of the standard logging system
+        for the 'qiskit.*' loggers, and might interfere with custom logger
+        configurations.
+    """
+    dictConfig(QISKIT_LOGGING_CONFIG)
+
+
+def unset_qiskit_logger():
+    """Remove the handlers for the 'qiskit' logger."""
+    qiskit_logger = logging.getLogger('qiskit')
+    for handler in qiskit_logger.handlers:
+        qiskit_logger.removeHandler(handler)

--- a/qiskit/_openquantumcompiler.py
+++ b/qiskit/_openquantumcompiler.py
@@ -1,10 +1,16 @@
+import logging
+
 import qiskit.qasm as qasm
 import qiskit.unroll as unroll
 import qiskit.mapper as mapper
 from qiskit._qiskiterror import QISKitError
 
+
+logger = logging.getLogger(__name__)
+
+
 def compile(qasm_circuit, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
-            initial_layout=None, silent=True, get_layout=False, format='dag'):
+            initial_layout=None, get_layout=False, format='dag'):
     """Compile the circuit.
 
     This builds the internal "to execute" list which is list of quantum
@@ -12,8 +18,6 @@ def compile(qasm_circuit, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
 
     Args:
         qasm_circuit (str): qasm text to compile
-        silent (bool): is an option to print out the compiling information
-            or not
         basis_gates (str): a comma seperated string and are the base gates,
                            which by default are: u1,u2,u3,cx,id
         coupling_map (dict): A directed graph of coupling::
@@ -54,17 +58,14 @@ def compile(qasm_circuit, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
     final_layout = None
     # if a coupling map is given compile to the map
     if coupling_map:
-        if not silent:
-            print("pre-mapping properties: %s"
-                  % compiled_dag_circuit.property_summary())
+        logger.info("pre-mapping properties: %s" %
+                    compiled_dag_circuit.property_summary())
         # Insert swap gates
         coupling = mapper.Coupling(coupling_map)
-        if not silent:
-            print("initial layout: %s" % initial_layout)
+        logger.info("initial layout: %s" % initial_layout)
         compiled_dag_circuit, final_layout = mapper.swap_mapper(
-            compiled_dag_circuit, coupling, initial_layout, trials=20, verbose=False)
-        if not silent:
-            print("final layout: %s" % final_layout)
+            compiled_dag_circuit, coupling, initial_layout, trials=20)
+        logger.info("final layout: %s" % final_layout)
         # Expand swaps
         compiled_dag_circuit = _unroller_code(compiled_dag_circuit.qasm())
         # Change cx directions
@@ -73,9 +74,8 @@ def compile(qasm_circuit, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
         mapper.cx_cancellation(compiled_dag_circuit)
         # Simplify single qubit gates
         compiled_dag_circuit = mapper.optimize_1q_gates(compiled_dag_circuit)
-        if not silent:
-            print("post-mapping properties: %s"
-                  % compiled_dag_circuit.property_summary())
+        logger.info("post-mapping properties: %s" %
+                    compiled_dag_circuit.property_summary())
     # choose output format
     if format == 'dag':
         compiled_circuit = compiled_dag_circuit

--- a/qiskit/_openquantumcompiler.py
+++ b/qiskit/_openquantumcompiler.py
@@ -58,14 +58,14 @@ def compile(qasm_circuit, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
     final_layout = None
     # if a coupling map is given compile to the map
     if coupling_map:
-        logger.info("pre-mapping properties: %s" %
+        logger.info("pre-mapping properties: %s",
                     compiled_dag_circuit.property_summary())
         # Insert swap gates
         coupling = mapper.Coupling(coupling_map)
-        logger.info("initial layout: %s" % initial_layout)
+        logger.info("initial layout: %s", initial_layout)
         compiled_dag_circuit, final_layout = mapper.swap_mapper(
             compiled_dag_circuit, coupling, initial_layout, trials=20)
-        logger.info("final layout: %s" % final_layout)
+        logger.info("final layout: %s", final_layout)
         # Expand swaps
         compiled_dag_circuit = _unroller_code(compiled_dag_circuit.qasm())
         # Change cx directions
@@ -74,7 +74,7 @@ def compile(qasm_circuit, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
         mapper.cx_cancellation(compiled_dag_circuit)
         # Simplify single qubit gates
         compiled_dag_circuit = mapper.optimize_1q_gates(compiled_dag_circuit)
-        logger.info("post-mapping properties: %s" %
+        logger.info("post-mapping properties: %s",
                     compiled_dag_circuit.property_summary())
     # choose output format
     if format == 'dag':

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -889,23 +889,31 @@ class QuantumProgram(object):
         return qobj
 
     def get_execution_list(self, qobj):
-        """Print the compiled circuits that are ready to run."""
+        """Print the compiled circuits that are ready to run.
+
+        Note:
+            This method is intended to be used during interactive sessions, and
+            prints directly to stdout instead of using the logger.
+
+        Returns:
+            list[str]: names of the circuits in `qobj`
+        """
         if not qobj:
-            logger.info("no executions to run")
+            print("no executions to run")
         execution_list = []
 
-        logger.info("id: %s", qobj['id'])
-        logger.info("backend: %s", qobj['config']['backend'])
-        logger.info("qobj config:")
+        print("id: %s" % qobj['id'])
+        print("backend: %s" % qobj['config']['backend'])
+        print("qobj config:")
         for key in qobj['config']:
             if key != 'backend':
-                logger.info(' %s: %s', key, str(qobj['config'][key]))
+                print(' '+ key + ': ' + str(qobj['config'][key]))
         for circuit in qobj['circuits']:
             execution_list.append(circuit["name"])
-            logger.info('  circuit name: %s', circuit["name"])
-            logger.info('  circuit config:')
+            print('  circuit name: ' + circuit["name"])
+            print('  circuit config:')
             for key in circuit['config']:
-                logger.info('   %s: ', str(circuit['config'][key]))
+                print('   '+ key + ': ' + str(circuit['config'][key]))
         return execution_list
 
     def get_compiled_configuration(self, qobj, name):

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -17,6 +17,7 @@ Qasm Program Class
 # pylint: disable=line-too-long
 import random
 import json
+import logging
 import os
 import string
 import re
@@ -35,6 +36,7 @@ from . import QuantumCircuit
 from . import QISKitError
 from . import JobProcessor
 from . import QuantumJob
+from ._logging import set_qiskit_logger, unset_qiskit_logger
 
 # Beta Modules
 from . import unroll
@@ -109,6 +111,39 @@ class QuantumProgram(object):
         self.jobs_results_ready_event = Event()
         self.are_multiple_results = False # are we expecting multiple results?
 
+    def enable_logs(self, level=logging.INFO):
+        """Enable the console output of the logging messages.
+
+        Enable the output of logging messages (above level `level`) to the
+        console, by configuring the `qiskit` logger accordingly.
+
+        Params:
+            level (int): minimum severity of the messages that are displayed.
+
+        Note:
+            This is a convenience method over the standard Python logging
+            facilities, and modifies the configuration of the 'qiskit.*'
+            loggers. If finer control over the logging configuration is needed,
+            it is encouraged to bypass this method.
+        """
+        # Update the handlers and formatters.
+        set_qiskit_logger()
+        # Set the logger level.
+        logging.getLogger('qiskit').setLevel(level)
+
+    def disable_logs(self):
+        """Disable the console output of the logging messages.
+
+        Disable the output of logging messages (above level `level`) to the
+        console, by removing the handlers from the `qiskit` logger.
+
+        Note:
+            This is a convenience method over the standard Python logging
+            facilities, and modifies the configuration of the 'qiskit.*'
+            loggers. If finer control over the logging configuration is needed,
+            it is encouraged to bypass this method.
+        """
+        unset_qiskit_logger()
 
     ###############################################################
     # methods to initiate an build a quantum program

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -200,12 +200,10 @@ class QuantumProgram(object):
             if size != len(self.__quantum_registers[name]):
                 raise QISKitError("Can't make this register: Already in"
                                   " program with different size")
-            logger.info(">> quantum_register exists: "
-                        "{0} {1}".format(name, size))
+            logger.info(">> quantum_register exists: %s %s", name, size)
         else:
             self.__quantum_registers[name] = QuantumRegister(name, size)
-            logger.info(">> new quantum_register created: "
-                        " {} {}".format(name, size))
+            logger.info(">> new quantum_register created: %s %s", name, size)
         return self.__quantum_registers[name]
 
     def create_quantum_registers(self, register_array):
@@ -245,11 +243,9 @@ class QuantumProgram(object):
             if size != len(self.__classical_registers[name]):
                 raise QISKitError("Can't make this register: Already in"
                                   " program with different size")
-            logger.info(">> classical register exists: "
-                        "{0} {1}".format(name, size))
+            logger.info(">> classical register exists: %s %s", name, size)
         else:
-            logger.info(">> new classical register created: "
-                        "{0} {1}".format(name, size))
+            logger.info(">> new classical register created: %s %s", name, size)
             self.__classical_registers[name] = ClassicalRegister(name, size)
         return self.__classical_registers[name]
 
@@ -898,18 +894,18 @@ class QuantumProgram(object):
             logger.info("no executions to run")
         execution_list = []
 
-        logger.info("id: %s" % qobj['id'])
-        logger.info("backend: %s" % qobj['config']['backend'])
+        logger.info("id: %s", qobj['id'])
+        logger.info("backend: %s", qobj['config']['backend'])
         logger.info("qobj config:")
         for key in qobj['config']:
             if key != 'backend':
-                logger.info(' '+ key + ': ' + str(qobj['config'][key]))
+                logger.info(' %s: %s', key, str(qobj['config'][key]))
         for circuit in qobj['circuits']:
             execution_list.append(circuit["name"])
-            logger.info('  circuit name: ' + circuit["name"])
+            logger.info('  circuit name: %s', circuit["name"])
             logger.info('  circuit config:')
             for key in circuit['config']:
-                logger.info('   '+ key + ': ' + str(circuit['config'][key]))
+                logger.info('   %s: ', str(circuit['config'][key]))
         return execution_list
 
     def get_compiled_configuration(self, qobj, name):

--- a/qiskit/backends/_qasm_cpp_simulator.py
+++ b/qiskit/backends/_qasm_cpp_simulator.py
@@ -144,8 +144,8 @@ class QasmCppSimulator(BaseBackend):
             # custom "backend" or "result" exception handler here?
             raise SimulatorError('local_qasm_cpp_simulator returned: {0}\n{1}'.
                             format(cout.decode(), cerr.decode()))
-        
-    def run_circuit(self, circuit, silent=True):
+
+    def run_circuit(self, circuit):
         """Run a single circuit on the C++ simulator
 
         Args:

--- a/qiskit/backends/_qasmsimulator.py
+++ b/qiskit/backends/_qasmsimulator.py
@@ -297,11 +297,8 @@ class QasmSimulator(BaseBackend):
         else:
             self._quantum_state = temp
 
-    def run(self, silent=True):
+    def run(self):
         """Run circuits in qobj
-        
-        Args:
-            silent (bool, optional): Silence print statements. Default is True.
         """
         result_list = []
         self._shots = self.qobj['config']['shots']

--- a/qiskit/backends/_unitarysimulator.py
+++ b/qiskit/backends/_unitarysimulator.py
@@ -90,11 +90,16 @@ returned results object::
             'state': 'DONE'
             }
 """
+import logging
 import numpy as np
 import json
 from ._simulatortools import enlarge_single_opt, enlarge_two_opt, single_gate_matrix
 from qiskit._result import Result
 from qiskit.backends._basebackend import BaseBackend
+
+
+logger = logging.getLogger(__name__)
+
 
 # TODO add ["status"] = 'DONE', 'ERROR' especitally for empty circuit error
 # does not show up
@@ -136,19 +141,15 @@ class UnitarySimulator(BaseBackend):
         unitaty_add = enlarge_two_opt(gate, q0, q1, self._number_of_qubits)
         self._unitary_state = np.dot(unitaty_add, self._unitary_state)
 
-    def run(self, silent=True):
-        """Run circuits in qobj
-        
-        Args:
-            silent (bool, optional): Silence print statements. Default is True.
-        """
+    def run(self):
+        """Run circuits in qobj"""
         result_list = []
         for circuit in self.qobj['circuits']:
-            result_list.append( self.run_circuit(circuit, silent=silent) )
+            result_list.append( self.run_circuit(circuit) )
         return Result({'result': result_list, 'status': 'COMPLETED'},
                       self.qobj)            
         
-    def run_circuit(self, circuit, silent=True):
+    def run_circuit(self, circuit):
         """Apply the single-qubit gate."""
         ccircuit = circuit['compiled_circuit']
         self._number_of_qubits = ccircuit['header']['number_of_qubits']
@@ -174,11 +175,11 @@ class UnitarySimulator(BaseBackend):
                                  [0, 1, 0, 0]])
                 self._add_unitary_two(gate, qubit0, qubit1)
             elif operation['name'] == 'measure':
-                if silent is False:
-                    print('Warning have dropped measure from unitary simulator')
+                logger.info('Warning have dropped measure from unitary '
+                            'simulator')
             elif operation['name'] == 'reset':
-                if silent is False:
-                    print('Warning have dropped reset from unitary simulator')
+                logger.info('Warning have dropped reset from unitary '
+                            'simulator')
             elif operation['name'] == 'barrier':
                 pass
             else:

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -69,13 +69,13 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials):
     has no multi-qubit gates.
     """
     logger.debug("layer_permutation: ----- enter -----")
-    logger.debug("layer_permutation: layer_partition = %s" %
-                pprint.pformat(layer_partition))
-    logger.debug("layer_permutation: layout = %s" %
-                pprint.pformat(layout))
-    logger.debug("layer_permutation: qubit_subset = %s" %
-                pprint.pformat(qubit_subset))
-    logger.debug("layer_permutation: trials = %s" % trials)
+    logger.debug("layer_permutation: layer_partition = %s",
+                 pprint.pformat(layer_partition))
+    logger.debug("layer_permutation: layout = %s",
+                 pprint.pformat(layout))
+    logger.debug("layer_permutation: qubit_subset = %s",
+                 pprint.pformat(qubit_subset))
+    logger.debug("layer_permutation: trials = %s", trials)
     rev_layout = {b: a for a, b in layout.items()}
     gates = []
     for layer in layer_partition:
@@ -84,12 +84,12 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials):
         elif len(layer) == 2:
             gates.append(tuple(layer))
 
-    logger.debug("layer_permutation: gates = %s" % pprint.pformat(gates))
+    logger.debug("layer_permutation: gates = %s", pprint.pformat(gates))
 
     # Can we already apply the gates?
     dist = sum([coupling.distance(layout[g[0]],
                                   layout[g[1]]) for g in gates])
-    logger.debug("layer_permutation: dist = %s" % dist)
+    logger.debug("layer_permutation: dist = %s", dist)
     if dist == len(gates):
         logger.debug("layer_permutation: done already")
         logger.debug("layer_permutation: ----- exit -----")
@@ -102,7 +102,7 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials):
     best_layout = None  # initialize best final layout
     for trial in range(trials):
 
-        logger.debug("layer_permutation: trial %s" % trial)
+        logger.debug("layer_permutation: trial %s", trial)
         trial_layout = copy.deepcopy(layout)
         rev_trial_layout = copy.deepcopy(rev_layout)
         trial_circ = ""  # circuit produced in this trial
@@ -147,7 +147,7 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials):
                         # Record progress if we succceed
                         if new_cost < min_cost:
                             logger.debug("layer_permutation: progress! "
-                                        "min_cost = %s" % min_cost)
+                                         "min_cost = %s", min_cost)
                             progress_made = True
                             min_cost = new_cost
                             opt_layout = new_layout
@@ -164,8 +164,8 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials):
                                                       opt_edge[0][1],
                                                       opt_edge[1][0],
                                                       opt_edge[1][1])
-                    logger.debug("layer_permutation: chose pair %s" %
-                                pprint.pformat(opt_edge))
+                    logger.debug("layer_permutation: chose pair %s",
+                                 pprint.pformat(opt_edge))
                 else:
                     break
 
@@ -173,7 +173,7 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials):
             # Compute the coupling graph distance
             dist = sum([coupling.distance(trial_layout[g[0]],
                                           trial_layout[g[1]]) for g in gates])
-            logger.debug("layer_permutation: dist = %s" % dist)
+            logger.debug("layer_permutation: dist = %s", dist)
             # If all gates can be applied now, we are finished
             # Otherwise we need to consider a deeper swap circuit
             if dist == len(gates):
@@ -183,15 +183,15 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials):
 
             # Increment the depth
             d += 1
-            logger.debug("layer_permutation: increment depth to %s" % d)
+            logger.debug("layer_permutation: increment depth to %s", d)
 
         # Either we have succeeded at some depth d < dmax or failed
         dist = sum([coupling.distance(trial_layout[g[0]],
                                       trial_layout[g[1]]) for g in gates])
-        logger.debug("layer_permutation: dist = %s" % dist)
+        logger.debug("layer_permutation: dist = %s", dist)
         if dist == len(gates):
             if d < best_d:
-                logger.debug("layer_permutation: got circuit with depth %s" % d)
+                logger.debug("layer_permutation: got circuit with depth %s", d)
                 best_circ = trial_circ
                 best_layout = trial_layout
             best_d = min(best_d, d)
@@ -240,20 +240,20 @@ def direction_mapper(circuit_graph, coupling_graph):
         nd = circuit_graph.multi_graph.node[cx_node]
         cxedge = tuple(nd["qargs"])
         if cxedge in cg_edges:
-            logger.debug("cx %s[%d], %s[%d] -- OK" %
-                        (cxedge[0][0], cxedge[0][1],
-                         cxedge[1][0], cxedge[1][1]))
+            logger.debug("cx %s[%d], %s[%d] -- OK",
+                         cxedge[0][0], cxedge[0][1],
+                         cxedge[1][0], cxedge[1][1])
             continue
         elif (cxedge[1], cxedge[0]) in cg_edges:
             circuit_graph.substitute_circuit_one(cx_node,
                                                  flipped_cx_circuit,
                                                  wires=[("q", 0), ("q", 1)])
-            logger.debug("cx %s[%d], %s[%d] -FLIP" %
-                        (cxedge[0][0], cxedge[0][1],
-                         cxedge[1][0], cxedge[1][1]))
+            logger.debug("cx %s[%d], %s[%d] -FLIP",
+                         cxedge[0][0], cxedge[0][1],
+                         cxedge[1][0], cxedge[1][1])
         else:
             raise MapperError("circuit incompatible with CouplingGraph: "
-                              "cx on %s" % pprint.pformat(cxedge))
+                              "cx on %s", pprint.pformat(cxedge))
     return circuit_graph
 
 
@@ -293,7 +293,7 @@ def update_qasm(i, first_layer, best_layout, best_d,
         # Output any swaps
         if best_d > 0:
             logger.debug("update_qasm_and_layout: swaps in this layer, "
-                        "depth %d" % best_d)
+                         "depth %d", best_d)
             openqasm_output += best_circ
         else:
             logger.debug("update_qasm_and_layout: no swaps in this layer")
@@ -332,7 +332,7 @@ def swap_mapper(circuit_graph, coupling_graph,
     layerlist = circuit_graph.layers()
     logger.debug("schedule:")
     for i in range(len(layerlist)):
-        logger.debug("    %d: %s" % (i, layerlist[i]["partition"]))
+        logger.debug("    %d: %s", i, layerlist[i]["partition"])
 
     if initial_layout is not None:
         # Check the input layout
@@ -358,7 +358,7 @@ def swap_mapper(circuit_graph, coupling_graph,
     layout = copy.deepcopy(initial_layout)
     openqasm_output = ""
     first_layer = True  # True until first layer is output
-    logger.debug("initial_layout = %s" % layout)
+    logger.debug("initial_layout = %s", layout)
 
     # Iterate over layers
     for i, layer in enumerate(layerlist):
@@ -367,9 +367,9 @@ def swap_mapper(circuit_graph, coupling_graph,
         success_flag, best_circ, best_d, best_layout, trivial_flag \
             = layer_permutation(layer["partition"], layout,
                                 qubit_subset, coupling_graph, trials)
-        logger.debug("swap_mapper: layer %d" % i)
-        logger.debug("swap_mapper: success_flag=%s,best_d=%s,trivial_flag=%s" %
-                    (success_flag, str(best_d), trivial_flag))
+        logger.debug("swap_mapper: layer %d", i)
+        logger.debug("swap_mapper: success_flag=%s,best_d=%s,trivial_flag=%s",
+                     success_flag, str(best_d), trivial_flag)
 
         # If this layer is only single-qubit gates,
         # and we have yet to see multi-qubit gates,
@@ -380,8 +380,8 @@ def swap_mapper(circuit_graph, coupling_graph,
 
         # If this fails, try one gate at a time in this layer
         if not success_flag:
-            logger.debug("swap_mapper: failed, layer %d, " % i,
-                        " retrying sequentially")
+            logger.debug("swap_mapper: failed, layer %d, "
+                         "retrying sequentially", i)
             serial_layerlist = layer["graph"].serial_layers()
 
             # Go through each gate in the layer
@@ -391,10 +391,10 @@ def swap_mapper(circuit_graph, coupling_graph,
                     = layer_permutation(serial_layer["partition"],
                                         layout, qubit_subset, coupling_graph,
                                         trials)
-                logger.debug("swap_mapper: layer %d, sublayer %d" % (i, j))
+                logger.debug("swap_mapper: layer %d, sublayer %d", i, j)
                 logger.debug("swap_mapper: success_flag=%s,best_d=%s,"
-                            "trivial_flag=%s" % (success_flag, str(best_d),
-                                                 trivial_flag))
+                             "trivial_flag=%s",
+                             success_flag, str(best_d), trivial_flag)
 
                 # Give up if we fail again
                 if not success_flag:
@@ -569,11 +569,11 @@ def yzy_to_zyz(xi, theta1, theta2, eps=1e-9):
     for delta_sol in zip(deltas, solutions):
         if delta_sol[0] < eps:
             return delta_sol[1]
-    logger.debug("xi=%s" % xi)
-    logger.debug("theta1=%s" % theta1)
-    logger.debug("theta2=%s" % theta2)
-    logger.debug("solutions=%s" % pprint.pformat(solutions))
-    logger.debug("deltas=%s" % pprint.pformat(deltas))
+    logger.debug("xi=%s", xi)
+    logger.debug("theta1=%s", theta1)
+    logger.debug("theta2=%s", theta2)
+    logger.debug("solutions=%s", pprint.pformat(solutions))
+    logger.debug("deltas=%s", pprint.pformat(deltas))
     assert False, "Error! No solution found. This should not happen."
 
 

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -20,12 +20,18 @@ Layout module to assist with mapping circuit qubits onto physical qubits.
 """
 import sys
 import copy
+import logging
 import math
 import numpy as np
 import networkx as nx
+import pprint
 from ._mappererror import MapperError
 from qiskit.qasm import Qasm
 import qiskit.unroll as unroll
+
+
+logger = logging.getLogger(__name__)
+
 
 # Notes:
 # Measurements may occur and be followed by swaps that result in repeated
@@ -37,7 +43,7 @@ import qiskit.unroll as unroll
 # because the initial state is zero. We don't do this.
 
 
-def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials, verbose=False):
+def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials):
     """Find a swap circuit that implements a permutation for this layer.
 
     The goal is to swap qubits such that qubits in the same two-qubit gates
@@ -62,12 +68,14 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials, v
     swap circuit has been applied. The trivial_flag is set if the layer
     has no multi-qubit gates.
     """
-    if verbose:
-        print("layer_permutation: ----- enter -----")
-        print("layer_permutation: layer_partition = ", layer_partition)
-        print("layer_permutation: layout = ", layout)
-        print("layer_permutation: qubit_subset = ", qubit_subset)
-        print("layer_permutation: trials = ", trials)
+    logger.debug("layer_permutation: ----- enter -----")
+    logger.debug("layer_permutation: layer_partition = %s" %
+                pprint.pformat(layer_partition))
+    logger.debug("layer_permutation: layout = %s" %
+                pprint.pformat(layout))
+    logger.debug("layer_permutation: qubit_subset = %s" %
+                pprint.pformat(qubit_subset))
+    logger.debug("layer_permutation: trials = %s" % trials)
     rev_layout = {b: a for a, b in layout.items()}
     gates = []
     for layer in layer_partition:
@@ -76,18 +84,15 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials, v
         elif len(layer) == 2:
             gates.append(tuple(layer))
 
-    if verbose:
-        print("layer_permutation: gates = ", gates)
+    logger.debug("layer_permutation: gates = %s" % pprint.pformat(gates))
 
     # Can we already apply the gates?
     dist = sum([coupling.distance(layout[g[0]],
                                   layout[g[1]]) for g in gates])
-    if verbose:
-        print("layer_permutation: dist = ", dist)
+    logger.debug("layer_permutation: dist = %s" % dist)
     if dist == len(gates):
-        if verbose:
-            print("layer_permutation: done already")
-            print("layer_permutation: ----- exit -----")
+        logger.debug("layer_permutation: done already")
+        logger.debug("layer_permutation: ----- exit -----")
         return True, "", 0, layout, len(gates) == 0
 
     # Begin loop over trials of randomized algorithm
@@ -97,8 +102,7 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials, v
     best_layout = None  # initialize best final layout
     for trial in range(trials):
 
-        if verbose:
-            print("layer_permutation: trial ", trial)
+        logger.debug("layer_permutation: trial %s" % trial)
         trial_layout = copy.deepcopy(layout)
         rev_trial_layout = copy.deepcopy(rev_layout)
         trial_circ = ""  # circuit produced in this trial
@@ -142,8 +146,8 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials, v
                                         for g in gates])
                         # Record progress if we succceed
                         if new_cost < min_cost:
-                            if verbose:
-                                print("layer_permutation: progress! min_cost = ", min_cost)
+                            logger.debug("layer_permutation: progress! "
+                                        "min_cost = %s" % min_cost)
                             progress_made = True
                             min_cost = new_cost
                             opt_layout = new_layout
@@ -160,8 +164,8 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials, v
                                                       opt_edge[0][1],
                                                       opt_edge[1][0],
                                                       opt_edge[1][1])
-                    if verbose:
-                        print("layer_permutation: chose pair ", opt_edge)
+                    logger.debug("layer_permutation: chose pair %s" %
+                                pprint.pformat(opt_edge))
                 else:
                     break
 
@@ -169,52 +173,44 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials, v
             # Compute the coupling graph distance
             dist = sum([coupling.distance(trial_layout[g[0]],
                                           trial_layout[g[1]]) for g in gates])
-            if verbose:
-                print("layer_permutation: dist = ", dist)
+            logger.debug("layer_permutation: dist = %s" % dist)
             # If all gates can be applied now, we are finished
             # Otherwise we need to consider a deeper swap circuit
             if dist == len(gates):
-                if verbose:
-                    print("layer_permutation: all can be applied now")
+                logger.debug("layer_permutation: all can be applied now")
                 trial_circ += circ
                 break
 
             # Increment the depth
             d += 1
-            if verbose:
-                print("layer_permutation: increment depth to ", d)
+            logger.debug("layer_permutation: increment depth to %s" % d)
 
         # Either we have succeeded at some depth d < dmax or failed
         dist = sum([coupling.distance(trial_layout[g[0]],
                                       trial_layout[g[1]]) for g in gates])
-        if verbose:
-            print("layer_permutation: dist = ", dist)
+        logger.debug("layer_permutation: dist = %s" % dist)
         if dist == len(gates):
             if d < best_d:
-                if verbose:
-                    print("layer_permutation: got circuit with depth ", d)
+                logger.debug("layer_permutation: got circuit with depth %s" % d)
                 best_circ = trial_circ
                 best_layout = trial_layout
             best_d = min(best_d, d)
 
     if best_circ is None:
-        if verbose:
-            print("layer_permutation: failed!")
-            print("layer_permutation: ----- exit -----")
+        logger.debug("layer_permutation: failed!")
+        logger.debug("layer_permutation: ----- exit -----")
         return False, None, None, None, False
     else:
-        if verbose:
-            print("layer_permutation: done")
-            print("layer_permutation: ----- exit -----")
+        logger.debug("layer_permutation: done")
+        logger.debug("layer_permutation: ----- exit -----")
         return True, best_circ, best_d, best_layout, False
 
 
-def direction_mapper(circuit_graph, coupling_graph, verbose=False):
+def direction_mapper(circuit_graph, coupling_graph):
     """Change the direction of CNOT gates to conform to CouplingGraph.
 
     circuit_graph = input DAGCircuit
     coupling_graph = corresponding CouplingGraph
-    verbose = optional flag to print more information
 
     Adds "h" to the circuit basis.
 
@@ -226,8 +222,8 @@ def direction_mapper(circuit_graph, coupling_graph, verbose=False):
     if "cx" not in circuit_graph.basis:
         return circuit_graph
     if circuit_graph.basis["cx"] != (2, 0, 0):
-        raise MapperError("cx gate has unexpected signature %s"
-                              % circuit_graph.basis["cx"])
+        raise MapperError("cx gate has unexpected signature %s" %
+                          circuit_graph.basis["cx"])
     flipped_qasm = "OPENQASM 2.0;\n" + \
                    "gate cx c,t { CX c,t; }\n" + \
                    "gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }\n" + \
@@ -244,26 +240,25 @@ def direction_mapper(circuit_graph, coupling_graph, verbose=False):
         nd = circuit_graph.multi_graph.node[cx_node]
         cxedge = tuple(nd["qargs"])
         if cxedge in cg_edges:
-            if verbose:
-                print("cx %s[%d], %s[%d] -- OK" % (cxedge[0][0], cxedge[0][1],
-                                                   cxedge[1][0], cxedge[1][1]))
+            logger.debug("cx %s[%d], %s[%d] -- OK" %
+                        (cxedge[0][0], cxedge[0][1],
+                         cxedge[1][0], cxedge[1][1]))
             continue
         elif (cxedge[1], cxedge[0]) in cg_edges:
             circuit_graph.substitute_circuit_one(cx_node,
                                                  flipped_cx_circuit,
                                                  wires=[("q", 0), ("q", 1)])
-            if verbose:
-                print("cx %s[%d], %s[%d] -FLIP" % (cxedge[0][0], cxedge[0][1],
-                                                   cxedge[1][0], cxedge[1][1]))
+            logger.debug("cx %s[%d], %s[%d] -FLIP" %
+                        (cxedge[0][0], cxedge[0][1],
+                         cxedge[1][0], cxedge[1][1]))
         else:
             raise MapperError("circuit incompatible with CouplingGraph: "
-                                  + "cx on %s" % cxedge)
+                              "cx on %s" % pprint.pformat(cxedge))
     return circuit_graph
 
 
 def update_qasm(i, first_layer, best_layout, best_d,
-                best_circ, circuit_graph, layer_list,
-                verbose=False):
+                best_circ, circuit_graph, layer_list):
     """Update the QASM string for an iteration of swap_mapper.
 
     i = layer number
@@ -273,7 +268,6 @@ def update_qasm(i, first_layer, best_layout, best_d,
     best_circ = swap circuit returned from swap algorithm
     circuit_graph = original input circuit
     layer_list = list of circuit objects for each layer
-    verbose = set True for more print output
 
     Return openqasm_output, the QASM string to append.
     """
@@ -284,8 +278,7 @@ def update_qasm(i, first_layer, best_layout, best_d,
     # output all layers up to this point and ignore any
     # swap gates. Set the initial layout.
     if first_layer:
-        if verbose:
-            print("update_qasm_and_layout: first multi-qubit gate layer")
+        logger.debug("update_qasm_and_layout: first multi-qubit gate layer")
         # Output all layers up to this point
         openqasm_output += circuit_graph.qasm(
             add_swap=True,
@@ -299,13 +292,11 @@ def update_qasm(i, first_layer, best_layout, best_d,
     else:
         # Output any swaps
         if best_d > 0:
-            if verbose:
-                print("update_qasm_and_layout: swaps in this layer, depth %d" %
-                      best_d)
+            logger.debug("update_qasm_and_layout: swaps in this layer, "
+                        "depth %d" % best_d)
             openqasm_output += best_circ
         else:
-            if verbose:
-                print("update_qasm_and_layout: no swaps in this layer")
+            logger.debug("update_qasm_and_layout: no swaps in this layer")
         # Output this layer
         openqasm_output += layer_list[i]["graph"].qasm(
             no_decls=True,
@@ -315,7 +306,7 @@ def update_qasm(i, first_layer, best_layout, best_d,
 
 def swap_mapper(circuit_graph, coupling_graph,
                 initial_layout=None,
-                basis="cx,u1,u2,u3,id", verbose=False, trials=20):
+                basis="cx,u1,u2,u3,id", trials=20):
     """Map a DAGCircuit onto a CouplingGraph using swap gates.
 
     Args:
@@ -325,7 +316,6 @@ def swap_mapper(circuit_graph, coupling_graph,
             of coupling_graph (optional)
         basis (str, optional): basis string specifying basis of output
             DAGCircuit
-        verbose (bool, optional): print more information
 
     Returns:
         Returns a DAGCircuit object containing a circuit equivalent to
@@ -340,10 +330,9 @@ def swap_mapper(circuit_graph, coupling_graph,
 
     # Schedule the input circuit
     layerlist = circuit_graph.layers()
-    if verbose:
-        print("schedule:")
-        for i in range(len(layerlist)):
-            print("    %d: %s" % (i, layerlist[i]["partition"]))
+    logger.debug("schedule:")
+    for i in range(len(layerlist)):
+        logger.debug("    %d: %s" % (i, layerlist[i]["partition"]))
 
     if initial_layout is not None:
         # Check the input layout
@@ -353,13 +342,11 @@ def swap_mapper(circuit_graph, coupling_graph,
         for k, v in initial_layout.items():
             qubit_subset.append(v)
             if k not in circ_qubits:
-                raise MapperError("initial_layout qubit %s[%d] not " %
-                                      (k[0], k[1]) +
-                                      "in input DAGCircuit")
+                raise MapperError("initial_layout qubit %s[%d] not in input "
+                                  "DAGCircuit" % (k[0], k[1]))
             if v not in coup_qubits:
-                raise MapperError("initial_layout qubit %s[%d] not " %
-                                      (v[0], v[1]) +
-                                      " in input CouplingGraph")
+                raise MapperError("initial_layout qubit %s[%d] not in input "
+                                  "CouplingGraph" % (v[0], v[1]))
     else:
         # Supply a default layout
         qubit_subset = coupling_graph.get_qubits()
@@ -371,8 +358,7 @@ def swap_mapper(circuit_graph, coupling_graph,
     layout = copy.deepcopy(initial_layout)
     openqasm_output = ""
     first_layer = True  # True until first layer is output
-    if verbose:
-        print("initial_layout = ", layout)
+    logger.debug("initial_layout = %s" % layout)
 
     # Iterate over layers
     for i, layer in enumerate(layerlist):
@@ -381,25 +367,21 @@ def swap_mapper(circuit_graph, coupling_graph,
         success_flag, best_circ, best_d, best_layout, trivial_flag \
             = layer_permutation(layer["partition"], layout,
                                 qubit_subset, coupling_graph, trials)
-        if verbose:
-            print("swap_mapper: layer %d" % i)
-            print("swap_mapper: success_flag=%s," % success_flag +
-                  "best_d=" + str(best_d) +
-                  ",trivial_flag=%s" % trivial_flag)
+        logger.debug("swap_mapper: layer %d" % i)
+        logger.debug("swap_mapper: success_flag=%s,best_d=%s,trivial_flag=%s" %
+                    (success_flag, str(best_d), trivial_flag))
 
         # If this layer is only single-qubit gates,
         # and we have yet to see multi-qubit gates,
         # continue to the next iteration
         if trivial_flag and first_layer:
-            if verbose:
-                print("swap_mapper: skip to next layer")
+            logger.debug("swap_mapper: skip to next layer")
             continue
 
         # If this fails, try one gate at a time in this layer
         if not success_flag:
-            if verbose:
-                print("swap_mapper: failed, layer %d, " % i,
-                      " retrying sequentially")
+            logger.debug("swap_mapper: failed, layer %d, " % i,
+                        " retrying sequentially")
             serial_layerlist = layer["graph"].serial_layers()
 
             # Go through each gate in the layer
@@ -409,28 +391,26 @@ def swap_mapper(circuit_graph, coupling_graph,
                     = layer_permutation(serial_layer["partition"],
                                         layout, qubit_subset, coupling_graph,
                                         trials)
-                if verbose:
-                    print("swap_mapper: layer %d, sublayer %d" % (i, j))
-                    print("swap_mapper: success_flag=%s," % success_flag +
-                          "best_d=" + str(best_d) +
-                          ",trivial_flag=%s" % trivial_flag)
+                logger.debug("swap_mapper: layer %d, sublayer %d" % (i, j))
+                logger.debug("swap_mapper: success_flag=%s,best_d=%s,"
+                            "trivial_flag=%s" % (success_flag, str(best_d),
+                                                 trivial_flag))
 
                 # Give up if we fail again
                 if not success_flag:
                     raise MapperError("swap_mapper failed: " +
-                                          "layer %d, sublayer %d" % (i, j) +
-                                          ", \"%s\"" %
-                                          serial_layer["graph"].qasm(
-                                              no_decls=True,
-                                              aliases=layout))
+                                      "layer %d, sublayer %d" % (i, j) +
+                                      ", \"%s\"" %
+                                      serial_layer["graph"].qasm(
+                                          no_decls=True,
+                                          aliases=layout))
 
                 # If this layer is only single-qubit gates,
                 # and we have yet to see multi-qubit gates,
                 # continue to the next inner iteration
                 if trivial_flag and first_layer:
-                    if verbose:
-                        print("swap_mapper: skip to next sublayer")
-                        continue
+                    logger.debug("swap_mapper: skip to next sublayer")
+                    continue
 
                 # Update the record of qubit positions for each inner iteration
                 layout = best_layout
@@ -438,7 +418,7 @@ def swap_mapper(circuit_graph, coupling_graph,
                 openqasm_output += update_qasm(j, first_layer,
                                                best_layout, best_d,
                                                best_circ, circuit_graph,
-                                               serial_layerlist, verbose)
+                                               serial_layerlist)
                 # Update initial layout
                 if first_layer:
                     initial_layout = layout
@@ -452,7 +432,7 @@ def swap_mapper(circuit_graph, coupling_graph,
             openqasm_output += update_qasm(i, first_layer,
                                            best_layout, best_d,
                                            best_circ, circuit_graph,
-                                           layerlist, verbose)
+                                           layerlist)
             # Update initial layout
             if first_layer:
                 initial_layout = layout
@@ -484,7 +464,7 @@ def test_trig_solution(theta, phi, lamb, xi, theta1, theta2):
     .. math::
        \cos(\phi+\lambda) \cos(\\theta) = \cos(xi) * \cos(\\theta1+\\theta2)
 
-       \sin(\phi+\lambda) \cos(\\theta) = \sin(xi) * \cos(\\theta1-\\theta2) 
+       \sin(\phi+\lambda) \cos(\\theta) = \sin(xi) * \cos(\\theta1-\\theta2)
 
        \cos(\phi-\lambda) \sin(\\theta) = \cos(xi) * \sin(\\theta1+\\theta2)
 
@@ -589,11 +569,11 @@ def yzy_to_zyz(xi, theta1, theta2, eps=1e-9):
     for delta_sol in zip(deltas, solutions):
         if delta_sol[0] < eps:
             return delta_sol[1]
-    print("xi=", xi)
-    print("theta1=", theta1)
-    print("theta2=", theta2)
-    print("solutions=", solutions)
-    print("deltas=", deltas)
+    logger.debug("xi=%s" % xi)
+    logger.debug("theta1=%s" % theta1)
+    logger.debug("theta2=%s" % theta2)
+    logger.debug("solutions=%s" % pprint.pformat(solutions))
+    logger.debug("deltas=%s" % pprint.pformat(deltas))
     assert False, "Error! No solution found. This should not happen."
 
 

--- a/test/python/test_job_processor.py
+++ b/test/python/test_job_processor.py
@@ -185,7 +185,7 @@ class TestJobProcessor(QiskitTestCase):
         quantum_job = QuantumJob(self.qasm_text, do_compile=True,
                                  backend='local_qasm_simulator')
         jp = jobprocessor.JobProcessor([quantum_job], callback=None)
-        jp.submit(silent=True)
+        jp.submit()
 
     def test_run_job_processor_local(self):
         njobs = 5
@@ -197,7 +197,7 @@ class TestJobProcessor(QiskitTestCase):
                                      do_compile=False)
             job_list.append(quantum_job)
         jp = jobprocessor.JobProcessor(job_list, callback=None)
-        jp.submit(silent=True)
+        jp.submit()
 
     @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
     def test_run_job_processor_online(self):
@@ -211,7 +211,7 @@ class TestJobProcessor(QiskitTestCase):
         jp = jobprocessor.JobProcessor(job_list, token=self.QE_TOKEN,
                                url=self.QE_URL,
                                callback=None)
-        jp.submit(silent=True)
+        jp.submit()
 
     @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
     def test_quantum_program_online(self):
@@ -250,7 +250,7 @@ class TestJobProcessor(QiskitTestCase):
         self.job_processor_exception = None
         jp = jobprocessor.JobProcessor(job_list, max_workers=None,
                                        callback=job_done_callback)
-        jp.submit(silent=True)
+        jp.submit()
 
         while not self.job_processor_finished:
             # Wait until the job_done_callback is invoked and completed.
@@ -271,7 +271,7 @@ class TestJobProcessor(QiskitTestCase):
                                      backend=backend)
             job_list.append(quantum_job)
         jp = jobprocessor.JobProcessor(job_list, max_workers=1, callback=None)
-        jp.submit(silent=True)
+        jp.submit()
 
     @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
     def test_mix_local_remote_jobs(self):
@@ -298,7 +298,7 @@ class TestJobProcessor(QiskitTestCase):
         jp = jobprocessor.JobProcessor(job_list, max_workers=None,
                                token=self.QE_TOKEN, url=self.QE_URL,
                                callback=None)
-        jp.submit(silent=True)
+        jp.submit()
 
     def test_error_in_job(self):
         def job_done_callback(results):
@@ -326,7 +326,7 @@ class TestJobProcessor(QiskitTestCase):
         tmp = jobprocessor.run_local_backend
         jobprocessor.run_local_backend = mock_run_local_backend
 
-        jp.submit(silent=True)
+        jp.submit()
         jobprocessor.run_local_backend = tmp
 
         while not self.job_processor_finished:

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -121,7 +121,7 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import ClassicalRegister
         """
         QP_program = QuantumProgram()
-        cr = QP_program.create_classical_register("cr", 3, verbose=False)
+        cr = QP_program.create_classical_register("cr", 3)
         self.assertIsInstance(cr, ClassicalRegister)
 
     def test_create_quantum_register(self):
@@ -135,7 +135,7 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import QuantumRegister
         """
         QP_program = QuantumProgram()
-        qr = QP_program.create_quantum_register("qr", 3, verbose=False)
+        qr = QP_program.create_quantum_register("qr", 3)
         self.assertIsInstance(qr, QuantumRegister)
 
     def test_fail_create_quantum_register(self):
@@ -151,10 +151,10 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import QISKitError
         """
         QP_program = QuantumProgram()
-        qr1 = QP_program.create_quantum_register("qr", 3, verbose=False)
+        qr1 = QP_program.create_quantum_register("qr", 3)
         self.assertIsInstance(qr1, QuantumRegister)
         self.assertRaises(QISKitError, QP_program.create_quantum_register,
-                          "qr", 2, verbose=False)
+                          "qr", 2)
 
     def test_fail_create_classical_register(self):
         """Test create_quantum_register.
@@ -169,11 +169,10 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import QISKitError
         """
         QP_program = QuantumProgram()
-        cr1 = QP_program.create_classical_register("cr", 3, verbose=False)
+        cr1 = QP_program.create_classical_register("cr", 3)
         self.assertIsInstance(cr1, ClassicalRegister)
         self.assertRaises(QISKitError,
-                          QP_program.create_classical_register, "cr", 2,
-                          verbose=False)
+                          QP_program.create_classical_register, "cr", 2)
 
     def test_create_quantum_register_same(self):
         """Test create_quantum_register of same name and size.
@@ -186,8 +185,8 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import QuantumRegister
         """
         QP_program = QuantumProgram()
-        qr1 = QP_program.create_quantum_register("qr", 3, verbose=False)
-        qr2 = QP_program.create_quantum_register("qr", 3, verbose=False)
+        qr1 = QP_program.create_quantum_register("qr", 3)
+        qr2 = QP_program.create_quantum_register("qr", 3)
         self.assertIs(qr1, qr2)
 
     def test_create_classical_register_same(self):
@@ -201,8 +200,8 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import ClassicalRegister
         """
         QP_program = QuantumProgram()
-        cr1 = QP_program.create_classical_register("cr", 3, verbose=False)
-        cr2 = QP_program.create_classical_register("cr", 3, verbose=False)
+        cr1 = QP_program.create_classical_register("cr", 3)
+        cr2 = QP_program.create_classical_register("cr", 3)
         self.assertIs(cr1, cr2)
 
     def test_create_classical_registers(self):
@@ -250,8 +249,8 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import QuantumCircuit
         """
         QP_program = QuantumProgram()
-        qr = QP_program.create_quantum_register("qr", 3, verbose=False)
-        cr = QP_program.create_classical_register("cr", 3, verbose=False)
+        qr = QP_program.create_quantum_register("qr", 3)
+        cr = QP_program.create_classical_register("cr", 3)
         qc = QP_program.create_circuit("qc", [qr], [cr])
         self.assertIsInstance(qc, QuantumCircuit)
 
@@ -266,10 +265,10 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import QuantumCircuit
         """
         QP_program = QuantumProgram()
-        qr1 = QP_program.create_quantum_register("qr1", 3, verbose=False)
-        cr1 = QP_program.create_classical_register("cr1", 3, verbose=False)
-        qr2 = QP_program.create_quantum_register("qr2", 3, verbose=False)
-        cr2 = QP_program.create_classical_register("cr2", 3, verbose=False)
+        qr1 = QP_program.create_quantum_register("qr1", 3)
+        cr1 = QP_program.create_classical_register("cr1", 3)
+        qr2 = QP_program.create_quantum_register("qr2", 3)
+        cr2 = QP_program.create_classical_register("cr2", 3)
         qc1 = QP_program.create_circuit("qc1", [qr1], [cr1])
         qc2 = QP_program.create_circuit("qc2", [qr2], [cr2])
         qc3 = QP_program.create_circuit("qc2", [qr1, qr2], [cr1, cr2])
@@ -287,8 +286,7 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import QuantumProgram
         """
         QP_program = QuantumProgram()
-        name = QP_program.load_qasm_file(self.QASM_FILE_PATH, name="",
-                                         verbose=False)
+        name = QP_program.load_qasm_file(self.QASM_FILE_PATH, name="")
         result = QP_program.get_circuit(name)
         to_check = result.qasm()
         self.log.info(to_check)
@@ -306,8 +304,7 @@ class TestQuantumProgram(QiskitTestCase):
         """
         QP_program = QuantumProgram()
         self.assertRaises(QISKitError,
-                          QP_program.load_qasm_file, "", name=None,
-                          verbose=False)
+                          QP_program.load_qasm_file, "", name=None)
 
     def test_load_qasm_text(self):
         """Test load_qasm_text and get_circuit.
@@ -327,7 +324,7 @@ class TestQuantumProgram(QiskitTestCase):
         QASM_string += "measure a[3]->c[3];\nmeasure b[0]->d[0];\n"
         QASM_string += "measure b[1]->d[1];\nmeasure b[2]->d[2];\n"
         QASM_string += "measure b[3]->d[3];"
-        name = QP_program.load_qasm_text(QASM_string, verbose=False)
+        name = QP_program.load_qasm_text(QASM_string)
         result = QP_program.get_circuit(name)
         to_check = result.qasm()
         self.log.info(to_check)
@@ -361,10 +358,10 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import QuantumProgram
         """
         QP_program = QuantumProgram()
-        qr1 = QP_program.create_quantum_register("qr1", 3, verbose=False)
-        cr1 = QP_program.create_classical_register("cr1", 3, verbose=False)
-        qr2 = QP_program.create_quantum_register("qr2", 3, verbose=False)
-        cr2 = QP_program.create_classical_register("cr2", 3, verbose=False)
+        qr1 = QP_program.create_quantum_register("qr1", 3)
+        cr1 = QP_program.create_classical_register("cr1", 3)
+        qr2 = QP_program.create_quantum_register("qr2", 3)
+        cr2 = QP_program.create_classical_register("cr2", 3)
         QP_program.create_circuit("qc1", [qr1], [cr1])
         QP_program.create_circuit("qc2", [qr2], [cr2])
         QP_program.create_circuit("qc2", [qr1, qr2], [cr1, cr2])
@@ -408,8 +405,8 @@ class TestQuantumProgram(QiskitTestCase):
                 from qiskit import QuantumProgram
         """
         QP_program = QuantumProgram()
-        qr = QP_program.create_quantum_register("qr", 3, verbose=False)
-        cr = QP_program.create_classical_register("cr", 3, verbose=False)
+        qr = QP_program.create_quantum_register("qr", 3)
+        cr = QP_program.create_classical_register("cr", 3)
         qc1 = QP_program.create_circuit("qc1", [qr], [cr])
         qc2 = QP_program.create_circuit("qc2", [qr], [cr])
         qc1.h(qr[0])
@@ -763,8 +760,8 @@ class TestQuantumProgram(QiskitTestCase):
         be different.
         """
         QP_program = QuantumProgram()
-        q = QP_program.create_quantum_register("q", 3, verbose=False)
-        c = QP_program.create_classical_register("c", 3, verbose=False)
+        q = QP_program.create_quantum_register("q", 3)
+        c = QP_program.create_classical_register("c", 3)
         qc = QP_program.create_circuit("circuitName", [q], [c])
         qc.h(q[0])
         qc.cx(q[0], q[1])
@@ -1053,8 +1050,8 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should the h otimes h and cx.
         """
         QP_program = QuantumProgram()
-        q = QP_program.create_quantum_register("q", 2, verbose=False)
-        c = QP_program.create_classical_register("c", 2, verbose=False)
+        q = QP_program.create_quantum_register("q", 2)
+        c = QP_program.create_classical_register("c", 2)
         qc1 = QP_program.create_circuit("qc1", [q], [c])
         qc2 = QP_program.create_circuit("qc2", [q], [c])
         qc1.h(q)
@@ -1123,8 +1120,8 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should return the data.
         """
         QP_program = QuantumProgram()
-        q = QP_program.create_quantum_register("q", 2, verbose=False)
-        c = QP_program.create_classical_register("c", 2, verbose=False)
+        q = QP_program.create_quantum_register("q", 2)
+        c = QP_program.create_classical_register("c", 2)
         qc = QP_program.create_circuit("qc", [q], [c])
         qc.h(q[0])
         qc.cx(q[0], q[1])
@@ -1151,8 +1148,8 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should return the data.
         """
         QP_program = QuantumProgram()
-        qr = QP_program.create_quantum_register("q", 1, verbose=False)
-        cr = QP_program.create_classical_register("c", 1, verbose=False)
+        qr = QP_program.create_quantum_register("q", 1)
+        cr = QP_program.create_classical_register("c", 1)
         qc = QP_program.create_circuit("qc", [qr], [cr])
         qc.h(qr[0])
         qc.measure(qr[0], cr[0])
@@ -1161,7 +1158,7 @@ class TestQuantumProgram(QiskitTestCase):
         backend = QP_program.online_simulators()[0]
         # print(backend)
         result = QP_program.execute(['qc'], backend=backend,
-                                    shots=shots, max_credits=3, silent=True,
+                                    shots=shots, max_credits=3,
                                     seed=73846087)
         counts = result.get_counts('qc')
         self.assertEqual(counts, {'0': 498, '1': 526})
@@ -1173,8 +1170,8 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should return the data.
         """
         QP_program = QuantumProgram()
-        qr = QP_program.create_quantum_register("q", 25, verbose=False)
-        cr = QP_program.create_classical_register("c", 25, verbose=False)
+        qr = QP_program.create_quantum_register("q", 25)
+        cr = QP_program.create_classical_register("c", 25)
         qc = QP_program.create_circuit("qc", [qr], [cr])
         qc.h(qr)
         qc.measure(qr, cr)
@@ -1183,7 +1180,7 @@ class TestQuantumProgram(QiskitTestCase):
         backend = 'ibmqx_qasm_simulator'
         result = QP_program.execute(['qc'], backend=backend,
                                     shots=shots, max_credits=3,
-                                    silent=True, seed=73846087)
+                                    seed=73846087)
         self.assertRaises(RegisterSizeError, result.get_data, 'qc')
 
     @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
@@ -1193,8 +1190,8 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should return the data.
         """
         QP_program = QuantumProgram()
-        qr = QP_program.create_quantum_register("q", 2, verbose=False)
-        cr = QP_program.create_classical_register("c", 2, verbose=False)
+        qr = QP_program.create_quantum_register("q", 2)
+        cr = QP_program.create_classical_register("c", 2)
         qc1 = QP_program.create_circuit("qc1", [qr], [cr])
         qc2 = QP_program.create_circuit("qc2", [qr], [cr])
         qc1.h(qr)
@@ -1209,8 +1206,7 @@ class TestQuantumProgram(QiskitTestCase):
         QP_program.set_api(QE_TOKEN, QE_URL)
         backend = QP_program.online_simulators()[0]
         result = QP_program.execute(circuits, backend=backend, shots=shots,
-                                    max_credits=3, silent=True,
-                                    seed=1287126141)
+                                    max_credits=3, seed=1287126141)
         counts1 = result.get_counts('qc1')
         counts2 = result.get_counts('qc2')
         self.assertEqual(counts1,  {'10': 277, '11': 238, '01': 258,
@@ -1224,8 +1220,8 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should return a result object
         """
         QP_program = QuantumProgram()
-        qr = QP_program.create_quantum_register("qr", 1, verbose=False)
-        cr = QP_program.create_classical_register("cr", 1, verbose=False)
+        qr = QP_program.create_quantum_register("qr", 1)
+        cr = QP_program.create_classical_register("cr", 1)
         qc = QP_program.create_circuit("circuitName", [qr], [cr])
         qc.h(qr)
         qc.measure(qr[0], cr[0])
@@ -1246,10 +1242,10 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should the data.
         """
         QP_program = QuantumProgram()
-        q1 = QP_program.create_quantum_register("q1", 2, verbose=False)
-        c1 = QP_program.create_classical_register("c1", 2, verbose=False)
-        q2 = QP_program.create_quantum_register("q2", 2, verbose=False)
-        c2 = QP_program.create_classical_register("c2", 2, verbose=False)
+        q1 = QP_program.create_quantum_register("q1", 2)
+        c1 = QP_program.create_classical_register("c1", 2)
+        q2 = QP_program.create_quantum_register("q2", 2)
+        c2 = QP_program.create_classical_register("c2", 2)
         qc1 = QP_program.create_circuit("qc1", [q1, q2], [c1, c2])
         qc2 = QP_program.create_circuit("qc2", [q1, q2], [c1, c2])
 
@@ -1280,10 +1276,10 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should the data.
         """
         QP_program = QuantumProgram()
-        q1 = QP_program.create_quantum_register("q1", 2, verbose=False)
-        c1 = QP_program.create_classical_register("c1", 2, verbose=False)
-        q2 = QP_program.create_quantum_register("q2", 2, verbose=False)
-        c2 = QP_program.create_classical_register("c2", 2, verbose=False)
+        q1 = QP_program.create_quantum_register("q1", 2)
+        c1 = QP_program.create_classical_register("c1", 2)
+        q2 = QP_program.create_quantum_register("q2", 2)
+        c2 = QP_program.create_classical_register("c2", 2)
         qc1 = QP_program.create_circuit("qc1", [q1, q2], [c1, c2])
         qc2 = QP_program.create_circuit("qc2", [q1, q2], [c1, c2])
 
@@ -1318,8 +1314,8 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should return the data
         """
         QP_program = QuantumProgram()
-        qr = QP_program.create_quantum_register("qr", 2, verbose=False)
-        cr = QP_program.create_classical_register("cr", 2, verbose=False)
+        qr = QP_program.create_quantum_register("qr", 2)
+        cr = QP_program.create_classical_register("cr", 2)
         qc1 = QP_program.create_circuit("qc1", [qr], [cr])
         qc2 = QP_program.create_circuit("qc2", [qr], [cr])
         qc1.h(qr[0])
@@ -1343,10 +1339,10 @@ class TestQuantumProgram(QiskitTestCase):
         If the circuits have different registers it should return a QISKitError
         """
         QP_program = QuantumProgram()
-        qr = QP_program.create_quantum_register("qr", 1, verbose=False)
-        cr = QP_program.create_classical_register("cr", 1, verbose=False)
-        q = QP_program.create_quantum_register("q", 1, verbose=False)
-        c = QP_program.create_classical_register("c", 1, verbose=False)
+        qr = QP_program.create_quantum_register("qr", 1)
+        cr = QP_program.create_classical_register("cr", 1)
+        q = QP_program.create_quantum_register("q", 1)
+        c = QP_program.create_classical_register("c", 1)
         qc1 = QP_program.create_circuit("qc1", [qr], [cr])
         qc2 = QP_program.create_circuit("qc2", [q], [c])
         qc1.h(qr[0])


### PR DESCRIPTION
## Description

* add `QuantumProgram.enable_logs()` and `disable_logs()` as the single point of entry for setting/unsetting the verbosity of the output, replacing the different `verbose` and `silent` parameters.
* add a `qiskit._logging` module that contains two convenience functions for setting up the loggers (format, handlers) to be used by the SDK, defaulting to sensible values.
* replace `print()` with `logger.info()` (or `logger.debug()` on the mapper)

Not included in this PR:
* replacement of `verbose/silent` and `print` in `qiskit.tools` (might be well suited for a follow-up first contribution PR)
* fine grained decision about what current output should be `INFO/WARNING/DEBUG`
* allowing the user to override the logging format (might be better tackled along with a bigger scope PR that introduces some sort of user configuration mechanism)

## Motivation and Context

As described in #88, there are a number of drawbacks to using `print` statements, specially on a SDK. Since a number of functions can emit log information, it changes the way "verbosity" is requested or specified by the user: now the user should call:
``` python
qp = QuantumProgram()
... (operations where he is not interested in the output)
qp.enable_logs()
... (from that point onward, the operations will be print its output)
qp.disable_logs()
.... (optionally, hide the output from that point onward)
```

This is mostly because it is not recommended that a [library modifies the configuration of the loggers directly](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library):
> (...) the configuration of handlers is the prerogative of the application developer who uses your library. The application developer knows their target audience and what handlers are most appropriate for their application: if you add handlers ‘under the hood’, you might well interfere with their ability to carry out unit tests and deliver logs which suit their requirements.

but at the same time trying to cater to users who want an easy way to "toggle the output" of specific snippets of their code and mostly just use `QuantumObject` directly.

## How Has This Been Tested?
`make test`. I would love to have some feedback and extra manual testing as it is very likely that the regular output is a bit more verbose than it was and there might be some formatting issues.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.