### PR TITLE
Support for a launch callback function

### DIFF
--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -86,7 +86,7 @@ class JobProcessor():
         # Set a default dummy callback just in case the user doesn't want
         # to pass any callback.
         self.callback = (lambda rs: ()) if callback is None else callback
-        self.launch_callback = None
+        self.launch_callback = launch_callback
         self.num_jobs = len(self.q_jobs)
         self.jobs_results = []
         if self.online:

--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -86,7 +86,7 @@ class JobProcessor():
         # Set a default dummy callback just in case the user doesn't want
         # to pass any callback.
         self.callback = (lambda rs: ()) if callback is None else callback
-        self.launch_callback = (lambda rs: ()) if callback is None else launch_callback
+        self.launch_callback = None
         self.num_jobs = len(self.q_jobs)
         self.jobs_results = []
         if self.online:

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1102,7 +1102,8 @@ class QuantumProgram(object):
         self.wait_for_results(timeout)
         return self.jobs_results
 
-    def run_async(self, qobj, wait=5, timeout=60, callback=None):
+    def run_async(self, qobj, wait=5, timeout=60, callback=None,
+                  launch_callback=None):
         """Run a program (a pre-compiled quantum program) asynchronously. This
         is a non-blocking function, so it will return inmediately.
 
@@ -1116,13 +1117,18 @@ class QuantumProgram(object):
             callback (fn(result)): A function with signature:
                     fn(result):
                     The result param will be a Result object.
+            launch_callback (fn(string)): Function called at job launch. It will
+                                          be passed the ID string of job, which
+                                          will match the job_id in the result.
         """
         self._run_internal([qobj],
                            wait=wait,
                            timeout=timeout,
-                           callback=callback)
+                           callback=callback,
+                           launch_callback=launch_callback)
 
-    def run_batch_async(self, qobj_list, wait=5, timeout=120, callback=None):
+    def run_batch_async(self, qobj_list, wait=5, timeout=120, callback=None,
+                        launch_callback=None):
         """Run various programs (a list of pre-compiled quantum program)
         asynchronously. This is a non-blocking function, so it will return
         inmediately.
@@ -1137,15 +1143,19 @@ class QuantumProgram(object):
                     fn(results):
                     The results param will be a list of Result objects, one
                     Result per qobj in the input list.
+            launch_callback (fn(string)): Function called at job launch. It will
+                                          be passed the ID string of job, which
+                                          will match the job_id in the result.
         """
         self._run_internal(qobj_list,
                            wait=wait,
                            timeout=timeout,
                            callback=callback,
+                           launch_callback=launch_callback,
                            are_multiple_results=True)
 
     def _run_internal(self, qobj_list, wait=5, timeout=60, callback=None,
-                      are_multiple_results=False):
+                      launch_callback=None, are_multiple_results=False):
 
         self.callback = callback
         self.are_multiple_results = are_multiple_results
@@ -1158,7 +1168,8 @@ class QuantumProgram(object):
             q_job_list.append(q_job)
 
         job_processor = JobProcessor(q_job_list, max_workers=5,
-                                     callback=self._jobs_done_callback)
+                                     callback=self._jobs_done_callback,
+                                     launch_callback=launch_callback)
         job_processor.submit()
 
     def _jobs_done_callback(self, jobs_results):

--- a/qiskit/backends/_basebackend.py
+++ b/qiskit/backends/_basebackend.py
@@ -24,7 +24,7 @@ class BaseBackend(ABC):
         self._configuration = configuration
 
     @abstractmethod
-    def run(self, q_job):
+    def run(self, q_job, launch_callback=None):
         pass
 
     @property

--- a/qiskit/backends/_qasm_cpp_simulator.py
+++ b/qiskit/backends/_qasm_cpp_simulator.py
@@ -62,12 +62,16 @@ class QasmCppSimulator(BaseBackend):
                 cmd = '"{0}" or "{1}" '.format(self._exe, './' + self._exe)
                 raise FileNotFoundError(cmd)
 
-    def run(self, q_job):
+    def run(self, q_job, launch_callback=None):
         """
         Run simulation on C++ simulator.
 
         Args:
             q_job (QuantumJob): describes job
+            launch_callback (fn(string)): Function called at job launch. It
+                                          will be passed the ID string of job,
+                                          which will match the job_id in the
+                                          result.
 
         Returns:
             Result: result object
@@ -77,7 +81,8 @@ class QasmCppSimulator(BaseBackend):
         """
         # Generating a string id for the job
         job_id = str(uuid.uuid4())
-
+        if launch_callback is not None:
+            launch_callback(job_id)
         qobj = q_job.qobj
         # TODO: use qobj schema for validation
         if 'config' in qobj:

--- a/qiskit/backends/_qasmsimulator.py
+++ b/qiskit/backends/_qasmsimulator.py
@@ -272,10 +272,12 @@ class QasmSimulator(BaseBackend):
         else:
             self._quantum_state = temp
 
-    def run(self, q_job):
+    def run(self, q_job, launch_callback=None):
         """Run circuits in q_job"""
         # Generating a string id for the job
         job_id = str(uuid.uuid4())
+        if launch_callback is not None:
+            launch_callback(job_id)
         qobj = q_job.qobj
         result_list = []
         self._shots = qobj['config']['shots']

--- a/qiskit/backends/_unitarysimulator.py
+++ b/qiskit/backends/_unitarysimulator.py
@@ -144,14 +144,20 @@ class UnitarySimulator(BaseBackend):
         unitaty_add = enlarge_two_opt(gate, q0, q1, self._number_of_qubits)
         self._unitary_state = np.dot(unitaty_add, self._unitary_state)
 
-    def run(self, q_job):
+    def run(self, q_job, launch_callback=None):
         """Run q_job
 
         Args:
-        q_job (QuantumJob): job to run
+            q_job (QuantumJob): job to run
+            launch_callback (fn(string)): Function called at job launch. It
+                                          will be passed the ID string of job,
+                                          which will match the job_id in the
+                                          result.
         """
         # Generating a string id for the job
         job_id = str(uuid.uuid4())
+        if launch_callback is not None:
+            launch_callback(job_id)
         qobj = q_job.qobj
         result_list = []
         for circuit in qobj['circuits']:

--- a/test/python/test_basebackend.py
+++ b/test/python/test_basebackend.py
@@ -84,7 +84,7 @@ class NoConfigurationBackend(BaseBackend):
     def __init__(self, configuration=None):
         pass
 
-    def run(self, q_job):
+    def run(self, q_job, launch_callback=None):
         pass
 
     @property


### PR DESCRIPTION
## Description
This adds the support for a launch callback function to be called when a job is successfully started.

## Motivation and Context
There are 2 motivations here. The first is that there is currently no way to get the job id for an execution until the job is completed, which prevents any problem determination if a job fails to complete. Second, when launching a large number of jobs, there is no way to tell when jobs are actually initiated (i.e., dispatched to a worker)

## How Has This Been Tested?
The callback function has been tested using the run_async path and the qeremote backend. Other test paths have only been validated through pylint.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed. (Of tests passing before)