### PR TITLE
[WIP] return futures when doing run_async

### DIFF
--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -21,7 +21,7 @@ from concurrent import futures
 import logging
 import pprint
 from threading import Lock
-
+from collections import OrderedDict
 import qiskit.backends
 from qiskit.backends import (local_backends, remote_backends)
 from qiskit._result import Result
@@ -75,7 +75,7 @@ class JobProcessor():
         self.max_workers = max_workers
         # check whether any jobs are remote
         self.online = any(qj.backend not in local_backends() for qj in q_jobs)
-        self.futures = {}
+        self.futures = OrderedDict()
         self.lock = Lock()
         # Set a default dummy callback just in case the user doesn't want
         # to pass any callback.
@@ -119,3 +119,4 @@ class JobProcessor():
             future.qobj = q_job.qobj
             self.futures[future] = q_job.qobj
             future.add_done_callback(self._job_done_callback)
+        return self.futures

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1197,10 +1197,10 @@ class QuantumProgram(object):
                     fn(result):
                     The result param will be a Result object.
         """
-        self._run_internal([qobj],
-                           wait=wait,
-                           timeout=timeout,
-                           callback=callback)
+        return self._run_internal([qobj],
+                                  wait=wait,
+                                  timeout=timeout,
+                                  callback=callback)
 
     def run_batch_async(self, qobj_list, wait=5, timeout=120, callback=None):
         """Run various programs (a list of pre-compiled quantum program)
@@ -1237,9 +1237,9 @@ class QuantumProgram(object):
                 'timeout':timeout})
             q_job_list.append(q_job)
 
-        job_processor = JobProcessor(q_job_list, max_workers=5,
+        self._job_processor = JobProcessor(q_job_list, max_workers=5,
                                      callback=self._jobs_done_callback)
-        job_processor.submit()
+        return self._job_processor.submit()
 
     def _jobs_done_callback(self, jobs_results):
         """ This internal callback will be called once all Jobs submitted have

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -933,8 +933,7 @@ class TestQuantumProgram(QiskitTestCase):
 
         self.qp_program_finished = False
         self.qp_program_exception = None
-        out = QP_program.run_async(qobj, callback=_job_done_callback)
-
+        future_dict = QP_program.run_async(qobj, callback=_job_done_callback)
         while not self.qp_program_finished:
             # Wait until the job_done_callback is invoked and completed.
             pass
@@ -1235,7 +1234,6 @@ class TestQuantumProgram(QiskitTestCase):
         shots = 1024  # the number of shots in the experiment.
         QP_program.set_api(QE_TOKEN, QE_URL)
         backend = QP_program.online_simulators()[0]
-        # print(backend)
         result = QP_program.execute(['qc'], backend=backend,
                                     shots=shots, max_credits=3,
                                     seed=73846087)


### PR DESCRIPTION
When running jobs asynchronously via run_async in quantum program, this change returns the futures dictionary so the caller can check the status of the job before it completes.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.