### PR TITLE
Added a save/load feature to Result

### DIFF
--- a/qiskit/_result.py
+++ b/qiskit/_result.py
@@ -46,10 +46,10 @@ class Result(object):
         return self._result['status']
 
     def __getitem__(self, i):
-        return self.__result['result'][i]
+        return self._result['result'][i]
 
     def __len__(self):
-        return len(self.__result['result'])
+        return len(self._result['result'])
 
     def __iadd__(self, other):
         """Append a Result object to current Result object.
@@ -114,7 +114,7 @@ class Result(object):
         Returns:
             a string containing the job id.
         """
-        return self.__result['job_id']
+        return self._result['job_id']
 
     def get_ran_qasm(self, name):
         """Get the ran qasm for the named circuit and backend.

--- a/qiskit/tools/file_io.py
+++ b/qiskit/tools/file_io.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""Utilities for File Input/Output."""
+
+
+import os
+import datetime
+import json
+from qiskit._qiskiterror import QISKitError
+import qiskit
+import numpy
+
+def convert_qobj_to_json(in_item):
+    """Combs recursively through a list/dictionary and finds any non-json compatible
+    elements and converts them. E.g. complex ndarray's are converted to lists of strings.
+    Assume that all such elements are stored in dictionaries!
+
+    Arg:
+        in_item: the input dict/list
+    """
+
+    key_list = []
+    for (item_index, item_iter) in enumerate(in_item):
+        if isinstance(in_item, list):
+            curkey = item_index
+        else:
+            curkey = item_iter
+
+        if isinstance(in_item[curkey], (list, dict)):
+            #go recursively through nested list/dictionaries
+            convert_qobj_to_json(in_item[curkey])
+        elif isinstance(in_item[curkey], numpy.ndarray):
+            #ndarray's are not json compatible. Save the key.
+            key_list.append(curkey)
+
+    #convert ndarray's to lists
+    #split complex arrays into two lists because complex values are not json compatible
+    for curkey in key_list:
+        if in_item[curkey].dtype == 'complex':
+            in_item[curkey+'_ndarray_imag'] = numpy.imag(in_item[curkey]).tolist()
+        in_item[curkey+'_ndarray_real'] = numpy.real(in_item[curkey]).tolist()
+        in_item.pop(curkey)
+
+def convert_json_to_qobj(in_item):
+    """Combs recursively through a list/dictionary that was loaded from json
+    and finds any lists that were converted from ndarray and converts them back
+
+    Arg:
+        in_item: the input dict/list
+    """
+
+    key_list = []
+    for (item_index, item_iter) in enumerate(in_item):
+        if isinstance(in_item, list):
+            curkey = item_index
+        else:
+            curkey = item_iter
+
+            if '_ndarray_real' in curkey:
+                key_list.append(curkey)
+                continue
+
+        if isinstance(in_item[curkey], (list, dict)):
+            convert_json_to_qobj(in_item[curkey])
+
+    for curkey in key_list:
+        curkey_root = curkey[0:-13]
+        in_item[curkey_root] = numpy.array(in_item[curkey])
+        in_item.pop(curkey)
+        if curkey_root+'_ndarray_imag' in in_item:
+            in_item[curkey_root] = in_item[curkey_root] + 1j*numpy.array(in_item[curkey_root+'_ndarray_imag'])
+            in_item.pop(curkey_root+'_ndarray_imag')
+
+def file_datestr(folder, fileroot):
+    """Constructs a filename using the current date-time
+
+    Args:
+        folder: path to the save folder
+        fileroot: root string for the file
+
+    Returns:
+        String: full file path of the form 'folder/YYYY_MM_DD_HH_MM_fileroot.json'
+    """
+
+    #if the fileroot has .json appended strip it off
+    if len(fileroot) > 4 and fileroot[-5:].lower() == '.json':
+        fileroot = fileroot[0:-5]
+
+    return os.path.join(folder, '{:%Y_%m_%d_%H_%M_}'.format(datetime.datetime.now())+fileroot+'.json')
+
+def load_result_from_file(filename):
+    """Load a results dictionary file (.json) to a Result object.
+    Note: The json file may not load properly if it was saved with a previous
+    version of the SDK.
+
+    Args:
+        filename: filename of the dictionary
+
+    Returns:
+        Result: The new Results object
+        Dict: if the metadata exists it will get returned
+    """
+
+    if not os.path.exists(filename):
+        raise QISKitError('File %s does not exist'%filename)
+
+    with open(filename, 'r') as load_file:
+        master_dict = json.load(load_file)
+
+    try:
+        qobj = master_dict['qobj']
+        qresult_dict = master_dict['result']
+        convert_json_to_qobj(qresult_dict)
+        metadata = master_dict['metadata']
+    except KeyError:
+        raise QISKitError('File %s does not have the proper dictionary structure')
+
+    qresult = qiskit.Result(qresult_dict, qobj)
+
+    return qresult, metadata

--- a/qiskit/tools/file_io.py
+++ b/qiskit/tools/file_io.py
@@ -52,8 +52,10 @@ def convert_qobj_to_json(in_item):
     for curkey in key_list:
         if in_item[curkey].dtype == 'complex':
             in_item[curkey+'_ndarray_imag'] = numpy.imag(in_item[curkey]).tolist()
-        in_item[curkey+'_ndarray_real'] = numpy.real(in_item[curkey]).tolist()
-        in_item.pop(curkey)
+            in_item[curkey+'_ndarray_real'] = numpy.real(in_item[curkey]).tolist()
+            in_item.pop(curkey)
+        else:
+            in_item[curkey] = in_item[curkey].tolist()
 
 def convert_json_to_qobj(in_item):
     """Combs recursively through a list/dictionary that was loaded from json
@@ -70,6 +72,7 @@ def convert_json_to_qobj(in_item):
         else:
             curkey = item_iter
 
+            #flat these lists so that we can recombine back into a complex number
             if '_ndarray_real' in curkey:
                 key_list.append(curkey)
                 continue

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1561,8 +1561,8 @@ class TestQuantumProgram(QiskitTestCase):
         if os.path.exists(test_2_path):
             os.remove(test_2_path)
 
-        file1 = result1.save(test_1_path, metadata=metadata)
-        file2 = result2.save(test_2_path, metadata=metadata)
+        file1 = file_io.save_result_to_file(result1, test_1_path, metadata=metadata)
+        file2 = file_io.save_result_to_file(result2, test_2_path, metadata=metadata)
 
         result_loaded1, metadata_loaded1 = file_io.load_result_from_file(file1)
         result_loaded2, metadata_loaded2 = file_io.load_result_from_file(file1)


### PR DESCRIPTION
Added functionality to the Result class to save/load the qobj and result to a JSON file. 

## Description
The save creates a new dictionary that combines qobj,result and a user-defined metadata dictionary. This is then saved to a JSON file. There is a function which can create a time-stamped filename. Because the 'local_unitary_simulator' backend creates a result dictionary with complex numpy arrays I added some hidden functions to the Result class to convert those into lists. 

## Motivation and Context
Currently there is no way to save results. This is needed functionality for running experiments where we need to keep a detailed record of past results and for analyzing results at a later date.

## How Has This Been Tested?
I saved and loaded Results from the different backends.  

Code will look something like this (where qpresult is the result output from an execution)
`qpresult.save(qpresult.save_datestr('','test.json'),x_vals)`
`qpresult2 = Result()`
`qpresult2.load('2017_10_11_00_52_test_1.json')`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.