### PR TITLE
catch deprecated basis specification

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -996,6 +996,11 @@ class QuantumProgram(object):
         if not basis_gates:
             if 'basis_gates' in backend_conf:
                 basis_gates = backend_conf['basis_gates']
+        elif len(basis_gates.split(',')) < 2:
+            # catches deprecated basis specification like 'SU2+CNOT'
+            logger.warn('encountered deprecated basis specification: '
+                        '"{}" substituting u1,u2,u3,cx,id'.format(basis_gates))
+            basis_gates = 'u1,u2,u3,cx,id'
         if not coupling_map:
             coupling_map = backend_conf['coupling_map']
         if not name_of_circuits:


### PR DESCRIPTION
Some devices would return a basis of the form 'SU2+CNOT'.
If there are no commas in basis string it will be replaced
with u1,u2,u3,cx.id and a warning will be logged.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this change the unroller just uses U and CX gates when it encounters this unrecognized basis specification. When all remote backends adopt the new basis specification this code can probably be elimintated, however, in the future it may be better for the unroller to throw an exception if it encounters such an error.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.