### PR TITLE
Patch for cpp-simulator

### DIFF
--- a/qiskit/backends/_qiskit_cpp_simulator.py
+++ b/qiskit/backends/_qiskit_cpp_simulator.py
@@ -166,6 +166,8 @@ def run(qobj, executable):
                 for result in cresult['result']:
                     if result['success'] is True:
                         __parse_sim_data(result['data'])
+                        if 'noise_params' in result:
+                            __parse_noise_params(result['noise_params'])
         return cresult
 
     except FileNotFoundError:
@@ -208,26 +210,31 @@ def __parse_json_complex_single(val):
 
 def __parse_json_complex(val):
     if isinstance(val, list):
-        return np.array([__parse_json_complex_single(j)
-                         for j in val])
+        return np.array([__parse_json_complex_single(j) for j in val])
     elif isinstance(val, dict):
-        return {i: __parse_json_complex_single(j)
-                for i, j in val.items()}
+        return {i: __parse_json_complex_single(j) for i, j in val.items()}
     return val
+
+
+def __parse_noise_params(noise):
+    if isinstance(noise, dict):
+        for key, val in noise:
+            if 'U_error' in val:
+                tmp = np.array([__parse_json_complex(row)
+                               for row in val['U_error']])
+                noise[key]['U_error'] = tmp
 
 
 def __parse_sim_data(data):
     if 'quantum_states' in data:
-        tmp = [__parse_json_complex(psi)
-               for psi in data['quantum_states']]
+        tmp = [__parse_json_complex(psi) for psi in data['quantum_states']]
         data['quantum_states'] = tmp
     if 'density_matrix' in data:
         tmp = np.array([__parse_json_complex(row)
                         for row in data['density_matrix']])
         data['density_matrix'] = tmp
     if 'inner_products' in data:
-        tmp = [__parse_json_complex(ips)
-               for ips in data['inner_products']]
+        tmp = [__parse_json_complex(ips) for ips in data['inner_products']]
         data['inner_products'] = tmp
     if 'saved_quantum_states' in data:
         for j in range(len(data['saved_quantum_states'])):
@@ -240,7 +247,6 @@ def __parse_sim_data(data):
         for j in range(len(data['saved_density_matrix'])):
             tmp = {}
             for key, val in data['saved_density_matrix'][j].items():
-                val = np.array([__parse_json_complex(row)
-                                for row in val])
+                val = np.array([__parse_json_complex(row) for row in val])
                 tmp[int(key)] = val
             data['saved_density_matrix'][j] = tmp

--- a/qiskit/backends/_qiskit_cpp_simulator.py
+++ b/qiskit/backends/_qiskit_cpp_simulator.py
@@ -221,7 +221,7 @@ def __parse_noise_params(noise):
         for key, val in noise:
             if 'U_error' in val:
                 tmp = np.array([__parse_json_complex(row)
-                               for row in val['U_error']])
+                                for row in val['U_error']])
                 noise[key]['U_error'] = tmp
 
 

--- a/src/cpp-simulator/README.md
+++ b/src/cpp-simulator/README.md
@@ -367,8 +367,8 @@ A single qubit gate error with gate time of *1* unit, depolarizing probability *
 A coherent error model for X-90 rotations due to pulse amplitude and a phase-offset errors may be implemented directly with the following keywords:
 
 ```python
-"amp_error": alpha,
-"phase_error: omega
+"calibration_error": alpha,
+"detuning_error: omega
 ```
 
 In this case the ideal X-90 rotation will be implemented as the unitary $$U_{X90} = \exp\left[ -i (\frac{\pi}{2} + alpha) (\cos(\omega) X + \sin(\omega) Y ) \right]$$. If a `"U_error"` keyword is specified this additional coherent error will then be applied after, followed by any specified incoherent errors.
