### PR TITLE
Fix raising on non-exception in Result.get_data()

### DIFF
--- a/qiskit/_result.py
+++ b/qiskit/_result.py
@@ -173,7 +173,11 @@ class Result(object):
         """
         if self._is_error():
             exception = self._result['result']
-            raise exception
+            if isinstance(exception, BaseException):
+                raise exception
+            else:
+                raise QISKitError(str(exception))
+
         try:
             qobj = self._qobj
             for index in range(len(qobj['circuits'])):


### PR DESCRIPTION
## Description

Add an extra check before raising the contents of `Result._result['result']` for erroneous results, as it is not guaranteed that they will contain an Exception in all cases.

## Motivation and Context

This was caught by a user and reported on [Quantum Experience](https://quantumexperience.ng.bluemix.net/qx/community/question?questionId=b628cacd77cab777ca51c48b01a37415).

It might be a better option to ensure that in **all** cases where `Result._is_error()` is `True`, `self._result['result']` contains an `Exception`. This would involve tweaking `_wait_for_job()`, making sure that it fulfills that condition - I have not implemented the fix using that approach as it seems a design decision rather than a minor fix.

## How Has This Been Tested?

`make test`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.