### PR TITLE
* Added support for Windows cpp simulator

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -41,6 +41,6 @@ from ._quantumprogram import QuantumProgram
 from ._result import Result
 from ._util import _check_ibmqe_version
 
-__version__ = '0.4.4'
+__version__ = '0.4.5'
 
 _check_ibmqe_version()

--- a/qiskit/backends/_qiskit_cpp_simulator.py
+++ b/qiskit/backends/_qiskit_cpp_simulator.py
@@ -25,22 +25,25 @@ import numbers
 import os
 import subprocess
 from subprocess import PIPE
+import platform
 
 import numpy as np
 
 from qiskit._result import Result
 from qiskit.backends import BaseBackend
 
+logger = logging.getLogger(__name__)
+
+EXTENSION = '.exe' if platform.system() == 'Windows' else ''
+
 # Add path to compiled qiskit simulator
 DEFAULT_SIMULATOR_PATHS = [
     # This is the path where Makefile creates the simulator by default
     os.path.abspath(os.path.dirname(__file__) + \
-                    '../../../out/qiskit_simulator'),
+                    '../../../out/qiskit_simulator' + EXTENSION),
     # This is the path where PIP installs the simulator
-    os.path.abspath(os.path.dirname(__file__) + '/qiskit_simulator'),
+    os.path.abspath(os.path.dirname(__file__) + '/qiskit_simulator' + EXTENSION),
 ]
-logger = logging.getLogger(__name__)
-
 
 class QISKitCppSimulator(BaseBackend):
     """C++ quantum circuit simulator with realistic noise"""

--- a/qiskit/backends/_qiskit_cpp_simulator.py
+++ b/qiskit/backends/_qiskit_cpp_simulator.py
@@ -45,6 +45,7 @@ DEFAULT_SIMULATOR_PATHS = [
     os.path.abspath(os.path.dirname(__file__) + '/qiskit_simulator' + EXTENSION),
 ]
 
+
 class QISKitCppSimulator(BaseBackend):
     """C++ quantum circuit simulator with realistic noise"""
 

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ class QiskitSimulatorBuild(build):
 
 setup(
     name="qiskit",
-    version="0.4.4",
+    version="0.4.5",
     description="Software for developing quantum computing programs",
     long_description="""QISKit is a software development kit for writing
         quantum computing experiments, programs, and applications. Works with

--- a/src/cpp-simulator/src/Makefile
+++ b/src/cpp-simulator/src/Makefile
@@ -10,7 +10,7 @@ OUTPUT_DIR = ../../../out
 # Check if compiler is Apple LLVM and doesn't support OpenMP
 APPLELLVM = $(shell ${CC} --version | grep ^Apple)
 ifeq ($(APPLELLVM),)
-	CPPFLAGS = -std=c++14 -fopenmp $(OPT) $(INCLUDE) $(WARNINGS)
+	CPPFLAGS = -static -std=c++14 -fopenmp $(OPT) $(INCLUDE) $(WARNINGS)
 else
 	CPPFLAGS = -std=c++14 $(OPT) $(INCLUDE) $(WARNINGS)
 endif

--- a/src/cpp-simulator/src/Makefile
+++ b/src/cpp-simulator/src/Makefile
@@ -10,7 +10,7 @@ OUTPUT_DIR = ../../../out
 # Check if compiler is Apple LLVM and doesn't support OpenMP
 APPLELLVM = $(shell ${CC} --version | grep ^Apple)
 ifeq ($(APPLELLVM),)
-	CPPFLAGS = -static -std=c++14 -fopenmp $(OPT) $(INCLUDE) $(WARNINGS)
+	CPPFLAGS = -std=c++14 -fopenmp $(OPT) $(INCLUDE) $(WARNINGS)
 else
 	CPPFLAGS = -std=c++14 $(OPT) $(INCLUDE) $(WARNINGS)
 endif


### PR DESCRIPTION
* Bumped version to: 0.4.5

## Motivation and Context
New Cpp Simulator can't be build automatically from the repo, but we are working on it. 
In the meantime, I did a Windows build by myself and distributed to some contributors who needed it.
With these changes, they can put the executable and all DLL dependencies in `C:\Users\<user>\Anaconda3\Lib\site-packages\qiskit\backends\` and the SDK will recognize it and be able to execute it.

## How Has This Been Tested?
make test passed all tests.
I did a simple Qiskit example program that uses the 'local_qiskit_simulator' on Windows, and it worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.