### PR TITLE
for Pauli multiplication adding Pauli vectors element-wise

### DIFF
--- a/qiskit/tools/qi/pauli.py
+++ b/qiskit/tools/qi/pauli.py
@@ -63,9 +63,9 @@ class Pauli:
     def __mul__(self, other):
         """Multiply two Paulis."""
         if self.numberofqubits != other.numberofqubits:
-            print('Paulis cannot be multiplied - different number of qubits')
-        vnew = (self.v + other.v) % 2
-        wnew = (self.w + other.w) % 2
+            print('These Paulis cannot be multiplied - different number of qubits')
+        vnew = [x % 2 for x in (self.v[i] + other.v[i] for i in range(self.numberofqubits))]
+        wnew = [x % 2 for x in (self.w[i] + other.w[i] for i in range(self.numberofqubits))]
         paulinew = Pauli(vnew, wnew)
         return paulinew
 


### PR DESCRIPTION
## Description
this fixes PR #160 

## Motivation and Context
multiplying Paulis was not working

## How Has This Been Tested?
from qiskit.tools.qi.pauli import Pauli
pauli_1 = Pauli([1,0,0],[1,0,0])
pauli_2 = Pauli([1,1,0],[1,0,1])
print(pauli_1)
print(pauli_2)
mult_pauli = pauli_1*pauli_2
print(mult_pauli)

maybe a testing routine should also go into test.python.test_qi.TestPauli, compare to PR #156 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.