### PR TITLE
Fix sphinx-doc.org link mistaken by github as a relative link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,7 @@
 Contributing
 ============
 
-**We appreciate all kinds of help, so thank you!** 
+**We appreciate all kinds of help, so thank you!**
 
 You can contribute in many ways to this project.
 
@@ -31,7 +31,7 @@ Documentation
 
 The documentation for the project is in the ``doc`` directory. The
 documentation for the python SDK is auto-generated from python
-docstrings using `Sphinx <www.sphinx-doc.org>`_ for generating the
+docstrings using `Sphinx <http://www.sphinx-doc.org>`_ for generating the
 documentation. Please follow `Google's Python Style
 Guide <https://google.github.io/styleguide/pyguide.html?showone=Comments#Comments>`_
 for docstrings. A good example of the style can also be found with


### PR DESCRIPTION
## Description
Link currently points at https://github.com/QISKit/qiskit-sdk-py/blob/master/www.sphinx-doc.org

I've also removed a (single) unnecessary piece of whitespace.

## Motivation and Context
https://github.com/QISKit/qiskit-sdk-py/issues/100

## How Has This Been Tested?
Link now works in my fork :+1:

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.  <-- *no denying this one*
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.