### PR TITLE
Issue 168 - Jobs timeouts are wrongly managed

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1124,7 +1124,9 @@ class QuantumProgram(object):
 
         q_job_list = []
         for qobj in qobj_list:
-            q_job = QuantumJob(qobj, preformatted=True)
+            q_job = QuantumJob(qobj, preformatted=True, resources={
+                'max_credits':qobj['config']['max_credits'], 'wait':wait,
+                'timeout':timeout})
             q_job_list.append(q_job)
 
         job_processor = JobProcessor(q_job_list, max_workers=5,

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1639,6 +1639,32 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertEqual(qobj['circuits'][0]['config']['0'], 2)
         self.assertEqual(qobj['circuits'][0]['config']['1'], 1)
 
+    def test_timeout(self):
+        """Test run.
+
+        If all correct should the data.
+        """
+        QP_program = QuantumProgram(specs=self.QPS_SPECS)
+        qr = QP_program.get_quantum_register("qname")
+        cr = QP_program.get_classical_register("cname")
+        qc2 = QP_program.create_circuit("qc2", [qr], [cr])
+        qc2.h(qr[0])
+        qc2.cx(qr[0], qr[1])
+        qc2.cx(qr[0], qr[2])
+        qc2.measure(qr, cr)
+        circuits = ['qc2']
+        shots = 1024  # the number of shots in the experiment.
+        backend = 'local_qasm_simulator'
+        qobj = QP_program.compile(circuits, backend=backend, shots=shots,
+                                seed=88)
+        try:
+            out = QP_program.run(qobj, timeout=0.01)
+            self.assertTrue(False, "Should timeout! but it didn't!")
+        except QISKitError as ex:
+            self.assertEqual(ex.message,
+                'Error waiting for Job results: Timeout after 0.01 seconds.')
+
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
* Propagate timeout (and other) parameters to QuantumJob constructor
* Test created to test timeouts

Fixes #168 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally tested.
A new tests has been introduced: test_quantumprogram.py: test_timeout()

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.