### PR TITLE
Relax the default linter checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,9 @@
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS,
+    standard,  # ignore qiskit.extensions.standard.*
+    _node      # ignore qiskit.qasm._node.*
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
@@ -20,7 +22,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.docparams  # enable checking of docstring args
 
 # Use multiple processes to speed up Pylint.
 jobs=1
@@ -65,7 +67,8 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,import-star-module-level,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,long-suffix,old-ne-operator,old-octal-literal,suppressed-message,useless-suppression
+disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,import-star-module-level,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,long-suffix,old-ne-operator,old-octal-literal,suppressed-message,useless-suppression,
+    no-self-use  # disabled as it is too verbose
 
 
 [REPORTS]
@@ -287,7 +290,9 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=
+generated-members=self.circuit.*
+# self.circuit.*: false positives when self.circuit == QuantumCircuit, as it
+# provides a "__getitem__" dynamic method.
 
 # List of decorators that produce context managers, such as
 # contextlib.contextmanager. Add to this list to register other decorators that

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ run:
 
 # Ignoring generated ones with .py extension.
 lint:
-	pylint --ignore=./qiskit/qasm/parsetab.py examples qiskit test tutorial
+	pylint qiskit test
 
 # TODO: Uncomment when the lint one passes.
 # test: lint

--- a/qiskit/backends/_qasmsimulator.py
+++ b/qiskit/backends/_qasmsimulator.py
@@ -1,5 +1,5 @@
-# pylint: disable=line-too-long
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/qiskit/backends/_simulatortools.py
+++ b/qiskit/backends/_simulatortools.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -41,6 +41,7 @@ class DAGCircuit:
     The nodes are connected by directed edges that correspond to qubits and
     bits.
     """
+    # pylint: disable=invalid-name
 
     def __init__(self):
         """Create an empty circuit."""

--- a/qiskit/mapper/_compiling.py
+++ b/qiskit/mapper/_compiling.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/qiskit/mapper/_coupling.py
+++ b/qiskit/mapper/_coupling.py
@@ -75,6 +75,7 @@ class Coupling:
     Nodes correspond to qubits and directed edges correspond to permitted
     CNOT gates
     """
+    # pylint: disable=invalid-name
 
     def __init__(self, couplingdict=None):
         """

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #
@@ -479,7 +480,7 @@ def swap_mapper(circuit_graph, coupling_graph,
 
 
 def test_trig_solution(theta, phi, lamb, xi, theta1, theta2):
-    """Test if arguments are a solution to a system of equations.
+    r"""Test if arguments are a solution to a system of equations.
 
     .. math::
        \cos(\phi+\lambda) \cos(\\theta) = \cos(xi) * \cos(\\theta1+\\theta2)

--- a/qiskit/qasm/_qasmlexer.py
+++ b/qiskit/qasm/_qasmlexer.py
@@ -37,6 +37,7 @@ class QasmLexer(object):
     This is a wrapper around the PLY lexer to support the "include" statement
     by creating a stack of lexers.
     """
+    # pylint: disable=invalid-name
 
     def __mklexer__(self, filename):
         """Create a PLY lexer."""

--- a/qiskit/unroll/_unrollerbackend.py
+++ b/qiskit/unroll/_unrollerbackend.py
@@ -26,6 +26,7 @@ class UnrollerBackend(object):
 
     This backend also serves as a base class for other unroller backends.
     """
+    # pylint: disable=unused-argument
 
     def __init__(self, basis=None):
         """Setup this backend.

--- a/test/python/test_apps.py
+++ b/test/python/test_apps.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/test/python/test_basebackend.py
+++ b/test/python/test_basebackend.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name,missing-docstring
+
 import unittest
 
 from qiskit import QISKitError

--- a/test/python/test_job_processor.py
+++ b/test/python/test_job_processor.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/test/python/test_jsonoutput.py
+++ b/test/python/test_jsonoutput.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/test/python/test_local_qasm_cpp_simulator.py
+++ b/test/python/test_local_qasm_cpp_simulator.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/test/python/test_qasm_parser.py
+++ b/test/python/test_qasm_parser.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/test/python/test_qasm_python_simulator.py
+++ b/test/python/test_qasm_python_simulator.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/test/python/test_qi.py
+++ b/test/python/test_qi.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #

--- a/test/python/test_unitary_python_simulator.py
+++ b/test/python/test_unitary_python_simulator.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #


### PR DESCRIPTION
## Description

Make the default linter configuration less strict, reducing the number
of false positives and the usefulness of the existing output with a
combination of:
* ignoring specific files entirely (such as the parser or the standard
  extension individual files)
* ignore specific warnings on some files (such as "invalid-name" on
  files that use variables mapped to mathematic algorithms)
* disable specific tags globaly (in particular, "no-self-use")

Also make the linter more strict when it comes to docstrings via the
"pylint.extensions.docparams" plugin.

In numbers, this would make the number of warnings from ~1700 to ~800 - which is still a sizable number but hopefully making the number of false positives and the significance of the warnings higher, and pave the way for making #90 easier to tackle.

## Motivation and Context


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

`make test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.