### PR TITLE
making sure that pauli_list_temp is a list of lists not tuple of tuples

### DIFF
--- a/qiskit/tools/apps/optimization.py
+++ b/qiskit/tools/apps/optimization.py
@@ -216,8 +216,8 @@ def group_paulis(pauli_list):
             pauli_list_temp = []
             # pauli_list_temp.extend(p_1) # this is going to signal the total
             # post-rotations of the set (set master)
-            pauli_list_temp.append(p_1)
-            pauli_list_temp.append(copy.deepcopy(p_1))
+            pauli_list_temp.append(list(p_1))
+            pauli_list_temp.append(copy.deepcopy(list(p_1)))
             pauli_list_temp[0][0] = 0
             for p_2 in pauli_list:
                 if p_2 not in pauli_list_sorted and p_1[1] != p_2[1]:


### PR DESCRIPTION
## Description
added conversion to list, to have pauli_list_temp as a list of lists not as a tuple of tuples which can not be edited later

## Motivation and Context
to prevent following error:
'tuple' object does not support item assignment

## How Has This Been Tested?
running classical optimization from QISKit tutorial