@@ -378,12 +378,12 @@ In this case the ideal X-90 rotation will be implemented as the unitary $$U_{X90
 A coherent error model for a CX gate implemented via a cross-resonance interaction with a pulse amplitude error, and a ZZ-interaction error may be implemented directly with the following keywords:
 
 ```python
-"amp_error": beta,
+"calibration_error": beta,
 "zz_error": gamma
 ```
 
 In this case the unitary for the CX gate is implemented as *U<sub>CX</sub> = U<sub>L</sub>\*U<sub>CR</sub>\*U<sub>R</sub>* where, *U<sub>CR</sub>* is the cross-resonance unitary, and *U<sub>L</sub>*, *U<sub>R</sub>* are the ideal local unitary rotations that would convert this to a CX in the ideal case. The ideal CR unitary is given by $$ U_{CR} = \exp\left[ -i \frac{\pi}{4} ZX  \right]$$, and the noisy one with the above errors is given by
-$$ U_{CR} = \exp\left[ -i (\frac{\pi}{4} + \beta) ( ZX + \gamma ZZ) \right]$$,
+$$ U_{CR} = \exp\left[ -i (\frac{\pi}{2} + \beta) ( \frac{Z \otimes X}{2} + \gamma \frac{Z\otimes Z}{2}) \right]$$,
 
 If a `"U_error"` keyword is specified this additional coherent error will then be applied after, followed by any specified incoherent errors.
 

--- a/src/cpp-simulator/README.md
+++ b/src/cpp-simulator/README.md
@@ -15,26 +15,26 @@ Copyright (c) 2017 IBM Corporation. All Rights Reserved.
 
 - [Installation](#installation)
 - [Using the simulator](#using-the-simulator)
-	- [Running from the command line](#running-from-the-command-line)
-	- [Running in Python](#running-in-python)
-	- [Running as a backend for qiskit-sdk-py](#running-as-a-backend-for-qiskit-sdk-py)
-	- [Simulator output](#simulator-output)
+    - [Running from the command line](#running-from-the-command-line)
+    - [Running in Python](#running-in-python)
+    - [Running as a backend for qiskit-sdk-py](#running-as-a-backend-for-qiskit-sdk-py)
+    - [Simulator output](#simulator-output)
 - [Config Settings](#config-settings)
- 	- [Using parallelization](#using-parallelization)
-	- [Using a custom initial state](#using-a-custom-initial-state)
-	- [Output data options](#output-data-options)
+     - [Using parallelization](#using-parallelization)
+    - [Using a custom initial state](#using-a-custom-initial-state)
+    - [Output data options](#output-data-options)
 - [Noise parameters](#noise-parameters)
-	- [Gate Errors](#gate-errors)
-	- [Thermal Relaxation Error](#thermal-relaxation-error)
-	- [Reset Error](#reset-error)
-	- [Measurement Readout Error](#measurement-readout-error)
+    - [Gate Errors](#gate-errors)
+    - [Thermal Relaxation Error](#thermal-relaxation-error)
+    - [Reset Error](#reset-error)
+    - [Measurement Readout Error](#measurement-readout-error)
 - [Full config specification](#full-config-specification)
 - [Acknowledgements]($#acknowledgements)
 - [License](#license)
 
 ## Installation
 
-After installing the required dependencies, build the simulator by running `make` in the root directory. This will build the exe `local_qiskit_simulator` in the repository directory. For detailed OS specific instructions on installing dependencies see the following sections
+After installing the required dependencies, build the simulator by running `make` in the root directory. This will build the executable `local_qiskit_simulator` in the repository directory. For detailed OS-specific instructions on installing dependencies see the following sections
 
 ### Dependencies
 Building requires a compiler compatible with the C++14 standard. For example:
@@ -59,7 +59,7 @@ The simplest way to install is without full OpenMP parallelization. This only re
 > make
 ```
 
-To make full use of the parallelization requires OpenMP which requires installing GCC. This can be done by installing the [Homebrew](https://brew.sh/) package mananger:
+To make full use of the parallelization requires OpenMP which requires installing GCC. This can be done by installing the [Homebrew](https://brew.sh/) package manager:
 
 ```bash
 > /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -69,7 +69,7 @@ To make full use of the parallelization requires OpenMP which requires installin
 
 #### Installation on Ubuntu 16.04 LTS
 
-Check that the build-essential, BLAS and LAPACK backages are installed, then make the repository:
+Check that the build-essential, BLAS and LAPACK packages are installed, then make the repository:
 
 ```bash
 > sudo apt-get update
@@ -133,9 +133,9 @@ backend = 'local_qiskit_simulator'
 shots = <int>
 config = <dict>
 results = QuantumProgram.execute(circs,
-				backend=backend,
-				shots=shots,
-				config=config)
+                backend=backend,
+                shots=shots,
+                config=config)
 ```
 
 You can check the backend was successfully added using the `available_backends` method of the `QuantumProgram` class. If successful the returned list will include `local_qiskit_simulator` and `local_clifford_simulator`.
@@ -168,13 +168,13 @@ The `"data"` key is a list of the output of each circuit in the qobj: If the qob
 
 #### qiskit-sdk-py output
 
-If the simulator is called though the Python QISKit SDK the input qobj will only contain a single circuit, and only the values in the `"data"` field will be accessable in the `Results` object. The dictionary of this data may be accessed using the `Results.get_data('name')` method.
+If the simulator is called though the Python QISKit SDK the input qobj will only contain a single circuit, and only the values in the `"data"` field will be accessible in the `Results` object. The dictionary of this data may be accessed using the `Results.get_data('name')` method.
 
 #### Complex number format in JSON
 
-In the raw output file complex numbers are stored as a list of the real and imaginary parts. Eg. for *z = a +ib* the ouput of *z* willl be `[a, b]`. Using this convention complex vectors and matrices are stored as one would expect: as lists of complex numbers, and as lists of lists of complex numbers repectively.
+In the raw output file, complex numbers are stored as a list of the real and imaginary parts. Eg. for *z = a +ib* the output of *z* will be `[a, b]`. Using this convention complex vectors and matrices are stored as one would expect: as lists of complex numbers, and as lists of lists of complex numbers respectively.
 
-If the simulator is called through the the Python qiskit SDK then these are parsed into standard Python complex datatypes.
+If the simulator is called through the Python qiskit SDK then these are parsed into standard Python complex datatypes.
 
 
 #### Runtime errors
@@ -183,22 +183,22 @@ If the simulator encounters an error at runtime it will return the error message
 
 ```python
 {
-	"status": "FAILED",
-	"message": "error message"
+    "status": "FAILED",
+    "message": "error message"
 }
 ```
 
-If a qobj contains multiple circuits failure of one circuit will not terminate evaluation of the remaining circuits. In this case the output will appear as
+If a qobj contains multiple circuits failure of one circuit will not terminate evaluation of the remaining circuits. In this case, the output will appear as
 
 ```python
 {
-	"id": ...,
-	"config": ...,
-	"time_taken": ...,
-	"results": [
-		<circ-1 results>, <circ-2 results>, ...
-	]
-	"status": "DONE"
+    "id": ...,
+    "config": ...,
+    "time_taken": ...,
+    "results": [
+        <circ-1 results>, <circ-2 results>, ...
+    ]
+    "status": "DONE"
 }
 ```
 
@@ -207,41 +207,41 @@ where for any circuit that encounted an error `<circ-n result>` will be given by
 
 ## Config Settings
 
-The following table lists all recognized keys and allowed values for the config settings of the input qobj. Any of these options may be specified at the **qobj** config level, or at the individual **circuit** config level. In the later case any circuit level config settings will override the top level config settings.
+The following table lists all recognized keys and allowed values for the config settings of the input qobj. Any of these options may be specified at the **qobj** config level, or at the individual **circuit** config level. In the latter case, any circuit-level config settings will override the top level config settings.
 
 ##### Table of config options
 | Key | Allowed Values | Default | Description |
 | --- | --- | --- | --- |
 | `"shots"`| Integer > 0 | 1 | The number of simulation shots to be evaluated for a given circuit.
-| `"seed"` | Integer >= 0 |Random | The inital seed to be used for setting the random number generater used by the simulator. Simulator output should be deterministic of fixed `"seed"` and `"shots_threads"` values.
+| `"seed"` | Integer >= 0 |Random | The initial seed to be used for setting the random number generator used by the simulator. Simulator output should be deterministic of fixed `"seed"` and `"shots_threads"` values.
 | `"shots_threads"` | Integer >= 0 | 1 | Allows parallelization of the simulation by evaluating multiple shots simultaneously. Note that this will cause the simulator to use more memory.
 | `"data"` | List of strings | None | This control what output data is reported after the simulation. It is a list of string options which are specified in the Data table.
 | `"noise_params"` | dict | None | This is a dictionary of noise parameters for the simulation. The allowed noise parameters are specified in the Noise Parameters table.
 | `"initial_state"` | Quantum state | None | Allows the circuit to be initialized in a fixed initial state. See the appropriate section for details.
-|`"target_states"` | List of quantum states | None | Specifies a list of target quantum states for comparison wiht the final simulator state if the `"inner_products"` or `"overlaps"` `"data"` options are used. See the appropriate section for details.
+|`"target_states"` | List of quantum states | None | Specifies a list of target quantum states for comparison with the final simulator state if the `"inner_products"` or `"overlaps"` `"data"` options are used. See the appropriate section for details.
 | `"renorm_target_states"` | True | Bool |  This option renormalizes all states in the `"target_states`" list to be valid quantum states (with norm 1). If set to `False` the target states will be used as input without normalization.
 | `"chop"` | double >= 0 | 1e-10 | Any numerical quantities smaller than this value will be set to zero in the returned output data.  |
 | `"max_memory"` | int | 16 | Specifies the maximum memory the simulator should use for storing the state vector. This is used in determining the maximum number of qubits for simulation, and the number of shots to be evaluated in parallel. |
 | `"max_threads_shot"` | int | Number of CPU cores | This option may be used to limit the number of shot threads that can be evaluated in parallel. |
-| `"max_threads_gate"` | int | Number of CPU cores  / shots threads| This option may be used to limit the number of parallel threads that should be used in updating the state vector when performing the state vector update from quantum circuit operations.
+| `"max_threads_gate"` | int | Number of CPU cores/shots threads| This option may be used to limit the number of parallel threads that should be used in updating the state vector when performing the state vector update from quantum circuit operations.
 | `"threshold_omp_gate"` | int | 20 | This options specifies the qubit number threshold for enabling parallelization when performing the state vector update from quantum circuit operations.
 
 ### Maximum qubit number
 
 The maximum qubit number is determined by the `"max_memory"` config setting by using this value as an upper bound on ab estimate of the memory requirements for storing the state vector of an *N* qubit system. This limit is given by the largest *N* such that *16 \* 2<sup>N</sup> \* 10<sup>-9</sup> <* `"max_memory"`. These values are:
 
-| Qubits | Memory (GB)	| Qubits 	| Memory (GB) |
-| ---    | ---   		| --- 		| ---         |
-| 25     | 0.54  		| 31     	| 34.36       |
-| 26     | 1.07  		| 32      | 68.72       |
-| 27     | 2.15  	   	| 33     	| 137         |
-| 28     | 4.29  		| 34     	| 275         |
-| 29     | 8.59  		| 35     	| 550         |
-| 30     | 17.18 		| 36      | 1100
+| Qubits | Memory (GB)    | Qubits     | Memory (GB) |
+| ---    | ---           | ---         | ---         |
+| 25     | 0.54          | 31         | 34.36       |
+| 26     | 1.07          | 32      | 68.72       |
+| 27     | 2.15             | 33         | 137         |
+| 28     | 4.29          | 34         | 275         |
+| 29     | 8.59          | 35         | 550         |
+| 30     | 17.18         | 36      | 1100
 
 ### Using parallelization
 
-If compiled with OpenMP support the simulator can use parallelization for both the number of shots evaluated concurrently, and for using parallel threads to update the state vector when applying circuit operations. If OpenMP support is not available (for example if compiled using XCode clang on MacOS), then parallelization over shots is still available using the C++11 standard library.
+If compiled with OpenMP support the simulator can use parallelization for both the number of shots evaluated concurrently and for using parallel threads to update the state vector when applying circuit operations. If OpenMP support is not available (for example if compiled using XCode clang on MacOS), then parallelization over shots is still available using the C++11 standard library.
 
 There are two types of parallel speedups available:
 
@@ -250,21 +250,21 @@ There are two types of parallel speedups available:
 
 If M1 threads are used in parallel shot evaluation, and M2 threads are used in parallel gate updates, then the total number of threads used is M = M1 * M2.
 
-The total number of threads used is always limited by the available number of CPU cores on a system, and is additionally controlled by several other heuristics which will be discussed below. These may be restricted further using the following configuration options: `"max_memory"`, `"max_threads_shot"`, `"max_threads_gate"` `"theshold_omp_gate"`.
+The total number of threads used is always limited by the available number of CPU cores on a system and is additionally controlled by several other heuristics which will be discussed below. These may be restricted further using the following configuration options: `"max_memory"`, `"max_threads_shot"`, `"max_threads_gate"` `"theshold_omp_gate"`.
 
 #### Parallel evaluation of shots
 
-If multiple shots are being simulated parallel evaluation of shots takes precidence in the used of CPU threads. The total number of threads used is limited by the `"max_memory"` config option and the number of qubits in the circuit. For a given estimate of the memory requirements of a N-qubit state, a number of shot threads will be launched up to lower number of: the `"max_memory"` limit, the number of shots, the number of CPU cores, the "`max_threads_shot"` config setting.
+If multiple shots are being simulated parallel evaluation of shots takes precedence in the used of CPU threads. The total number of threads used is limited by the `"max_memory"` config option and the number of qubits in the circuit. For a given estimate of the memory requirements of a N-qubit state, a number of shot threads will be launched up to the lower number of: the `"max_memory"` limit, the number of shots, the number of CPU cores, the "`max_threads_shot"` config setting.
 
 #### Parallel state vector update
 
-The second type of parallelization is used to update lare N-qubit state vectors in parallel. This is only available if the simulator is compiled with **OpenMP** using the `-fopenmp` option. Parallelization is activated when the number of qubits in a circuit is greater than the number specified by `"theshold_omp_gate"`, and it uses any remaining threads *after* shot parallelization. Once above the threshold the number of threads used *per shot thread* is given by the minimium of: the number of CPU cores / number of shot threads (rounded down), the `"max_threads_gate"` config setting. The default threshold is 20 qubits. Lowering this may reduce performance due to the overhead of thread management on the shared state vector.
+The second type of parallelization is used to update large N-qubit state vectors in parallel. This is only available if the simulator is compiled with **OpenMP** using the `-fopenmp` option. Parallelization is activated when the number of qubits in a circuit is greater than the number specified by `"theshold_omp_gate"`, and it uses any remaining threads *after* shot parallelization. Once above the threshold the number of threads used *per shot thread* is given by the minimum of: the number of CPU cores/number of shot threads (rounded down), the `"max_threads_gate"` config setting. The default threshold is 20 qubits. Lowering this may reduce performance due to the overhead of thread management on the shared state vector.
 
 
 
 ### Using a custom initial state
 
-By defaul the simulator will always initalize with all qubits in the 0-state. A custom initial state for each shot of the simulator maybe be specified by using the config setting `"initial_state"`. This maybe be specified in the QOBJ as a vector or in a Bra-Ket style notaiton. If the initial state is the wrong dimension for the circuit being evaluated then the simulation will fail and return an error message.
+By default, the simulator will always be initialized with all qubits in the 0-state. A custom initial state for each shot of the simulator may be specified by using the config setting `"initial_state"`. This maybe be specified in the QOBJ as a vector or in a Bra-Ket style notation. If the initial state is the wrong dimension for the circuit being evaluated then the simulation will fail and return an error message.
 
 
 ##### Qobj Example
@@ -294,18 +294,18 @@ config = {'initial_state': np.array([1, 0, 0, 1j]) / np.sqrt(2)}
 | `"classical_state"` | Returns a list of the final classical register bitstring after each shot.
 | `"quantum_state"`| Returns a list of the final quantum state vector of the system after each shot.
 | `"quantum_state_ket"`| As above but with the states represented in ket form.
-| `"density_matrix"`| Returns the final quantum state density matrix obtained from averaging the final state vector over all shots.
+| `"density_matrix"`| Returns the final quantum state density matrix obtained from averaging the final state vector overall shots.
 | `"probabilities"` | Returns the diagonal of the final state density matrix.
 | `"probabilities_ket"` | As above but with the probabilities represented in ket form.
 | `"target_states_inner"` | Returns a list of the inner products of the final quantum state with the list of target states for each shot. The target states are specified by `"target_states"` config option.
-| `"target_states_probs"` | Returns the expecation value of the final quantum state with the list of target states averaged over all shots. The target states are specified by `"target_states"` config option.
+| `"target_states_probs"` | Returns the expectation value of the final quantum state with the list of target states averaged over all shots. The target states are specified by `"target_states"` config option.
 | `"saved_quantum_states"` | Returns a list of dictionaries of any saved quantum states for each shot. The state of the system can be saved by the custom `save(n)` gate. the integer `n` will be the key for accessing the saved state in the returned dictionary.
 | `"saved_quantum_states_ket"` | As above but with the states represented in ket form.
 | `"saved_density_matrix"` | Returns a dictionary of the saved quantum state density matrix obtained by averaging the saved state vector over all shots.
 | `"saved_probabilities"` | As above but only returns the diagonal of the density matrix.
 | `"probabilities_ket"` | As above but with the probabilities represented in ket form.
 | `"saved_target_states_inner"` | Returns a list of the inner products of the saved quantum states with the list of target states for each shot. The target states are specified by `"target_states"` config option.
-| `"saved_target_states_probs"` | Returns the expecation value of the saved quantum states with the list of target states averaged over all shots. The target states are specified by `"target_states"` config option.
+| `"saved_target_states_probs"` | Returns the expectation value of the saved quantum states with the list of target states averaged over all shots. The target states are specified by `"target_states"` config option.
 
 
 ## Noise Parameters
@@ -314,7 +314,7 @@ We now describe the noise model parameters used by the simulator
 
 ### Gate Errors
 
-Gate errors are specified by the error name, and a dictionary of error parameters. Gate names are
+Gate errors are specified by the error name and a dictionary of error parameters. Gate names are
 
 | Name | Operations Affected |
 | --- | --- |
@@ -325,9 +325,9 @@ Gate errors are specified by the error name, and a dictionary of error parameter
 | `"U"` | `U, u0, u1, u2, u3, x, y, z, h, s, sdg, t, tdg` |
 | `"X90"` | `U, u0, u1, u2, u3, x, y, z, h, s, sdg, t, tdg` |
 
-Note that `"U"` and `"X90"` implement different error models. `"U"` specifies a single qubit error model for all single qubit gates, while `"X90"` specifies an error model for 90-degree X rotation pulses, and single qubit gates are implemented in terms of noisy X-90 pulses and ideal Z-rotations. If both `"U"` and `"X90"` are set, then `"U"` will *only* effect `U` operations, while `"X90"` will effect all other operations (`u0, u1, u2, u3, x, y, z, h, s, sdg, t, tdg`).
+Note that `"U"` and `"X90"` implement different error models. `"U"` specifies a single qubit error model for all single qubit gates, while `"X90"` specifies an error model for 90-degree X rotation pulses, and single qubit gates are implemented in terms of noisy X-90 pulses and ideal Z-rotations. If both `"U"` and `"X90"` are set, then `"U"` will *only* effect `U` operations, while `"X90"` will affect all other operations (`u0, u1, u2, u3, x, y, z, h, s, sdg, t, tdg`).
 
-In terms of X90 pulses single qubit gates are effected as:
+In terms of X90 pulses single qubit gates are affected as:
 
 - `u1, z, s, sdg, t, tdg` have no error (zero X-90 pulses)
 - `u2, h`: have single gate error (one X-90 pulse)
@@ -350,13 +350,13 @@ A single qubit gate error with gate time of *1* unit, depolarizing probability *
 
 ```python
 "U": {
-	"p_depol": 0.001,
-	"p_pauli": [0.99, 0, 0, 0.01],
-	"gate_time": 1,
-	"U_error": [
-		[[1, 0], [0, 0]],
-		[[0, 0], [0.995004165, 0.099833417]]
-	]
+    "p_depol": 0.001,
+    "p_pauli": [0.99, 0, 0, 0.01],
+    "gate_time": 1,
+    "U_error": [
+        [[1, 0], [0, 0]],
+        [[0, 0], [0.995004165, 0.099833417]]
+    ]
 }
 ```
 
@@ -364,7 +364,7 @@ A single qubit gate error with gate time of *1* unit, depolarizing probability *
 
 ##### X90 Gate
 
-A coherent error model for X-90 rotations due to pulse amplitude and a phase-offset errors may be implemented directly with the following keywords:
+A coherent error model for X-90 rotations due to calibration errors in the control pulse amplitude, and detuning errors in the control pulse frequency may be implemented directly with the following keywords:
 
 ```python
 "calibration_error": alpha,
@@ -375,7 +375,7 @@ In this case the ideal X-90 rotation will be implemented as the unitary $$U_{X90
 
 ##### CX Gate
 
-A coherent error model for a CX gate implemented via a cross-resonance interaction with a pulse amplitude error, and a ZZ-interaction error may be implemented directly with the following keywords:
+A coherent error model for a CX gate implemented via a cross-resonance interaction with a the control pulse amplitude calibration error, and a ZZ-interaction error may be implemented directly with the following keywords:
 
 ```python
 "calibration_error": beta,
@@ -391,10 +391,10 @@ If a `"U_error"` keyword is specified this additional coherent error will then b
 
 ```python
 "relaxation_rate": r
-"thermal_populations": p0
+"thermal_populations": [p0, p1]
 ```
 
-Specifies the parameters for the *T<sub>1</sub>* relaxation error of a system (with *T<sub>2</sub>=T<sub>1</sub>*). The probability of a relaxation error for a get of length *t* is given by $p_{err} = 1-exp(-t r) $. If a relaxation error occurs the system be reset to the 0 or 1 state with probability *p0* and *1-p0* respectively.
+Specifies the parameters for the *T<sub>1</sub>* relaxation error of a system (with *T<sub>2</sub>=T<sub>1</sub>*). The probability of a relaxation error for a get of length *t* is given by $p_{err} = 1-exp(-t r) $. If a relaxation error occurs the system be reset to the 0 or 1 state with probability *p0* and *p1 = 1-p0* respectively.
 
 Note that for single qubit gates the relaxation error occurs the noisy (or ideal) gate is not applied to the state.
 
@@ -411,7 +411,7 @@ When a qubit is reset it be set to the 0 or 1 states with probabilities *1-p* an
 
 ### Measurement Readout Error
 
-This error models incorrectly assigning the value of a classical bit after a measurement. It does not effect the quantum state of the system at all, only the classical registers. If used in combination with the `"measure"` gate error, the gate error is applied first, and then teh readout error is applied to measurement of the resulting quantum state.
+This error models incorrectly assigning the value of a classical bit after a measurement. It does not affect the quantum state of the system at all, only the classical registers. If used in combination with the `"measure"` gate error, the gate error is applied first, and then the readout error is applied to the measurement of the resulting quantum state.
 
 
 ```python
@@ -424,8 +424,8 @@ This error models incorrectly assigning the value of a classical bit after a mea
 "readout_error": [m0, m1]
 ```
 
-- If a system is measured to be in the 0 state, the correct (0) and incorrect (1) outcome will be recorded with probability *1-m0* and *m0* respecitvely.
-- If the system is measured to be in the 1 state the correct (1) and incorrect (0) outcome will be recorded with probability *1-m1* and *m1* repectively.
+- If a system is measured to be in the 0 state, the correct (0) and incorrect (1) outcome will be recorded with probability *1-m0* and *m0* respectively.
+- If the system is measured to be in the 1 state the correct (1) and incorrect (0) outcome will be recorded with probability *1-m1* and *m1* respectively.
 
 ## Full Config Specification
 
@@ -433,74 +433,74 @@ An example of a configuration file for a 2-qubit circuit using all options is gi
 
 ```python
 "config": {
-	"shots": 4,
-	"seed": 0,
-	"shots_threads": 4,[]()
-	"data": [
-		"classical_state",
-		"quantum_state",
-		"quantum_state_probs",
-		"target_states_inner",
-		"target_states_probs",
-		"saved_quantum_states"
-	],
-	"initial_state": [1, 0, 0, 1],
-	"target_states": [
-		[1, 0, 0, 1],
-		[1, 0, 0, -1]
-		[[1, 0], [0, 0], [0, 0], [0, 1]],
-		[[1, 0], [0, 0], [0, 0], [0, -1]]
-	],
-	"renom_target_states: True,
-	"chop": 1e-10,
-	"noise_params": {
-		"reset_error": p_reset,
-		"readout_error: [p_m0, p_m1],
-		"relaxation_rate": r,
-		"thermal_populations": [p0, p1],
-		"measure": {
-			"p_depol": p_meas,
-			"p_pauli": [pI_meas, pX_meas, pY_meas, pZ_meas],
-			"gate_time": t_meas,
-			"U_error": matrix_meas
-		},
-		"measure": {
-			"p_depol": p_res,
-			"p_pauli": [pI_res, pX_res, pY_res, pZ_res],
-			"gate_time": t_res,
-			"U_error": matrix_res
-		},
-		"id": {
-			"p_depol": p_id,
-			"p_pauli": [pI_id, pX_id, pY_id, pZ_id],
-			"gate_time": t_id,
-			"U_error": matrix_id
-		},
-		"U": {
-			"p_depol": p_u,
-			"p_pauli": [pI_u, pX_u, pY_u, pZ_u],
-			"gate_time": t_u,
-			"U_error": matrix_u
-		},
-		"X90": {
-			"p_depol": p_x90,
-			"p_pauli": [pI_x90, pX_x90, pY_x90, pZ_x90],
-			"gate_time": t_X90,
-			"U_error": matrix_x90,
-			"amp_error": alpha,
-			"phase_error": omega
-		},
-		"CX": {
-			"p_depol": p_cx,
-			"p_pauli": [pII_cx, pIX_cx, pIY_cx, pIZ_cx,
-						pXI_cx, pXX_cx, pXY_cx, pXZ_cx,
-						pYI_cx, pYX_cx, pYY_cx, pYZ_cx,
-						pZI_cx, pZX_cx, pZY_cx, pZZ_cx],
-			"gate_time": t_cx,
-			"U_error": matrix_cx,
-			"amp_error": alpha,
-			"zz_error": gamma
-	}
+    "shots": 4,
+    "seed": 0,
+    "shots_threads": 4,[]()
+    "data": [
+        "classical_state",
+        "quantum_state",
+        "quantum_state_probs",
+        "target_states_inner",
+        "target_states_probs",
+        "saved_quantum_states"
+    ],
+    "initial_state": [1, 0, 0, 1],
+    "target_states": [
+        [1, 0, 0, 1],
+        [1, 0, 0, -1]
+        [[1, 0], [0, 0], [0, 0], [0, 1]],
+        [[1, 0], [0, 0], [0, 0], [0, -1]]
+    ],
+    "renom_target_states: True,
+    "chop": 1e-10,
+    "noise_params": {
+        "reset_error": p_reset,
+        "readout_error: [p_m0, p_m1],
+        "relaxation_rate": r,
+        "thermal_populations": [p0, p1],
+        "measure": {
+            "p_depol": p_meas,
+            "p_pauli": [pI_meas, pX_meas, pY_meas, pZ_meas],
+            "gate_time": t_meas,
+            "U_error": matrix_meas
+        },
+        "measure": {
+            "p_depol": p_res,
+            "p_pauli": [pI_res, pX_res, pY_res, pZ_res],
+            "gate_time": t_res,
+            "U_error": matrix_res
+        },
+        "id": {
+            "p_depol": p_id,
+            "p_pauli": [pI_id, pX_id, pY_id, pZ_id],
+            "gate_time": t_id,
+            "U_error": matrix_id
+        },
+        "U": {
+            "p_depol": p_u,
+            "p_pauli": [pI_u, pX_u, pY_u, pZ_u],
+            "gate_time": t_u,
+            "U_error": matrix_u
+        },
+        "X90": {
+            "p_depol": p_x90,
+            "p_pauli": [pI_x90, pX_x90, pY_x90, pZ_x90],
+            "gate_time": t_X90,
+            "U_error": matrix_x90,
+            "amp_error": alpha,
+            "phase_error": omega
+        },
+        "CX": {
+            "p_depol": p_cx,
+            "p_pauli": [pII_cx, pIX_cx, pIY_cx, pIZ_cx,
+                        pXI_cx, pXX_cx, pXY_cx, pXZ_cx,
+                        pYI_cx, pYX_cx, pYY_cx, pYZ_cx,
+                        pZI_cx, pZX_cx, pZY_cx, pZZ_cx],
+            "gate_time": t_cx,
+            "U_error": matrix_cx,
+            "amp_error": alpha,
+            "zz_error": gamma
+    }
 }
 ```
 

--- a/src/cpp-simulator/README.md
+++ b/src/cpp-simulator/README.md
@@ -390,7 +390,7 @@ If a `"U_error"` keyword is specified this additional coherent error will then b
 ### Thermal Relaxation Error
 
 ```python
-"relaxation_rates": r
+"relaxation_rate": r
 "thermal_populations": p0
 ```
 

--- a/src/cpp-simulator/src/backends/ideal_backend.hpp
+++ b/src/cpp-simulator/src/backends/ideal_backend.hpp
@@ -688,8 +688,8 @@ void IdealBackend::qc_measure_reset(const uint_t qubit,
           for (uint_t k2 = 0; k2 < end2; k2++) {
             const auto i0 = k1 | k2;
             const auto i1 = i0 | end2;
-            qreg[i0] = renorm * qreg[i1];
-            qreg[i1] = 0;
+            qreg[i1] = renorm * qreg[i0];
+            qreg[i0] = 0;
           }
       }
     } else { // Measurement outcome was 0

--- a/src/cpp-simulator/src/backends/noise_models.hpp
+++ b/src/cpp-simulator/src/backends/noise_models.hpp
@@ -650,10 +650,11 @@ inline void from_json(const json_t &js, QubitNoise &noise) {
           g = load_gate_error(n, 1, js);
 
         // Check for special gate params
-        if (n == "x90") {
+        if (n == "X90") {
           double theta = 0., omega = 0.;
           const json_t &jsg = js[n];
-          JSON::get_value(theta, "amp_error", jsg);
+          JSON::get_value(theta, "amp_error", jsg); // legacy key (use calibration_error)
+          JSON::get_value(theta, "calibration_error", jsg);
           JSON::get_value(omega, "detuning_error", jsg);
 
           if (theta > 0. || theta < 0. || omega > 0. || omega < 0.) {
@@ -693,7 +694,8 @@ inline void from_json(const json_t &js, QubitNoise &noise) {
 
           double theta = 0., omega = 0.;
           const json_t &jsg = js[n];
-          JSON::get_value(theta, "amp_error", jsg);
+          JSON::get_value(theta, "amp_error", jsg); // legacy key (use calibration_error)
+          JSON::get_value(theta, "calibration_error", jsg);
           JSON::get_value(omega, "zz_error", jsg);
 
           if (theta > 0. || theta < 0. || omega > 0. || omega < 0.) {
@@ -709,7 +711,7 @@ inline void from_json(const json_t &js, QubitNoise &noise) {
 
             // CR gate noise
             double b = sqrt(1. + omega * omega);
-            double a = b * (M_PI / 4. + theta);
+            double a = 0.5 * b * (M_PI / 2. + theta);
             double c = 1. / (sqrt(2.) * b);
             U_CNOT_noise(0, 0) = c * (b * cos(a) + sin(a));
             U_CNOT_noise(1, 3) = U_CNOT_noise(0, 0);

--- a/src/cpp-simulator/src/utilities/types.hpp
+++ b/src/cpp-simulator/src/utilities/types.hpp
@@ -161,7 +161,7 @@ public:
    * Eg: qs_srt = {0, 1, 2}
    */
   template <size_t N>
-  uint_t index0(const std::array<uint_t, N> qs_srt, const uint_t k) const;
+  uint_t index0(const std::array<uint_t, N> &qs_srt, const uint_t k) const;
 
   /**
    * This function does not require the qubits to be sorted, but takes as input
@@ -169,16 +169,16 @@ public:
    * specified by qs.
    */
   template <size_t N>
-  std::array<uint_t, 1ULL << N> indexes(const std::array<uint_t, N> qs,
-                                        const std::array<uint_t, N> qs_srt,
+  std::array<uint_t, 1ULL << N> indexes(const std::array<uint_t, N> &qs,
+                                        const std::array<uint_t, N> &qs_srt,
                                         const uint_t k) const;
 
-  std::array<uint_t, 4> indexes(const std::array<uint_t, 2> qs,
-                                const std::array<uint_t, 2> qs_srt,
+  std::array<uint_t, 4> indexes(const std::array<uint_t, 2> &qs,
+                                const std::array<uint_t, 2> &qs_srt,
                                 const uint_t k) const;
 
-  std::array<uint_t, 2> indexes(const std::array<uint_t, 1> qs,
-                                const std::array<uint_t, 1> qs_srt,
+  std::array<uint_t, 2> indexes(const std::array<uint_t, 1> &qs,
+                                const std::array<uint_t, 1> &qs_srt,
                                 const uint_t k) const;
 };
 
@@ -326,7 +326,7 @@ void from_json(const json_t &js, Clifford &clif);
 //------------------------------------------------------------------------------
 
 template <size_t N>
-uint_t MultiPartiteIndex::index0(const std::array<uint_t, N> qs_srt,
+uint_t MultiPartiteIndex::index0(const std::array<uint_t, N> &qs_srt,
                                  const uint_t k) const {
   uint_t lowbits = 0, mask = 0;
   for (size_t j = 0; j < N; j++) {
@@ -341,8 +341,8 @@ uint_t MultiPartiteIndex::index0(const std::array<uint_t, N> qs_srt,
 
 template <size_t N>
 std::array<uint_t, 1ULL << N>
-MultiPartiteIndex::indexes(const std::array<uint_t, N> qs,
-                           const std::array<uint_t, N> qs_srt,
+MultiPartiteIndex::indexes(const std::array<uint_t, N> &qs,
+                           const std::array<uint_t, N> &qs_srt,
                            const uint_t k) const {
   std::array<uint_t, 1ULL << N> ret;
   ret[0] = index0<N>(qs_srt, k);
@@ -356,8 +356,8 @@ MultiPartiteIndex::indexes(const std::array<uint_t, N> qs,
 }
 
 std::array<uint_t, 2>
-MultiPartiteIndex::indexes(const std::array<uint_t, 1> qs,
-                           const std::array<uint_t, 1> qs_srt,
+MultiPartiteIndex::indexes(const std::array<uint_t, 1> &qs,
+                           const std::array<uint_t, 1> &qs_srt,
                            const uint_t k) const {
   std::array<uint_t, 2> ret;
   ret[0] = index0(qs_srt, k);
@@ -366,8 +366,8 @@ MultiPartiteIndex::indexes(const std::array<uint_t, 1> qs,
 }
 
 std::array<uint_t, 4>
-MultiPartiteIndex::indexes(const std::array<uint_t, 2> qs,
-                           const std::array<uint_t, 2> qs_srt,
+MultiPartiteIndex::indexes(const std::array<uint_t, 2> &qs,
+                           const std::array<uint_t, 2> &qs_srt,
                            const uint_t k) const {
   std::array<uint_t, 4> ret;
   ret[0] = index0(qs_srt, k);

--- a/src/cpp-simulator/test/inputs/reset_error.json
+++ b/src/cpp-simulator/test/inputs/reset_error.json
@@ -1,0 +1,72 @@
+{
+  "id": "test_reset_error",
+  "config": {
+    "shots": 100,
+    "seed": 1,
+    "data": ["probabilities"]
+  },
+  "circuits": [
+    {
+      "name": "reset_in0_out0",
+      "config": {"noise_params": {"reset_error": [1, 0]}},
+      "compiled_circuit": {
+        "header": {
+          "clbit_labels": [],
+          "number_of_clbits": 0,
+          "number_of_qubits": 1,
+          "qubit_labels": [["q", 0]]
+        },
+        "operations": [
+          {"name": "reset", "qubits": [0]}
+        ]
+      }
+    },
+    {
+      "name": "reset_in1_out0",
+      "config": {"noise_params": {"reset_error": [1, 0]}},
+      "compiled_circuit": {
+        "header": {
+          "clbit_labels": [],
+          "number_of_clbits": 0,
+          "number_of_qubits": 1,
+          "qubit_labels": [["q", 0]]
+        },
+        "operations": [
+          {"name": "x", "qubits": [0]},
+          {"name": "reset", "qubits": [0]}
+        ]
+      }
+    },
+    {
+      "name": "reset_in0_out1",
+      "config": {"noise_params": {"reset_error": [0, 1]}},
+      "compiled_circuit": {
+        "header": {
+          "clbit_labels": [],
+          "number_of_clbits": 0,
+          "number_of_qubits": 1,
+          "qubit_labels": [["q", 0]]
+        },
+        "operations": [
+          {"name": "reset", "qubits": [0]}
+        ]
+      }
+    },
+    {
+      "name": "reset_in1_out1",
+      "config": {"noise_params": {"reset_error": [0, 1]}},
+      "compiled_circuit": {
+        "header": {
+          "clbit_labels": [],
+          "number_of_clbits": 0,
+          "number_of_qubits": 1,
+          "qubit_labels": [["q", 0]]
+        },
+        "operations": [
+          {"name": "x", "qubits": [0]},
+          {"name": "reset", "qubits": [0]}
+        ]
+      }
+    }
+  ]
+}

--- a/src/cpp-simulator/test/refs/reset_error.ref
+++ b/src/cpp-simulator/test/refs/reset_error.ref
@@ -1,0 +1,61 @@
+{
+    "backend": "local_qiskit_simulator",
+    "id": "test_reset_error",
+    "result": [{
+            "data": {
+                "probabilities": [1.0, 0.0],
+                "time_taken": 0.000582
+            },
+            "name": "reset_in0_out0",
+            "noise_params": null,
+            "seed": 1,
+            "shots": 100,
+            "status": "DONE",
+            "success": true,
+            "threads_shot": 4
+        }, {
+            "data": {
+                "probabilities": [1.0, 0.0],
+                "time_taken": 0.000255
+            },
+            "name": "reset_in1_out0",
+            "noise_params": null,
+            "seed": 1,
+            "shots": 100,
+            "status": "DONE",
+            "success": true,
+            "threads_shot": 4
+        }, {
+            "data": {
+                "probabilities": [0.0, 1.0],
+                "time_taken": 0.000231
+            },
+            "name": "reset_in0_out1",
+            "noise_params": {
+                "reset_error": [0.0, 1.0]
+            },
+            "seed": 1,
+            "shots": 100,
+            "status": "DONE",
+            "success": true,
+            "threads_shot": 4
+        }, {
+            "data": {
+                "probabilities": [0.0, 1.0],
+                "time_taken": 0.000306
+            },
+            "name": "reset_in1_out1",
+            "noise_params": {
+                "reset_error": [0.0, 1.0]
+            },
+            "seed": 1,
+            "shots": 100,
+            "status": "DONE",
+            "success": true,
+            "threads_shot": 4
+        }],
+    "simulator": "qubit",
+    "status": "COMPLETED",
+    "success": true,
+    "time_taken": 0.00142
+}


### PR DESCRIPTION
## Description

- Fixes several bugs with noise implementations in the simulator.
- Changes some naming conventions for `"amp_error"` noise parameters to `"calibration_error"`
- Fixes many spelling mistakes in simulator README.

### Bug fixes:

1. Fixed bug with reset operation in noise simulator. This effected both the `"reset_error"` noise parameter, and the `"thermal_populations"` parameter for relaxation errors (which are implemented via a reset). Previously during a reset operation, if a qubit was initially in a zero state and then a reset error to occur to reset to the 1 state the renormalization was applied backwards zeroing the state vector. This has been fixed to correctly reset the state. A test `reset_error.json` has been added to the test folder to check the four canonical reset error cases (initially in 0 reset to 0, initially in 1 reset to 0, initially in 0 reset to 1, initially in 1 reset to 1).
2. Added parsing of the `"U_error"` matrix in simulator output into python. Previously this was left as a JSON representation of a complex matrix. This fixes it to be parsed into a complex numpy ndarray as originally intended.
3. Fixed bug with shorthand noise parameter keys for X90 coherent errors (`"amp_error"`, `"detuning_error"`) not being parsed. 
4. Fixed typos in README which incorrectly called the `"detuning_error"` parameter a `"phase_error"`, and incorrectly called the `"relaxation_rate"` parameter `"relaxation_rates`".

### Other changes

1. Renamed `"amp_error"` noise parameter keys for X90 and CX gates to "`calibration_error"`. This is because these errors typically result in incorrect calibration of a gate pulse, and also to avoid confusion of this parameter and  an amplitude damping channel error. Legacy support for the old keys is left in so that "`amp_error`" will still be parsed as a calibration error. This should be phased out though.
2. The `“calibration_error”`/`“amp_error”` parameter for the CX gate was changed to twice its
previous value for consistency with literature. This now means it corresponds to a rotation generated by the Hamiltonian: 
`H = ( pi / 2 + err) (ZX / 2)` rather than 
`H = (pi / 4 + err) ZX` as it was before.
3. Changed source code index functions to pass qubits by reference instead of by value.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.