### PR TITLE
mapper issue

### DIFF
--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -681,6 +681,9 @@ def optimize_1q_gates(circuit):
                                     right_parameters[1], left_parameters[1] +
                                     sympy.pi / 2, right_parameters[2] +
                                     sympy.pi / 2)
+            elif name_tuple[1] == "nop":
+                right_name = left_name
+                right_parameters = left_parameters
             else:
                 # For composing u3's or u2's with u3's, use
                 # u2(phi, lambda) = u3(pi/2, phi, lambda)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When an operator is removed in the function optimize_1q_gates an operator u3 is created without necessity and harms the next iterations. For instance with the following code based on #159 

from qiskit import QuantumProgram
import Qconfig
import pickle
import sympy as sp

qp = QuantumProgram()
qp.set_api(Qconfig.APItoken, Qconfig.config["url"])

qr = qp.create_quantum_register('qr',2)
cr = qp.create_classical_register('cr',2)
qc = qp.create_circuit('Bell',[qr],[cr])

qc.h(qr[1])
qc.h(qr[1])
qc.h(qr[1])
qc.cx(qr[1], qr[0])
qc.cx(qr[1], qr[0])
qc.cx(qr[1], qr[0])
qc.measure(qr[0], cr[0])
qc.measure(qr[1], cr[1])

backend = 'ibmqx4'
try:
    f = open(backend,'rb')
    cmap = pickle.load(backend)
except:
    cmap = qp.get_backend_configuration(backend)['coupling_map']
qobj = qp.compile(["Bell"], backend=backend, coupling_map=cmap)
qobj['config']['shots'] = 50
qobj['config']['backend'] = 'local_qasm_simulator'
print(qp.get_compiled_qasm(qobj,"Bell"))
result = qp.run(qobj)
data = result.get_counts('Bell')
print(data)


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This pull request reduces the number of operators in the compiled qasm

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make test returned only timeout errors and two api_parameters test fails.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.