### PR TITLE
fixed typo in iden.py

### DIFF
--- a/qiskit/extensions/standard/iden.py
+++ b/qiskit/extensions/standard/iden.py
@@ -44,7 +44,7 @@ class IdGate(Gate):
 
     def reapply(self, circ):
         """Reapply this gate to corresponding qubits in circ."""
-        self._modifiers(circ.id(self.arg[0]))
+        self._modifiers(circ.iden(self.arg[0]))
 
 
 def iden(self, q):


### PR DESCRIPTION
## Description
Fixed typo with identity circuit extension.

The `reapply` method called `id` instead of `iden`. This bug only showed up if you tried to combine circuits containing an identity gate. Eg:

```Python
from qiskit import QuantumProgram
qp = QuantumProgram()
qr = qp.create_quantum_register('qr', 1)
circ1 = qp.create_circuit('circ1', [qr], [])
circ2 = qp.create_circuit('circ2', [qr], [])
circ1.h(qr)
circ2.iden(qr)
circ1 + circ2
>>> AttributeError: 'QuantumCircuit' object has no attribute 'id'
```

## How Has This Been Tested?
Tests pass

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.