### PR TITLE
use absolute path from setup.py path to read requirements file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup
+from os.path import dirname
 
-with open('requirements.txt', 'r') as f:
+with open(dirname(__file__)+'/requirements.txt', 'r') as f:
     requirements = [line.strip() for line in f]
 
 packages = ["qiskit",


### PR DESCRIPTION
## Description
using absolute path for reading the requirements.txt

## Motivation and Context
file can not be found when importing qiskit by adding its path to the system paths, like
`sys.path.insert(1,'../../qiskit-sdk-py')`
`from qiskit import QuantumProgram`
because open expects the file in the current working directory, which might be the directory of a jupyter notebook

## How Has This Been Tested?
tested under Linux and Windows

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.