### PR TITLE
Added support for ibmqx_hpc_qasm_simulator backend:

### DIFF
--- a/doc/example_real_backend.rst
+++ b/doc/example_real_backend.rst
@@ -101,3 +101,33 @@ the IBM Q features:
 
 Please check the Installation :ref:`qconfig-setup` section for more details on
 how to setup your IBM Q credentials.
+
+
+Using the HPC online backend
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``ibmqx_hpc_qasm_simulator`` online backend has the following configurable
+parameters:
+
+- ``multi_shot_optimization``: boolean (True or False)
+- ``omp_num_threads``: integer between 1 and 16.
+
+The parameters can be specified to ``QuantumProgram.compile()`` via the
+``hpc`` parameter. For example:
+
+.. code-block:: python
+    :linenos:
+
+    QP_program.compile(circuits,
+                       backend=backend,
+                       shots=shots,
+                       seed=88,
+                       hpc={
+                           'multi_shot_optimization': True,
+                           'omp_num_threads': 16
+                       })
+
+
+Please note that these parameters must only be used for the
+``ibmqx_hpc_qasm_simulator``, and will be reset to None along with emitting
+a warning by the SDK if used with another backend.

--- a/qiskit/_openquantumcompiler.py
+++ b/qiskit/_openquantumcompiler.py
@@ -152,6 +152,7 @@ def dag2json(dag_circuit, basis_gates='u1,u2,u3,cx,id'):
         circuit_string = dag_circuit.qasm(qeflag=True)
     except TypeError:
         circuit_string = dag_circuit.qasm()
+    basis_gates = 'u1,u2,u3,cx,id' if basis_gates is None else basis_gates
     unroller = unroll.Unroller(qasm.Qasm(data=circuit_string).parse(),
                                unroll.JsonBackend(basis_gates.split(",")))
     json_circuit = unroller.execute()

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -945,7 +945,7 @@ class QuantumProgram(object):
             max_credits (int): the max credits to use 3, or 5
             seed (int): the intial seed the simulatros use
             qobj_id (str): identifier of the qobj.
-            hpc (json): This will setup some parameter for
+            hpc (dict): This will setup some parameter for
                         ibmqx_hpc_qasm_simulator, using a JSON-like format like:
                         {
                             'multi_shot_optimization': Boolean,

--- a/qiskit/backends/_qeremote.py
+++ b/qiskit/backends/_qeremote.py
@@ -5,6 +5,7 @@ This module is used for connecting to the Quantum Experience.
 import time
 import logging
 import pprint
+import json
 from qiskit.backends._basebackend import BaseBackend
 from qiskit import _openquantumcompiler as openquantumcompiler
 from qiskit import QISKitError
@@ -60,10 +61,16 @@ class QeRemote(BaseBackend):
                 api_jobs.append({'qasm': circuit['compiled_circuit_qasm']})
 
         seed0 = qobj['circuits'][0]['config']['seed']
+        hpc = None
+        if (qobj['config']['backend'] == 'ibmqx_hpc_qasm_simulator' and
+           'hpc' in qobj['config']):
+            hpc = qobj['config']['hpc']
+
         output = self._api.run_job(api_jobs, qobj['config']['backend'],
                                    shots=qobj['config']['shots'],
                                    max_credits=qobj['config']['max_credits'],
-                                   seed=seed0)
+                                   seed=seed0,
+                                   hpc=hpc)
         if 'error' in output:
             raise ResultError(output['error'])
 

--- a/qiskit/backends/_qeremote.py
+++ b/qiskit/backends/_qeremote.py
@@ -5,7 +5,6 @@ This module is used for connecting to the Quantum Experience.
 import time
 import logging
 import pprint
-import json
 from qiskit.backends._basebackend import BaseBackend
 from qiskit import _openquantumcompiler as openquantumcompiler
 from qiskit import QISKitError

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1734,6 +1734,48 @@ class TestQuantumProgram(QiskitTestCase):
             self.assertEqual(ex.message,
                 'Error waiting for Job results: Timeout after 0.01 seconds.')
 
+    def test_hpc_parameter_is_correct(self):
+        """Test for checking HPC parameter in compile() method.
+        It must be only used when the backend is ibmqx_hpc_qasm_simulator.
+        It will warn the user if the parameter is passed correctly but the
+        backend is not ibmqx_hpc_qasm_simulator.
+        """
+        QP_program = QuantumProgram(specs=self.QPS_SPECS)
+        qr = QP_program.get_quantum_register("qname")
+        cr = QP_program.get_classical_register("cname")
+        qc2 = QP_program.create_circuit("qc2", [qr], [cr])
+        qc2.h(qr[0])
+        qc2.cx(qr[0], qr[1])
+        qc2.cx(qr[0], qr[2])
+        qc2.measure(qr, cr)
+        circuits = ['qc2']
+        shots = 1  # the number of shots in the experiment.
+        backend = 'ibmqx_hpc_qasm_simulator'
+        QP_program.set_api(QE_TOKEN, QE_URL)
+        qobj = QP_program.compile(circuits, backend=backend, shots=shots,
+                    seed=88, hpc={'multi_shot_optimization': True,
+                                  'omp_num_threads': 16})
+        self.assertTrue(qobj)
+
+    def test_hpc_parameter_is_incorrect(self):
+        """Test for checking HPC parameter in compile() method.
+        It must be only used when the backend is ibmqx_hpc_qasm_simulator.
+        If the parameter format is incorrect, it will raise a QISKitError.
+        """
+        QP_program = QuantumProgram(specs=self.QPS_SPECS)
+        qr = QP_program.get_quantum_register("qname")
+        cr = QP_program.get_classical_register("cname")
+        qc2 = QP_program.create_circuit("qc2", [qr], [cr])
+        qc2.h(qr[0])
+        qc2.cx(qr[0], qr[1])
+        qc2.cx(qr[0], qr[2])
+        qc2.measure(qr, cr)
+        circuits = ['qc2']
+        shots = 1  # the number of shots in the experiment.
+        backend = 'ibmqx_hpc_qasm_simulator'
+        QP_program.set_api(QE_TOKEN, QE_URL)
+        self.assertRaises(QISKitError, QP_program.compile, circuits,
+            backend=backend, shots=shots, seed=88, hpc={'invalid_key': None})
 
 
 if __name__ == '__main__':

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1734,6 +1734,7 @@ class TestQuantumProgram(QiskitTestCase):
             self.assertEqual(ex.message,
                 'Error waiting for Job results: Timeout after 0.01 seconds.')
 
+    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
     def test_hpc_parameter_is_correct(self):
         """Test for checking HPC parameter in compile() method.
         It must be only used when the backend is ibmqx_hpc_qasm_simulator.
@@ -1757,6 +1758,7 @@ class TestQuantumProgram(QiskitTestCase):
                                   'omp_num_threads': 16})
         self.assertTrue(qobj)
 
+    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
     def test_hpc_parameter_is_incorrect(self):
         """Test for checking HPC parameter in compile() method.
         It must be only used when the backend is ibmqx_hpc_qasm_simulator.


### PR DESCRIPTION
* QuantumProgram::compile() now accepts an 'hpc' parameter with
  the format:
  { "multi_shot_optimization": Boolean,
    "omp_num_threads": Numeric }
* hpc parameter is mandatory for the new backend but it's not
  allowed for the rest of the backends.
* Tests added for checking parameter format correctness.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run all tests locally: make test
Added two new tests: test_hpc_parameter_is_correct and test_hpc_parameter_is_incorrect

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.