### PR TITLE
Add support for IBM Q hubs, groups and projects

### DIFF
--- a/Qconfig.py.default
+++ b/Qconfig.py.default
@@ -1,13 +1,23 @@
 # Before you can use the jobs API, you need to set up an access token.
 # Log in to the Quantum Experience. Under "Account", generate a personal 
-# access token. Replace "None" below with the quoted token string.
-# Uncomment the APItoken variable, and you will be ready to go.
+# access token. Replace 'PUT_YOUR_API_TOKEN_HERE' below with the quoted
+# token string. Uncomment the APItoken variable, and you will be ready to go.
 
-#APItoken = "PUT_YOUR_API_TOKEN_HERE"
+#APItoken = 'PUT_YOUR_API_TOKEN_HERE'
 
 config = {
-  "url": 'https://quantumexperience.ng.bluemix.net/api'
+    'url': 'https://quantumexperience.ng.bluemix.net/api',
+
+    # If you have access to IBM Q features, you also need to fill the "hub",
+    # "group", and "project" details. Replace "None" on the lines below
+    # with your details from Quantum Experience, quoting the strings, for
+    # example: 'hub': 'my_hub'
+    # You will also need to update the 'url' above, pointing it to your custom
+    # URL for IBM Q.
+    'hub': None,
+    'group': None,
+    'project': None
 }
 
 if 'APItoken' not in locals():
-  raise Exception("Please set up your access token. See Qconfig.py.")
+    raise Exception('Please set up your access token. See Qconfig.py.')

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ We are ready to try out some QASM examples, which runs via the local simulator.
 This is a simple superposition example.
 
 ```python
-from qiskit import QuantumProgram
+from qiskit import QuantumProgram, QISKitError, RegisterSizeError
 
 # Creating Programs create your first QuantumProgram object instance.
 Q_program = QuantumProgram()
@@ -105,14 +105,53 @@ COMPLETED
 {'00': 509, '11': 515}
 ```
 
