### PR TITLE
Add destroy routines for registers and circuits

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -208,6 +208,22 @@ class QuantumProgram(object):
             logger.info(">> new quantum_register created: %s %s", name, size)
         return self.__quantum_registers[name]
 
+    def destroy_quantum_register(self, name):
+        """Destroy an existing Quantum Register.
+
+        Args:
+            name (str): the name of the quantum register
+
+        Raises:
+            QISKitError: if the register does not exist in the program.
+        """
+        if name not in self.__quantum_registers:
+            raise QISKitError("Can't destroy this register: Not present")
+        else:
+            logger.info(">> quantum_register destroyed: %s", name)
+            del self.__quantum_registers[name]
+
+
     def create_quantum_registers(self, register_array):
         """Create a new set of Quantum Registers based on a array of them.
 
@@ -231,6 +247,24 @@ class QuantumProgram(object):
                 register["name"], register["size"])
             new_registers.append(register)
         return new_registers
+
+    def destroy_quantum_registers(self, register_array):
+        """Destroy a set of Quantum Registers based on a array of them.
+
+        Args:
+            register_array (list[dict]): An array of quantum registers in
+                dictionay format::
+
+                    "quantum_registers": [
+                        {
+                        "name": "qr",
+                        },
+                        ...
+                    ]
+                "size" may be a key for compatibility, but is ignored.
+        """
+        for register in register_array:
+            self.destroy_quantum_register(register["name"])
 
     def create_classical_register(self, name, size):
         """Create a new Classical Register.
@@ -277,6 +311,39 @@ class QuantumProgram(object):
                 register["name"], register["size"]))
         return new_registers
 
+    def destroy_classical_register(self, name):
+        """Destroy an existing Classical Register.
+
+        Args:
+            name (str): the name of the classical register
+
+        Raises:
+            QISKitError: if the register does not exist in the program.
+        """
+        if name not in self.__classical_registers:
+            raise QISKitError("Can't destroy this register: Not present")
+        else:
+            logger.info(">> classical register destroyed: %s", name)
+            del self.__classical_registers[name]
+
+    def destroy_classical_registers(self, registers_array):
+        """Destroy a set of Classical Registers based on a array of them.
+
+        Args:
+            registers_array (list[dict]): An array of classical registers in
+                dictionay fromat::
+
+                    "classical_registers": [
+                        {
+                        "name": "qr",
+                        },
+                        ...
+                    ]
+                "size" may be a key for compatibility, but is ignored.
+        """
+        for register in registers_array:
+            self.destroy_classical_register(register["name"])
+
     def create_circuit(self, name, qregisters=None, cregisters=None):
         """Create a empty Quantum Circuit in the Quantum Program.
 
@@ -303,6 +370,20 @@ class QuantumProgram(object):
             quantum_circuit.add(register)
         self.add_circuit(name, quantum_circuit)
         return self.__quantum_program[name]
+
+    def destroy_circuit(self, name):
+        """Destroy a Quantum Circuit in the Quantum Program. This will not
+        destroy any registers associated with the circuit.
+
+        Args:
+            name (str): the name of the circuit
+
+        Raises:
+            QISKitError: if the register does not exist in the program.
+        """
+        if name not in self.__quantum_program:
+            raise QISKitError("Can't destroy this circuit: Not present")
+        del self.__quantum_program[name]
 
     def add_circuit(self, name, quantum_circuit):
         """Add a new circuit based on an Object representation.

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -223,7 +223,6 @@ class QuantumProgram(object):
             logger.info(">> quantum_register destroyed: %s", name)
             del self.__quantum_registers[name]
 
-
     def create_quantum_registers(self, register_array):
         """Create a new set of Quantum Registers based on a array of them.
 

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -240,6 +240,32 @@ class TestQuantumProgram(QiskitTestCase):
         for i in qrs:
             self.assertIsInstance(i, QuantumRegister)
 
+    def test_destroy_classical_register(self):
+        """Test destroy_classical_register."""
+        QP_program = QuantumProgram()
+        _ = QP_program.create_classical_register('c1', 3)
+        self.assertIn('c1', QP_program.get_classical_register_names())
+        QP_program.destroy_classical_register('c1')
+        self.assertNotIn('c1', QP_program.get_classical_register_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            QP_program.destroy_classical_register('c1')
+        self.assertIn('Not present', str(context.exception))
+
+    def test_destroy_quantum_register(self):
+        """Test destroy_quantum_register."""
+        QP_program = QuantumProgram()
+        _ = QP_program.create_quantum_register('q1', 3)
+        self.assertIn('q1', QP_program.get_quantum_register_names())
+        QP_program.destroy_quantum_register('q1')
+        self.assertNotIn('q1', QP_program.get_quantum_register_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            QP_program.destroy_quantum_register('q1')
+        self.assertIn('Not present', str(context.exception))
+
     def test_create_circuit(self):
         """Test create_circuit.
 
@@ -277,6 +303,21 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertIsInstance(qc1, QuantumCircuit)
         self.assertIsInstance(qc2, QuantumCircuit)
         self.assertIsInstance(qc3, QuantumCircuit)
+
+    def test_destroy_circuit(self):
+        """Test destroy_circuit."""
+        QP_program = QuantumProgram()
+        qr = QP_program.create_quantum_register('qr', 3)
+        cr = QP_program.create_classical_register('cr', 3)
+        _ = QP_program.create_circuit('qc', [qr], [cr])
+        self.assertIn('qc', QP_program.get_circuit_names())
+        QP_program.destroy_circuit('qc')
+        self.assertNotIn('qc', QP_program.get_circuit_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            QP_program.destroy_circuit('qc')
+        self.assertIn('Not present', str(context.exception))
 
     def test_load_qasm_file(self):
         """Test load_qasm_file and get_circuit.


### PR DESCRIPTION
## Description
New routines destroy_* that pair with all the create_* routines

## Motivation and Context
The codebase contains routines for creating quantum registers, classical registers, and circuits, but there is no way to destroy them. Since a new register or circuit cannot be created with the same name, this restricts the reuse of a quantum program, resulting in either an ever-growing quantum program with more registers and circuits, or constantly recreating the quantum program object

## How Has This Been Tested?
I have been running stress tests, which include 6 hour runs using a single quantum program object, constantly reusing the same named quantum and classical registers and circuits, creating and destroying them each pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed. (Of the tests that were passing before)