### PR TITLE
[test suite] No more logs in file. Logs on stderr on demand.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,6 @@ lint:
 test:
 	python3 -m unittest discover -v
 
-test_verbose: export LOG_LEVEL=DEBUG
-test_verbose: test
-
 profile:
 	python3 -m unittest discover -p "profile*.py" -v
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ lint:
 test:
 	python3 -m unittest discover -v
 
+test_verbose: export LOG_LEVEL=DEBUG
+test_verbose: test
+
 profile:
 	python3 -m unittest discover -p "profile*.py" -v
 

--- a/doc/dev_introduction.rst
+++ b/doc/dev_introduction.rst
@@ -120,3 +120,23 @@ the messages. For example, if the module is `qiskit/some/module.py`:
    logger = logging.getLogger(__name__)  # logger for "qiskit.some.module"
    ...
    logger.info("This is an info message)
+
+
+Testing
+-------
+
+The SDK uses the `standard Pyton "unittest" framework
+<https://docs.python.org/3/library/unittest.html>`_ for the testing of the
+different components and functionality.
+
+For executing the tests, a ``make test`` target is available. The execution
+of the tests (both via the make target and during manual invocation) takes into
+account the ``LOG_LEVEL`` environment variable. If present, a ``.log`` file
+will be created on the test directory with the output of the log calls, which
+will also be printed to stdout. You can adjust the verbosity via the content
+of that variable, for example:
+
+.. code-block::
+
+    $ LOG_LEVEL=DEBUG make test
+    $ LOG_LEVEL=INFO python -m unittest test/python/test_apps.py

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -30,6 +30,13 @@ if os.getenv('TRAVIS_PULL_REQUEST_SLUG'):
     if os.getenv('TRAVIS_REPO_SLUG') != os.getenv('TRAVIS_PULL_REQUEST_SLUG'):
         TRAVIS_FORK_PULL_REQUEST = True
 
+LOG_LEVEL = logging.CRITICAL
+if os.getenv('LOG_LEVEL'):
+    toset = os.getenv('LOG_LEVEL')
+    goodlevels = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']
+    if not toset in goodlevels:
+        raise Exception("The env variable LOG_LEVEL is %s instead of something in %s" % (toset,goodlevels   ))
+    LOG_LEVEL = getattr(logging,toset)
 
 class Path(Enum):
     """Helper with paths commonly used during the tests."""
@@ -45,18 +52,18 @@ class QiskitTestCase(unittest.TestCase):
     """Helper class that contains common functionality."""
     @classmethod
     def setUpClass(cls):
-        # Setup logging to a file 'test_xxx.log'
         cls.moduleName = os.path.splitext(inspect.getfile(cls))[0]
         cls.log = logging.getLogger(cls.__name__)
-        cls.log.setLevel(logging.INFO)
-        logFileName = cls.moduleName + '.log'
-        handler = logging.FileHandler(logFileName)
-        handler.setLevel(logging.INFO)
+        cls.log.setLevel(LOG_LEVEL)
         log_fmt = ('{}.%(funcName)s:%(levelname)s:%(asctime)s:'
                    ' %(message)s'.format(cls.__name__))
         formatter = logging.Formatter(log_fmt)
-        handler.setFormatter(formatter)
-        cls.log.addHandler(handler)
+
+        # logger for the stdout
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(formatter)
+
+        cls.log.addHandler(stream_handler)
 
     @staticmethod
     def _get_resource_path(filename, path=Path.TEST):

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1308,7 +1308,7 @@ class TestQuantumProgram(QiskitTestCase):
         backend = 'ibmqx_qasm_simulator'
         shots = 1  # the number of shots in the experiment.
         status = QP_program.get_backend_status(backend)
-        if status['available'] is False:
+        if not status.get('available', False):
             pass
         else:
             result = QP_program.execute(['circuitName'], backend=backend,


### PR DESCRIPTION
## Description and motivation
It looks like the logfiles generated by the test suite are unnecessary (comment here if I'm wrong). Logs can be useful in very specific situations, such as writing new tests or checking when one of them is failing. This PR makes them show up "on demand", with a env var called `LOG_LEVEL`:

`env LOG_LEVEL="INFO" python -m unittest test/python/test_apps.py`

If you wan to run the full test suite:

`make test_verbose`

By default, the tests only print CRITICAL issues. They should be rare and, when show up, should not be ignored.

The output now is cleaner, so you can focus on things that are really important.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)