-You can also use QISKit to execute your code on a [real Quantum Chip](https://github.com/QISKit/ibmqx-backend-information).
+### Executing your code on a real Quantum chip
 
- First, get your API token:
+You can also use QISKit to execute your code on a
+[real Quantum Chip](https://github.com/QISKit/ibmqx-backend-information).
+In order to do so, you need to configure the SDK for using the credentials for
+your Quantum Experience Account:
 
--  Create an [IBM Q experience](https://quantumexperience.ng.bluemix.net) account if you haven't already done so
--  Get an API token from the IBM Q experience website under “My Account” > “Personal Access Token”
 
-This API token allows you to execute your programs with the IBM Q experience backends. [Example](doc/example_real_backend.rst).
+#### Configure your API token and QE credentials
+
+
+1. Create an [IBM Q experience](https://quantumexperience.ng.bluemix.net)>
+   account if you haven't already done so
+2. Get an API token from the IBM Q experience website under "`My Account`" >
+   "`Personal Access Token`". This API token allows you to execute your
+   programs with the IBM Q experience backends.
+   [Example](doc/example_real_backend.rst).
+3. You will insert your API token in a file called `Qconfig.py`. First
+   copy the default version of this file from the tutorial folder to the
+   main SDK folder (on Windows, replace `cp` with `copy`):
+
+   ```bash
+    $ cp Qconfig.py.default Qconfig.py
+   ```
+
+4. Open your Qconfig.py, remove the `#` from the beginning of the API
+   token line, and copy/paste your API token into the space between the
+   quotation marks on that line. Save and close the file.
+
+5. If you have access to the IBM Q features, you also need to setup the
+   values for your hub, group, and project. You can do so by filling the
+   `config` variable with the values you can find on your IBM Q account
+   page.
+
+For example, a valid and fully configured `Qconfig.py` file would look like:
+
+```python
+APItoken = '123456789abc...'
+
+config = {
+    'url': 'https://quantumexperience.ng.bluemix.net/api',
+    # The following should only be needed for IBM Q users.
+    'hub': 'MY_HUB',
+    'group': 'MY_GROUP',
+    'project': 'MY_PROJECT'
+}
+```
 
 More details on this and more information see [our QISKit documentation](doc/qiskit.rst).
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -84,8 +84,8 @@ with QISKit, and install the required dependencies:
     .\make env
 
 
-4. Configure your API token
----------------------------
+4. Configure your API token and QE credentials
+----------------------------------------------
 
 -  Create an `IBM Q
    experience <https://quantumexperience.ng.bluemix.net>`__ account if
@@ -103,6 +103,26 @@ with QISKit, and install the required dependencies:
 -  Open your Qconfig.py, remove the ``#`` from the beginning of the API
    token line, and copy/paste your API token into the space between the
    quotation marks on that line. Save and close the file.
+
+-  If you have access to the IBM Q features, you also need to setup the
+   values for your hub, group, and project. You can do so by filling the
+   ``config`` variable with the values you can find on your IBM Q account
+   page.
+
+For example, a valid and fully configured ``Qconfig.py`` file would look like:
+
+.. code:: python
+
+    APItoken = '123456789abc...'
+
+    config = {
+        'url': 'https://quantumexperience.ng.bluemix.net/api',
+        # The following should only be needed for IBM Q users.
+        'hub': 'MY_HUB',
+        'group': 'MY_GROUP',
+        'project': 'MY_PROJECT'
+    }
+
 
 Install Jupyter-based tutorials
 ===============================

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -470,7 +470,8 @@ class QuantumProgram(object):
     # methods for working with backends
     ###############################################################
 
-    def set_api(self, token, url, verify=True):
+    def set_api(self, token, url, hub=None, group=None, project=None,
+                verify=True):
         """ Setup the API.
 
         Fills the __ONLINE_BACKENDS, __api, and __api_config variables.
@@ -481,19 +482,46 @@ class QuantumProgram(object):
                 as the quantum experience.
             url (str): The url used for online backend such as the quantum
                 experience.
+            hub (str): The hub used for online backend.
+            group (str): The group used for online backend.
+            project (str): The project used for online backend.
             verify (bool): If False, ignores SSL certificates errors.
         Raises:
             ConnectionError: if the API instantiation failed.
+            QISKitError: if no hub, group or project were specified.
         """
         try:
-            self.__api = IBMQuantumExperience(token, {"url": url}, verify)
+            config_dict = {
+                'url': url,
+                'hub': hub,
+                'group': group,
+                'project': project
+            }
+            self.__api = IBMQuantumExperience(token, config_dict, verify)
         except Exception as ex:
             raise ConnectionError("Couldn't connect to IBMQuantumExperience server: {0}"
                                   .format(ex))
         qiskit.backends.discover_remote_backends(self.__api)
         self.__ONLINE_BACKENDS = self.online_backends()
         self.__api_config["token"] = token
-        self.__api_config["url"] = {"url": url}
+        self.__api_config["config"] = config_dict.copy()
+
+    def set_api_hubs_config(self, hub, group, project):
+        """Update the API hubs configuration, replacing the previous one.
+
+            hub (str): The hub used for online backend.
+            group (str): The group used for online backend.
+            project (str): The project used for online backend.
+        """
+        config_dict = {
+            'hub': hub,
+            'group': group,
+            'project': project
+        }
+
+        for k, v in config_dict.items():
+            self.__api.config[k] = v
+            self.__api_config['config'][k] = v
 
     def get_api_config(self):
         """Return the program specs."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-IBMQuantumExperience>=1.8.17
+IBMQuantumExperience>=1.8.19
 requests>=2.18,<2.19
 networkx>=1.11,<1.12
 ply==3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-IBMQuantumExperience>=1.8.13
+IBMQuantumExperience>=1.8.17
 requests>=2.18,<2.19
 networkx>=1.11,<1.12
 ply==3.10

--- a/test/python/test_ai_ibmq.py
+++ b/test/python/test_ai_ibmq.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
+
+# Copyright 2017 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""Test API hub, groups and projects related functionality."""
+import os
+from unittest import skipIf
+from unittest.mock import patch
+
+from qiskit import QuantumProgram
+from IBMQuantumExperience.IBMQuantumExperience import _Request
+
+from .common import QiskitTestCase
+
+
+# We need the environment variable for Travis.
+HAS_GROUP_VARS = False
+try:
+    import Qconfig
+
+    QE_TOKEN = Qconfig.APItoken
+    QE_URL = Qconfig.config['url']
+    QE_HUB = Qconfig.config['hub']
+    QE_GROUP = Qconfig.config['group']
+    QE_PROJECT = Qconfig.config['project']
+    HAS_GROUP_VARS = True
+except ImportError:
+    if all(var in os.environ for var in
+           ['QE_TOKEN', 'QE_URL', 'QE_HUB', 'QE_GROUP', 'QE_PROJECT']):
+        QE_TOKEN = os.environ['QE_TOKEN']
+        QE_URL = os.environ['QE_URL']
+        QE_HUB = os.environ['QE_HUB']
+        QE_GROUP = os.environ['QE_GROUP']
+        QE_PROJECT = os.environ['QE_PROJECT']
+        HAS_GROUP_VARS = True
+
+
+class TestApiHub(QiskitTestCase):
+    """Tests for API hubs, groups, and projects."""
+
+    def setUp(self):
+        super(TestApiHub, self).setUp()
+        self.backend = 'ibmqx4'
+
+    def _get_quantum_program(self):
+        quantum_program = QuantumProgram()
+        qr = quantum_program.create_quantum_register("q", 1)
+        cr = quantum_program.create_classical_register("c", 1)
+        qc = quantum_program.create_circuit("qc", [qr], [cr])
+        qc.h(qr[0])
+        qc.measure(qr[0], cr[0])
+
+        return quantum_program
+
+    @skipIf(not HAS_GROUP_VARS, 'QE group variables not present')
+    def test_execute_api_no_parameters(self):
+        """Test calling the API with no hub parameters."""
+        quantum_program = self._get_quantum_program()
+
+        # Invoke with no hub, group or project parameters.
+        quantum_program.set_api(QE_TOKEN, QE_URL)
+
+        # Store the original post() method.
+        post_original = quantum_program._QuantumProgram__api.req.post
+        with patch.object(_Request, 'post',
+                          wraps=post_original) as mocked_post:
+            _ = quantum_program.execute(
+                ['qc'], backend=self.backend, shots=1, max_credits=3)
+
+            # Get the first parameter of the `run_job` POST call.
+            url = mocked_post.call_args_list[-1][0][0]
+            self.assertEqual('/Jobs', url)
+
+    @skipIf(not HAS_GROUP_VARS, 'QE group variables not present')
+    def test_execute_api_parameters(self):
+        """Test calling the API with hub parameters."""
+        quantum_program = self._get_quantum_program()
+
+        # Invoke with hub, group and project parameters.
+        quantum_program.set_api(QE_TOKEN, QE_URL, QE_HUB, QE_GROUP, QE_PROJECT)
+
+        # Store the original post() method.
+        post_original = quantum_program._QuantumProgram__api.req.post
+        with patch.object(_Request, 'post',
+                          wraps=post_original) as mocked_post:
+            _ = quantum_program.execute(
+                ['qc'], backend=self.backend, shots=1, max_credits=3)
+
+            # Get the first parameter of the `run_job` POST call.
+            url = mocked_post.call_args_list[-1][0][0]
+            self.assertEqual('/Network/%s/Groups/%s/Projects/%s/jobs' %
+                             (QE_HUB, QE_GROUP, QE_PROJECT),
+                             url)
+
+    @skipIf(not HAS_GROUP_VARS, 'QE group variables not present')
+    def test_execute_api_modified_parameters(self):
+        """Test calling the API with modified hub parameters."""
+        quantum_program = self._get_quantum_program()
+
+        # Invoke with hub, group and project parameters.
+        FAKE_QE_HUB = 'HUB'
+        FAKE_QE_GROUP = 'GROUP'
+        FAKE_QE_PROJECT = 'PROJECT'
+        quantum_program.set_api(QE_TOKEN, QE_URL,
+                                FAKE_QE_HUB, FAKE_QE_GROUP, FAKE_QE_PROJECT)
+
+        # Modify the api parameters.
+        self.assertEqual(quantum_program._QuantumProgram__api.config['hub'],
+                         FAKE_QE_HUB)
+        quantum_program.set_api_hubs_config(QE_HUB, QE_GROUP, QE_PROJECT)
+        self.assertEqual(quantum_program._QuantumProgram__api.config['hub'],
+                         QE_HUB)
+
+        # Store the original post() method.
+        post_original = quantum_program._QuantumProgram__api.req.post
+        with patch.object(_Request, 'post',
+                          wraps=post_original) as mocked_post:
+            _ = quantum_program.execute(
+                ['qc'], backend=self.backend, shots=1, max_credits=3)
+
+            # Get the first parameter of the `run_job` POST call.
+            url = mocked_post.call_args_list[-1][0][0]
+            self.assertEqual('/Network/%s/Groups/%s/Projects/%s/jobs' %
+                             (QE_HUB, QE_GROUP, QE_PROJECT),
+                             url)
+
+    @skipIf(not HAS_GROUP_VARS, 'QE group variables not present')
+    def test_api_calls_no_parameters(self):
+        """Test calling some endpoints of the API with no hub parameters.
+
+        Note: this tests does not make assertions, it is only intended to
+            verify the endpoints.
+        """
+        quantum_program = self._get_quantum_program()
+
+        # Invoke with no hub, group or project parameters.
+        quantum_program.set_api(QE_TOKEN, QE_URL)
+
+        self.log.info(quantum_program.online_backends())
+        self.log.info(quantum_program.get_backend_parameters(self.backend))
+        self.log.info(quantum_program.get_backend_calibration(self.backend))
+
+    @skipIf(not HAS_GROUP_VARS, 'QE group variables not present')
+    def test_api_calls_parameters(self):
+        """Test calling some endpoints of the API with hub parameters.
+
+        Note: this tests does not make assertions, it is only intended to
+            verify the endpoints.
+        """
+        quantum_program = self._get_quantum_program()
+
+        # Invoke with hub, group and project parameters.
+        quantum_program.set_api(QE_TOKEN, QE_URL, QE_HUB, QE_GROUP, QE_PROJECT)
+
+        self.log.info(quantum_program.online_backends())
+        self.log.info(quantum_program.get_backend_parameters(self.backend))
+        self.log.info(quantum_program.get_backend_calibration(self.backend))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes related for supporting IBM Q features while preserving compatibility:
* Update `QuantumProgram.set_api()` so it accepts `hub`, `group`, `project` as optional parameters.
* Add a new `QuantumProgram.set_api_hubs_config()` for modifying those parameters during a run.
* Revise the `Qconfig.py.default` file, adding the new parameters and clarifying the instructions.
* Revise the documentation, copying the `Qconfig` information to the main `README.md` and updating the instructions.
* Add tests (currently only not-skipped if a valid Qconfig is found, still not on the CI)


## Motivation and Context

Support the new IBM Q features.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.