### PR TITLE
Issue 137 - QASM parser problems with multiuser environments

### DIFF
--- a/qiskit/qasm/_qasm.py
+++ b/qiskit/qasm/_qasm.py
@@ -44,14 +44,15 @@ class Qasm(object):
         if self._filename:
             self._data = open(self._filename).read()
 
-        qasm_p = QasmParser(self._filename)
-        return qasm_p.print_tokens()
+        with QasmParser(self._filename) as qasm_p:
+            return qasm_p.print_tokens()
 
     def parse(self):
         """Parse the data."""
         if self._filename:
             with open(self._filename) as ifile:
                 self._data = ifile.read()
-        qasm_p = QasmParser(self._filename)
-        qasm_p.parse_debug(False)
-        return qasm_p.parse(self._data)
+
+        with QasmParser(self._filename) as qasm_p:
+            qasm_p.parse_debug(False)
+            return qasm_p.parse(self._data)


### PR DESCRIPTION
* Yacc temporary files are generated in random temporary
  directories, allowing multiple users to use QISKit in the same
  machine.
* QasmParser is now a context manager.

## Motivation and Context
This PR fixes issue 137.

## How Has This Been Tested?
$ make test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.