### PR TITLE
Added a reconfigure qobj method to quantum program

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -925,6 +925,48 @@ class QuantumProgram(object):
             qobj["circuits"].append(job)
         return qobj
 
+    def reconfig(self, qobj, backend=None, config=None, shots=None, max_credits=None, seed=None):
+        """Change configuration parameters for a compile qobj. Only parameters which
+        don't affect the circuit compilation can change, e.g., the coupling_map
+        cannot be changed here!
+
+        Notes:
+            If the inputs are left as None then the qobj is not updated
+
+        Args:
+            qobj (dict): already compile qobj
+            backend (str): see .compile
+            config (dict): see .compile
+            shots (int): see .compile
+            max_credits (int): see .compile
+            seed (int): see .compile
+
+        Returns:
+            qobj: updated qobj
+        """
+
+        if backend is not None:
+            qobj['config']['backend'] = backend
+
+        if shots is not None:
+            qobj['config']['shots'] = shots
+
+        if max_credits is not None:
+            qobj['config']['max_credits'] = max_credits
+
+
+        for circuits in qobj['circuits']:
+
+            if seed is not None:
+                circuits['seed'] = seed
+
+            if config is not None:
+                circuits['config'].update(config)
+
+
+        return qobj
+
+
     def get_execution_list(self, qobj):
         """Print the compiled circuits that are ready to run.
 

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -944,28 +944,20 @@ class QuantumProgram(object):
         Returns:
             qobj: updated qobj
         """
-
         if backend is not None:
             qobj['config']['backend'] = backend
-
         if shots is not None:
             qobj['config']['shots'] = shots
-
         if max_credits is not None:
             qobj['config']['max_credits'] = max_credits
 
-
         for circuits in qobj['circuits']:
-
             if seed is not None:
                 circuits['seed'] = seed
-
             if config is not None:
                 circuits['config'].update(config)
 
-
         return qobj
-
 
     def get_execution_list(self, qobj):
         """Print the compiled circuits that are ready to run.

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1597,6 +1597,31 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertTrue(np.array_equal(yvals, [[-1,-1],[1,-1]]))
         self.assertTrue(np.array_equal(xvals, [0,1]))
 
+    def test_reconfig(self):
+        """Test reconfiguring the qobj from 1024 shots to 2048 using
+        reconfig instead of recompile
+        """
+        QP_program = QuantumProgram(specs=self.QPS_SPECS)
+        qr = QP_program.get_quantum_register("qname")
+        cr = QP_program.get_classical_register("cname")
+        qc2 = QP_program.create_circuit("qc2", [qr], [cr])
+        qc2.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        qc2.measure(qr[2], cr[2])
+        circuits = ['qc2']
+        shots = 1024  # the number of shots in the experiment.
+        backend = 'local_qasm_simulator'
+        qobj = QP_program.compile(circuits, backend=backend, shots=shots)
+        out = QP_program.run(qobj)
+        results = out.get_counts('qc2')
+
+        #change the number of shots
+        qobj = QP_program.reconfig(qobj, shots=2048)
+        out2 = QP_program.run(qobj)
+        results2 = out2.get_counts('qc2')
+
+        self.assertEqual(results, {'000': 1024})
+        self.assertEqual(results2, {'000': 2048})
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1608,20 +1608,37 @@ class TestQuantumProgram(QiskitTestCase):
         qc2.measure(qr[0], cr[0])
         qc2.measure(qr[1], cr[1])
         qc2.measure(qr[2], cr[2])
-        circuits = ['qc2']
         shots = 1024  # the number of shots in the experiment.
         backend = 'local_qasm_simulator'
-        qobj = QP_program.compile(circuits, backend=backend, shots=shots)
+        test_config = {'0': 0, '1': 1}
+        qobj = QP_program.compile(['qc2'], backend=backend, shots=shots, config=test_config)
         out = QP_program.run(qobj)
         results = out.get_counts('qc2')
 
-        #change the number of shots
+        #change the number of shots and re-run to test if the reconfig does not break
+        #the ability to run the qobj
         qobj = QP_program.reconfig(qobj, shots=2048)
         out2 = QP_program.run(qobj)
         results2 = out2.get_counts('qc2')
 
         self.assertEqual(results, {'000': 1024})
         self.assertEqual(results2, {'000': 2048})
+
+        #change backend
+        qobj = QP_program.reconfig(qobj, backend='local_unitary_simulator')
+        self.assertEqual(qobj['config']['backend'], 'local_unitary_simulator')
+        #change maxcredits
+        qobj = QP_program.reconfig(qobj, max_credits=11)
+        self.assertEqual(qobj['config']['max_credits'], 11)
+        #change seed
+        qobj = QP_program.reconfig(qobj, seed=11)
+        self.assertEqual(qobj['circuits'][0]['seed'], 11)
+        #change the config
+        test_config_2 = {'0': 2}
+        qobj = QP_program.reconfig(qobj, config=test_config_2)
+        self.assertEqual(qobj['circuits'][0]['config']['0'], 2)
+        self.assertEqual(qobj['circuits'][0]['config']['1'], 1)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Add a method to `QuantumProgram` to reconfigure an already compiled qobj to change parameters that are not dependent on compilation (e.g. shots, backend, config...)

## Description


## Motivation and Context
The compilation step (`QuantumProgram.compile()`) takes a finite amount of time and it is not necessary to recompile if we just need to change certain configuration options. Technically the user could just change the qobj dictionary, but this abstraction will ensure less code is broken if there are future changes to the qobj structure as these would just need to be fixed in this method. 

## How Has This Been Tested?
Added a unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.