### PR TITLE
Fix static linking of the C++ Simulator

### DIFF
--- a/cmake/defaults.cmake
+++ b/cmake/defaults.cmake
@@ -2,3 +2,8 @@
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release")
 endif()
+
+# Static linking is the default
+if(NOT STATIC_LINKING)
+	set(STATIC_LINKING True CACHE BOOL "Static linking of executables")
+endif()

--- a/cmake/defaults.cmake
+++ b/cmake/defaults.cmake
@@ -1,9 +1,7 @@
+# Default values for global scope variables.
+# They can be overriden by passing -DVARIABLE=Value to cmake, like:
+#     out$ cmake -DSTATIC_LINKING=False ..
+#
 
-if(NOT CMAKE_BUILD_TYPE)
-	set(CMAKE_BUILD_TYPE "Release")
-endif()
-
-# Static linking is the default
-if(NOT STATIC_LINKING)
-	set(STATIC_LINKING True CACHE BOOL "Static linking of executables")
-endif()
+set(CMAKE_BUILD_TYPE "Release")
+set(STATIC_LINKING True CACHE BOOL "Static linking of executables")

--- a/cmake/python-build.cmake
+++ b/cmake/python-build.cmake
@@ -43,7 +43,7 @@ function(add_pypi_package_target TARGET_NAME PACKAGE_TYPE)
 
 	# For source distributions, we don't want any binary in the final package
 	if(PIP_PACKAGE_SOURCE_DIST)
-		set(TARGET_NAME_SDIST ${TARGET_NAME}_SDIST)
+		set(TARGET_NAME_SDIST ${TARGET_NAME}_sdist)
 		add_custom_target(${TARGET_NAME_SDIST})
 		add_custom_command(TARGET ${TARGET_NAME_SDIST}
 			COMMAND ${PYTHON} ${SETUP_PY} ${PIP_PACKAGE_SOURCE_DIST}
@@ -51,7 +51,7 @@ function(add_pypi_package_target TARGET_NAME PACKAGE_TYPE)
 	endif()
 
 	if(PIP_PACKAGE_PLATFORM_WHEELS)
-		set(COPY_QISKIT_SIM_TARGET ${TARGET_NAME}_COPY_QISKIT_SIMULATOR)
+		set(COPY_QISKIT_SIM_TARGET ${TARGET_NAME}_copy_qiskit_simulator)
 		# We create a target which will depend on TARGET_NAME_WHEELS for
 		# copying all the binaries to their final locations
 		add_custom_target(${COPY_QISKIT_SIM_TARGET})
@@ -78,7 +78,7 @@ function(add_pypi_package_target TARGET_NAME PACKAGE_TYPE)
 			endforeach()
 		endif()
 
-		set(TARGET_NAME_WHEELS ${TARGET_NAME}_WHEELS)
+		set(TARGET_NAME_WHEELS ${TARGET_NAME}_wheels)
 		add_custom_target(${TARGET_NAME_WHEELS})
 		add_custom_command(TARGET ${TARGET_NAME_WHEELS}
 			COMMAND ${PYTHON} ${SETUP_PY} ${PIP_PACKAGE_PLATFORM_WHEELS}

--- a/setup.py.in
+++ b/setup.py.in
@@ -58,7 +58,7 @@ class QiskitSimulatorBuild(build):
             cmd_cmake.append("-GMinGW Makefiles")
         cmd_cmake.append('..')
 
-        cmd_make = ['make', 'qiskit_simulator']
+        cmd_make = ['make', 'pypi_package_copy_qiskit_simulator']
 
         try:
             cmd_make.append('-j%d' % cpu_count())

--- a/src/qiskit-simulator/CMakeLists.txt
+++ b/src/qiskit-simulator/CMakeLists.txt
@@ -1,3 +1,25 @@
+# CMake config file to build the C++ Simulator
+#
+# For Windows, we always build static executables. QISKit provides with the 
+# necessary external binary libraries (.lib and .dll), these .lib comes from an
+# external source and they are simple import files, so we still need the .dll
+# files in order to run the final executable. We only support MinGW64 toolchain
+# so the static linking makes sure that other required libraries from this
+# toolchain are included in the final executable. As MinGW64 can be installed
+# anywhere in the system, the user needs to provide the PATH where the pthreads
+# library is installed using the USER_LIB_PATH variable, like:
+#     C:\..\out> cmake -DUSER_LIB_PATH=C:\path\to\mingw64\lib -G "MinGW Makefiles" ..
+#
+# For Linux and Mac, we can build both statically or dynamically. The former is the
+# default. If you want to build a dynamic executable, you need to set
+# STATIC_LINKING to True, example:
+#     out$ cmake -DSTATIC_LINKING=False ..
+#
+# For Mac, you probably need to install static versions of the toolchain in order
+# to make a static executable. Additionaly, the OpenMP features are only supported
+# on GNU g++ comipler, CLang doesn't include it so if you are building with CLang
+# you won't get all the performance.
+
 project(qiskit_simulator VERSION 1.0 LANGUAGES CXX)
 
 set(QISKIT_SIMULATOR_SRC_DIR "${PROJECT_SOURCE_DIR}/src")
@@ -22,7 +44,8 @@ enable_cxx_compiler_flag_if_supported("-O3")
 enable_cxx_compiler_flag_if_supported("-march=native")
 enable_cxx_compiler_flag_if_supported("-fopenmp")
 
-if(MINGW)
+# We force static linking on Windows
+if(STATIC_LINKING OR MINGW)
 	enable_cxx_compiler_flag_if_supported("-static")
 	enable_cxx_compiler_flag_if_supported("-static-libstdc++")
 	enable_cxx_compiler_flag_if_supported("-static-libgcc")
@@ -48,10 +71,11 @@ target_include_directories(qiskit_simulator PRIVATE ${QISKIT_SIMULATOR_SRC_DIR}/
 
 # For header only libraries
 SET(CMAKE_FIND_LIBRARY_PREFIXES ${CMAKE_FIND_LIBRARY_PREFIXES} "")
-SET(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} ".hpp")
+SET(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} .hpp)
 
-if(MINGW)
-    SET(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} ".lib" ".a")
+# We force static linking on Windows
+if(STATIC_LINKING OR MINGW)
+    SET(CMAKE_FIND_LIBRARY_SUFFIXES .a .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
 endif()
 
 # Looking for external libraries


### PR DESCRIPTION
* The command: pyhton setup.py bdist_wheel/sdist, now copies the
  executables to qiskit/backends/, so platforms without wheels
  package support have a chance to run the c++ simulator
* Improved some in-file CMake documentation

## How Has This Been Tested?
Tested manually, as we don't have automated tests for these procedures.
These changes don't affect the code, they are related to the build system.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.