### PR TITLE
Overloading of comparison operator for pauli operator class. 

### DIFF
--- a/qiskit/tools/apps/fermion.py
+++ b/qiskit/tools/apps/fermion.py
@@ -113,7 +113,7 @@ def pauli_term_append(pauli_term, pauli_list, threshold):
         if not not pauli_list:   # if the list is not empty
             for i in range(len(pauli_list)):
                 # check if the new pauli belongs to the list
-                if pauli_list[i][1].to_label() == pauli_term[1].to_label():
+                if pauli_list[i][1] == pauli_term[1]:
                     # if found renormalize the coefficient of existent pauli
                     pauli_list[i][0] += pauli_term[0]
                     # remove the element if coeff. value is now less than

--- a/qiskit/tools/qi/pauli.py
+++ b/qiskit/tools/qi/pauli.py
@@ -62,6 +62,14 @@ class Pauli:
             stemp += str(j) + '\t'
         return stemp
 
+    def __eq__(self, other):
+        """Return True if all Pauli terms are equal."""
+        bres = False
+        if self.numberofqubits == other.numberofqubits:
+            if np.all(self.v == other.v) and np.all(self.w == other.w):
+                    bres = True
+        return bres
+  
     def __mul__(self, other):
         """Multiply two Paulis."""
         if self.numberofqubits != other.numberofqubits:

--- a/test/python/test_qi.py
+++ b/test/python/test_qi.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #
@@ -55,7 +54,7 @@ class TestQI(QiskitTestCase):
 
         all_pass = True
         for i, j in zip(rhos, taus):
-            all_pass &= (np.linalg.norm(i-j) == 0)
+            all_pass &= (np.linalg.norm(i - j) == 0)
         self.assertTrue(all_pass)
 
     def test_vectorize(self):
@@ -97,7 +96,8 @@ class TestQI(QiskitTestCase):
         psi1 = [0.70710678118654746, 0, 0, 0.70710678118654746]
         psi2 = [0., 0.70710678118654746, 0.70710678118654746, 0.]
         rho1 = [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]]
-        mix = [[0.25, 0, 0, 0], [0, 0.25, 0, 0], [0, 0, 0.25, 0], [0, 0, 0, 0.25]]
+        mix = [[0.25, 0, 0, 0], [0, 0.25, 0, 0],
+               [0, 0, 0.25, 0], [0, 0, 0, 0.25]]
         test_pass = round(state_fidelity(psi1, psi1), 7) == 1.0 and \
             round(state_fidelity(psi1, psi2), 8) == 0.0 and \
             round(state_fidelity(psi1, rho1), 8) == 1.0 and \
@@ -121,7 +121,8 @@ class TestQI(QiskitTestCase):
     def test_concurrence(self):
         psi1 = [1, 0, 0, 0]
         rho1 = [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]]
-        rho2 = [[0, 0, 0, 0], [0, 0.5, -0.5j, 0], [0, 0.5j, 0.5, 0], [0, 0, 0, 0]]
+        rho2 = [[0, 0, 0, 0], [0, 0.5, -0.5j, 0],
+                [0, 0.5j, 0.5, 0], [0, 0, 0, 0]]
         rho3 = 0.5 * np.array(rho1) + 0.5 * np.array(rho2)
         rho4 = 0.75 * np.array(rho1) + 0.25 * np.array(rho2)
         test_pass = concurrence(psi1) == 0.0 and \
@@ -150,7 +151,6 @@ class TestPauli(QiskitTestCase):
         self.log.info(p.to_label())
         self.log.info("In matrix form:")
         self.log.info(p.to_matrix())
-
 
         q = random_pauli(2)
         self.log.info(q)
@@ -184,6 +184,41 @@ class TestPauli(QiskitTestCase):
         self.log.info(p1.to_label())
         self.log.info(p3.to_label())
         self.log.info(sgn)
