### PR TITLE
updated state_fidelity convention

### DIFF
--- a/qiskit/tools/qi/qi.py
+++ b/qiskit/tools/qi/qi.py
@@ -447,7 +447,11 @@ def funm_svd(a, func):
 def state_fidelity(state1, state2):
     """Return the state fidelity between two quantum states.
 
-    Either input may be a state vector, or a density matrix.
+    Either input may be a state vector, or a density matrix. The state
+    fidelity (F) for two density matrices is defined as:
+        F(rho1, rho2) = Tr[sqrt(sqrt(rho1).rho2.sqrt(rho1))] ^ 2
+    For two pure states the fidelity is given by
+        F(|psi1>, |psi2>) = |<psi1|psi2>|^2
 
     Args:
         state1 (array_like): a quantum state vector or density matrix.
@@ -462,18 +466,18 @@ def state_fidelity(state1, state2):
 
     # fidelity of two state vectors
     if s1.ndim == 1 and s2.ndim == 1:
-        return np.abs(s2.conj().dot(s1))
+        return np.abs(s2.conj().dot(s1)) ** 2
     # fidelity of vector and density matrix
     elif s1.ndim == 1:
         # psi = s1, rho = s2
-        return np.sqrt(np.abs(s1.conj().dot(s2).dot(s1)))
+        return np.abs(s1.conj().dot(s2).dot(s1))
     elif s2.ndim == 1:
         # psi = s2, rho = s1
-        return np.sqrt(np.abs(s2.conj().dot(s1).dot(s2)))
+        return np.abs(s2.conj().dot(s1).dot(s2))
     # fidelity of two density matrices
     s1sq = funm_svd(s1, np.sqrt)
     s2sq = funm_svd(s2, np.sqrt)
-    return np.linalg.norm(s1sq.dot(s2sq), ord='nuc')
+    return np.linalg.norm(s1sq.dot(s2sq), ord='nuc') ** 2
 
 
 def purity(state):

--- a/test/python/test_qi.py
+++ b/test/python/test_qi.py
@@ -101,16 +101,24 @@ class TestQI(QiskitTestCase):
         rho1 = [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]]
         mix = [[0.25, 0, 0, 0], [0, 0.25, 0, 0],
                [0, 0, 0.25, 0], [0, 0, 0, 0.25]]
-        test_pass = (round(state_fidelity(psi1, psi1), 7) == 1.0 and
-                     round(state_fidelity(psi1, psi2), 8) == 0.0 and
-                     round(state_fidelity(psi1, rho1), 8) == 1.0 and
-                     round(state_fidelity(psi1, mix), 8) == 0.5 and
-                     round(state_fidelity(psi2, rho1), 8) == 0.0 and
-                     round(state_fidelity(psi2, mix), 8) == 0.5 and
-                     round(state_fidelity(rho1, rho1), 8) == 1.0 and
-                     round(state_fidelity(rho1, mix), 8) == 0.5 and
-                     round(state_fidelity(mix, mix), 8) == 1.0)
-        self.assertTrue(test_pass)
+        self.assertAlmostEqual(state_fidelity(psi1, psi1), 1.0, places=7,
+                               msg='vector-vector input')
+        self.assertAlmostEqual(state_fidelity(psi1, psi2), 0.0, places=7,
+                               msg='vector-vector input')
+        self.assertAlmostEqual(state_fidelity(psi1, rho1), 1.0, places=7,
+                               msg='vector-matrix input')
+        self.assertAlmostEqual(state_fidelity(psi1, mix), 0.25, places=7,
+                               msg='vector-matrix input')
+        self.assertAlmostEqual(state_fidelity(psi2, rho1), 0.0, places=7,
+                               msg='vector-matrix input')
+        self.assertAlmostEqual(state_fidelity(psi2, mix), 0.25, places=7,
+                               msg='vector-matrix input')
+        self.assertAlmostEqual(state_fidelity(rho1, psi1), 1.0, places=7,
+                               msg='matrix-vector input')
+        self.assertAlmostEqual(state_fidelity(rho1, rho1), 1.0, places=7,
+                               msg='matrix-matrix input')
+        self.assertAlmostEqual(state_fidelity(mix, mix), 1.0, places=7,
+                               msg='matrix-matrix input')
 
     def test_purity(self):
         rho1 = [[1, 0], [0, 0]]

--- a/test/python/test_tomography.py
+++ b/test/python/test_tomography.py
@@ -121,8 +121,8 @@ class TestTomography(QiskitTestCase):
 
 def _tomography_test_data(qp, name, qr, cr, tomoset, shots):
     tomo.create_tomography_circuits(qp, name, qr, cr, tomoset)
-    result = qp.execute(
-        tomo.tomography_circuit_names(tomoset, name), shots=shots, seed=42)
+    result = qp.execute(tomo.tomography_circuit_names(tomoset, name),
+                        shots=shots, seed=42, timeout=180)
     data = tomo.tomography_data(result, name, tomoset)
     return tomo.fit_tomography_data(data)
 


### PR DESCRIPTION
Change the definition of `state_fidelity` to be consistent with IBM quantum group research papers. #278 

## Description

The new definition is that:
- Pure states: F(|a>, |b>) = |<a|b>|^2.
- Mixed states: F(rho1, rho2) = Tr[sqrt(sqrt(rho1).rho2.sqrt(rho1))] ^ 2

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.