### PR TITLE
Fix display of code-blocks on .rst pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Q_program.set_api(Qconfig.APItoken, Qconfig.config["url"], verify=False,
 ```
 
 For more details on this and more information see
-[our QISKit documentation](doc/qiskit.rst).
+[our QISKit documentation](https://www.qiskit.org/documentation/).
 
 
 ### Next Steps

--- a/doc/example_real_backend.rst
+++ b/doc/example_real_backend.rst
@@ -5,7 +5,6 @@ The following code is an example of how to execute a Quantum Program on a real
 Quantum device:
 
 .. code-block:: python
-    :linenos:
 
     from qiskit import QuantumProgram
     
@@ -53,7 +52,6 @@ executing the same example as described on the previous section, but using
 the IBM Q features:
 
 .. code-block:: python
-    :linenos:
 
     from qiskit import QuantumProgram
 
@@ -116,7 +114,6 @@ The parameters can be specified to ``QuantumProgram.compile()`` and
 ``QuantumProgram.execute()`` via the ``hpc`` parameter. For example:
 
 .. code-block:: python
-    :linenos:
 
     QP_program.compile(circuits,
                        backend=backend,

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -23,7 +23,7 @@ should install Git too: https://git-scm.com/download/.
 
 
 2. Installation
---------------
+---------------
 
 Option A: Installing via PIP
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/ja/example_real_backend.rst
+++ b/doc/ja/example_real_backend.rst
@@ -2,7 +2,6 @@
 ^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
-    :linenos:
 
     from qiskit import QuantumProgram
 

--- a/doc/ja/quickstart.rst
+++ b/doc/ja/quickstart.rst
@@ -10,7 +10,6 @@ QuantumProgramのメソッドは量子回路を実機やシミュレーターの
 シミュレーター上で量子回路を設計して実行するには、以下のようにします。
 
 .. code-block:: python
-   :linenos:
 
    from qiskit import QuantumProgram
    qp = QuantumProgram()

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -13,7 +13,6 @@ To compose and run a circuit on a simulator, which is distributed with
 this project, one can do,
 
 .. code-block:: python
-   :linenos:
 
    from qiskit import QuantumProgram
    qp = QuantumProgram()


### PR DESCRIPTION
Remove the "linenos" sphinx directive, in order to allow some code blocks (in particular the examples) when browsing the .rst files from the GitHub interface. Point the documentation link on the README to the landing page docs.

Thanks to David Bowen for pointing it out.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.