+
+        self.log.info("test equality operator: equal Paulis")
+        p1 = random_pauli(5)
+        p2 = p1
+        self.assertTrue(p1 == p2)
+        self.log.info(p2.to_label())
+        self.log.info(p1.to_label())
+        self.log.info(p1 == p2)
+
+        self.log.info("test equality operator: different Paulis")
+        p1 = random_pauli(5)
+        p2 = p1
+        p2.v[0] = (p1.v[0] + 1) % 2
+        self.assertFalse(p1 == p2)
+        self.log.info(p2.to_label())
+        self.log.info(p1.to_label())
+        self.log.info(p1 == p2)
+
+        self.log.info("test inequality operator: equal Paulis")
+        p1 = random_pauli(5)
+        p2 = p1
+        self.assertFalse(p1 != p2)
+        self.log.info(p2.to_label())
+        self.log.info(p1.to_label())
+        self.log.info(p1 != p2)
+
+        self.log.info("test inequality operator: different Paulis")
+        p1 = random_pauli(5)
+        p2 = p1
+        p2.v[0] = (p1.v[0] + 1) % 2
+        self.assertTrue(p1 != p2)
+        self.log.info(p2.to_label())
+        self.log.info(p1.to_label())
+        self.log.info(p1 != p2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/test_qi.py
+++ b/test/python/test_qi.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #
@@ -16,7 +17,7 @@
 # =============================================================================
 
 """Quick program to test the Pauli class."""
-
+from copy import deepcopy
 import unittest
 
 import numpy as np
@@ -137,7 +138,6 @@ class TestPauli(QiskitTestCase):
     """Tests for Pauli class"""
 
     def test_pauli(self):
-
         v = np.zeros(3)
         w = np.zeros(3)
         v[0] = 1
@@ -185,34 +185,38 @@ class TestPauli(QiskitTestCase):
         self.log.info(p3.to_label())
         self.log.info(sgn)
 
-        self.log.info("test equality operator: equal Paulis")
+    def test_equality_equal(self):
+        """Test equality operator: equal Paulis"""
         p1 = random_pauli(5)
-        p2 = p1
+        p2 = deepcopy(p1)
         self.assertTrue(p1 == p2)
         self.log.info(p2.to_label())
         self.log.info(p1.to_label())
         self.log.info(p1 == p2)
 
-        self.log.info("test equality operator: different Paulis")
+    def test_equality_different(self):
+        """Test equality operator: different Paulis"""
         p1 = random_pauli(5)
-        p2 = p1
+        p2 = deepcopy(p1)
         p2.v[0] = (p1.v[0] + 1) % 2
         self.assertFalse(p1 == p2)
         self.log.info(p2.to_label())
         self.log.info(p1.to_label())
         self.log.info(p1 == p2)
 
-        self.log.info("test inequality operator: equal Paulis")
+    def test_inequality_equal(self):
+        """Test inequality operator: equal Paulis"""
         p1 = random_pauli(5)
-        p2 = p1
+        p2 = deepcopy(p1)
         self.assertFalse(p1 != p2)
         self.log.info(p2.to_label())
         self.log.info(p1.to_label())
         self.log.info(p1 != p2)
 
-        self.log.info("test inequality operator: different Paulis")
+    def test_inequality_different(self):
+        """Test inequality operator: different Paulis"""
         p1 = random_pauli(5)
-        p2 = p1
+        p2 = deepcopy(p1)
         p2.v[0] = (p1.v[0] + 1) % 2
         self.assertTrue(p1 != p2)
         self.log.info(p2.to_label())


### PR DESCRIPTION
This allows for direct comparison of pauli operators and is much faster than conversion to text as used previously. 

## Description
in qiskit.tools.qi.pauli I added the two overloading operators to the Pauli class for == and !=
in qiskit.tools.apps.fermion I changed the textual comparison that was used to a direct one

## Motivation and Context

Some code in the chemistry examples uses a comparison 'if pauli1.to_label() == pauli2.to_label().'
With the proposed change the comparison is just 'if pauli1 == pauli2'. The direct comparison is 15x faster than the conversion to strings and thus significantly speeds up several codes.

## How Has This Been Tested?
pa = Pauli([0,0,1,1,1],[1,0,1,0,0])
pb = Pauli([0,0,1,1,1],[1,0,1,0,0])
pc = Pauli([0,0,1,1,1],[1,0,1,0,1])
if pa == pb:
    print('the first two are equal')
if pa != pc:
    print('the second two are not equal')

and I tested it on a new version of QChem Notebook which gave a 15x improvement when generating the Paulis for larger molecules. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.