### PR TITLE
Revise travis configuration (cmake+stages+deploy)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ stage_osx: &stage_osx
   os: osx
   osx_image: xcode9.2
   language: generic
-  env: CMAKE_FLAGS="-D STATIC_LINKING=False -D CMAKE_CXX_COMPILER=g++-6 -D ENABLE_TARGETS_QA=False"
+  env: CMAKE_FLAGS="-D CMAKE_CXX_COMPILER=g++-6 -D ENABLE_TARGETS_QA=False"
   before_install:
     # Travis does not provide support for Python 3 under osx - it needs to be
     # installed manually.

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,16 +66,17 @@ stage_osx: &stage_osx
   os: osx
   osx_image: xcode9.2
   language: generic
-  env: CMAKE_FLAGS="-D STATIC_LINKING=False -D ENABLE_TARGETS_QA=False"
+  env: CMAKE_FLAGS="-D STATIC_LINKING=False -D CMAKE_CXX_COMPILER=g++-6 -D ENABLE_TARGETS_QA=False"
   before_install:
     # Travis does not provide support for Python 3 under osx - it needs to be
     # installed manually.
     |
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
       brew install python3
+      brew install gcc@6
+      brew link --overwrite gcc@6
       virtualenv env -p python3
       source env/bin/activate
-      python --version
     fi
 
 stage_linux_no_compile: &stage_linux_no_compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,29 +13,165 @@
 # limitations under the License.
 # =============================================================================
 
-# Authors: Jesus Perez <jesusper@us.ibm.com>
+notifications:
+  email: false
 
-language: python
 cache: pip
+sudo: false
 
-matrix:
-  include:
-    - python: 3.5
-      env: LINT_JOB=YES
-    - python: 3.5
-    - python: 3.6
-  fast_finish: true
+###############################################################################
+# Anchored and aliased definitions.
+###############################################################################
 
-install:
-  - pip install -r requirements.txt
-  - pip install -r requirements-dev.txt
+# These are used for avoiding repeating code, and due to problems with
+# overriding some keys (in particular, "os" and "language: ptyhon") when using
+# the standard travis matrix with stages.
+#
+# This allows re-using different "sets" of configurations in the stages
+# matrix, mimicking a hierarchy:
+# * stage_generic
+#   * stage_linux
+#     * stage_linux_no_compile
+#   * stage_osx
 
-script:
-  - if [ "$LINT_JOB" = "YES" ]; then make style && make lint; else make test; fi
+stage_generic: &stage_generic
+  install:
+    # Install step for jobs that require compilation and qa.
+    - pip install -U -r requirements.txt
+    - pip install -U -r requirements-dev.txt
+    # Create the basic cmake structure, setting out/ as the default dir.
+    - mkdir out && cd out && cmake $CMAKE_FLAGS ..
+  script:
+    # Compile the executables and run the tests.
+    - make && ARGS="-V" make test
 
-deploy:
+stage_linux: &stage_linux
+  <<: *stage_generic
+  os: linux
+  dist: trusty
+  language: python
+  python: 3.5
+  env: CMAKE_FLAGS="-D CMAKE_CXX_COMPILER=g++-5 -D ENABLE_TARGETS_QA=False"
+  addons:
+    apt:
+      sources:
+        - ubuntu-toolchain-r-test
+      packages:
+        - liblapack-dev
+        - libblas-dev
+        - g++-5
+
+stage_osx: &stage_osx
+  <<: *stage_generic
+  os: osx
+  osx_image: xcode9.2
+  language: generic
+  env: CMAKE_FLAGS="-D STATIC_LINKING=False -D ENABLE_TARGETS_QA=False"
+  before_install:
+    # Travis does not provide support for Python 3 under osx - it needs to be
+    # installed manually.
+    |
+    if [ ${TRAVIS_OS_NAME} = "osx" ]; then
+      brew install python3
+      virtualenv env -p python3
+      source env/bin/activate
+      python --version
+    fi
+
+stage_linux_no_compile: &stage_linux_no_compile
+  <<: *stage_linux
+  addons: false
+  env: CMAKE_FLAGS="-D ENABLE_TARGETS_NON_PYTHON=False"
+
+
+# Other aliases: for convenience, keeping the "jobs" matrix defined later on
+# less verbose.
+
+deploy_ghpages: &deploy_ghpages
   provider: script
   skip_cleanup: true
-  script: tools/ghpages-documentation-deploy.sh
+  script: tools/ghpages_documentation_deploy.sh
   on:
     branch: stable
+
+deploy_pypi: &deploy_pypi
+  provider: pypi
+  skip_cleanup: true
+  user: "diegoplan9"
+  password:
+     secure: "QIhEDs+gec0XvmJnzO2USLOz6I0eGKKcjqFtFYDdw1tbFby8OpnVviT7mJLrBx5qTWeR2RfiiEkm9v+HmevZQEdhOZg2A9w98bHLdWh2sYfjSJgvorNUjXgxba+mvsov9nixTf/k2RK8K7IvY1nbAuAwmS3uSXUBNvbyj0MhwUactPCcjwX9QCjCGrhVeZ1IlwoHPhOG7+zBPJ99ws6g0UBwhszotKN+3yTSgNU/PhW7jG3bjpKOso/CKg7Nv+UIdO8IljbcoJpLNZC/SC9XyHEjd8i4MKNi+tDFdguHk5b54Qobx2x0UaisrIrrNVfGZQliel5DU3eYs2kUPjVetmByO7sK8mXXj5HvIFv9t+XDkQVb1Y9D5CcU+DiKQGl0chWP+ZJu5uzxGClzm8MPO2ChGSKoFbYx95QFSiLc3gKjd6Z6lM4e3HYjMQ4ANt7Hjrez9mHbmbZnElKsg2vJS3gttglxEq5rlZg3Xm/6rRQfcbn93JHG29vLKAe+FjHCs9aG1l+MHn9eRgLbEz2JvMowHU7Tua0YM54J59ERZu1008FCvA2UR6k3sF+htnRiXDmbj/777cGcqv8ckm+OXKSB1ujGRbekkHgR9pf7HNUXPsZ3bwuHyio3mPikFQqU6m3Lm1esTQWrA5QoFuImyXQxDcSFeEx3/bFPkJfMOSw="
+  server: "https://test.pypi.org/legacy/"
+  distributions: "sdist bdist_wheel"
+  on:
+    branch: stable
+    condition: '$TRAVIS_COMMIT_MESSAGE == "pip release: "*'
+
+
+###############################################################################
+# Stage-related definitions
+###############################################################################
+
+# Define the order of the stages.
+stages:
+  - lint and pure python test
+  - test
+  - deploy doc and pypi
+
+# Define the job matrix explicitly, as matrix expansion causes issues when
+# using it with stages and some variables/sections cannot be overridden.
+jobs:
+  include:
+    # "lint and and pure python test" stage
+    ###########################################################################
+    # Linter and style check (GNU/Linux, Python 3.5)
+    - stage: lint and pure python test
+      <<: *stage_linux_no_compile
+      script: make style VERBOSE=""; make lint VERBOSE=""
+
+    # Run the tests against without compilation (GNU/Linux, Python 3.5)
+    - stage: lint and pure python test
+      <<: *stage_linux_no_compile
+
+    # "test" stage
+    ###########################################################################
+    # GNU/Linux, Python 3.5
+    - stage: test
+      <<: *stage_linux
+
+    # GNU/Linux, Python 3.6
+    - stage: test
+      <<: *stage_linux
+      python: 3.6
+
+    # OSX, Python 3.latest (brew does not support versioning)
+    - stage: test
+      <<: *stage_osx
+
+    # "deploy" stage.
+    ###########################################################################
+    # github pages documentation update (GNU/Linux, Python 3.5)
+    - stage: deploy doc and pypi
+      <<: *stage_linux_no_compile
+      if: branch = stable and repo = QISKit/qiskit-sdk-py
+      script: cd ..
+      deploy:
+        <<: *deploy_ghpages
+
+    # GNU/Linux, Python 3.5
+    - stage: deploy doc and pypi
+      <<: *stage_linux
+      if: branch = stable and repo = QISKit/qiskit-sdk-py
+      install: mkdir out && cd out && cmake $CMAKE_FLAGS ..
+      script: cd ..
+      deploy:
+        <<: *deploy_pypi
+
+    # OSX, Python 3.latest (brew does not support versions)
+    - stage: deploy doc and pypi
+      <<: *stage_osx
+      if: branch = stable and repo = QISKit/qiskit-sdk-py
+      install: mkdir out && cd out && cmake $CMAKE_FLAGS ..
+      script: cd ..
+      deploy:
+        <<: *deploy_pypi
+        distributions: "bdist_wheel"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,19 +7,24 @@ set(QISKIT_VERSION ${PROJECT_VERSION} CACHE INTERNAL "VERSION OF QISKIT")
 
 include(cmake/defaults.cmake)
 
-# Add Toolchain utilities for C++ sources
-include(cmake/toolchain-utils.cmake)
+if (ENABLE_TARGETS_NON_PYTHON)
+    # Add Toolchain utilities for C++ sources
+    include(cmake/toolchain-utils.cmake)
 
-# Add C++ Qiskit Simulator
-add_subdirectory(${PROJECT_SOURCE_DIR}/src/qiskit-simulator)
+    # Add C++ Qiskit Simulator
+    add_subdirectory(${PROJECT_SOURCE_DIR}/src/qiskit-simulator)
 
-# Add tests and linters
-include(cmake/code-qa.cmake)
-add_lint_target()
-add_code_style_target()
-add_doc_target(html "./" "_build/")
+    # Add Python distributable package generator
+    include(cmake/python-build.cmake)
+    add_pypi_package_target(pypi_package both)
+endif()
 
+include(cmake/tests.cmake)
 
-# Add Python distributable package generator
-include(cmake/python-build.cmake)
-add_pypi_package_target(pypi_package both)
+if (ENABLE_TARGETS_QA)
+    # Add QA tools: lint, style and sphinx
+    include(cmake/code-qa.cmake)
+    add_lint_target()
+    add_code_style_target()
+    add_doc_target(html "./" "_build/")
+endif()

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -129,6 +129,9 @@ Windows:
     C:\..\> set LOG_LEVEL="INFO"
     C:\..\> python -m unittest test/python/test_apps.py
 
+Additionally, an environment variable ``SKIP_ONLINE_TESTS`` can be used for
+toggling the execution of the tests that require network access to the API.
+
 Style guide
 ~~~~~~~~~~~
 

--- a/cmake/code-qa.cmake
+++ b/cmake/code-qa.cmake
@@ -1,14 +1,9 @@
-enable_testing()
 # Run python code tests
 # Create Python distrubution package
 find_program(PYTHON "python")
 if (NOT PYTHON)
     message(FATAL_ERROR "Couldn't find Python in your system. Please, install it and try again.")
 endif()
-
-add_test(NAME qiskit_python
-    COMMAND ${PYTHON} -m unittest discover -s test -v
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 function(add_lint_target)
     find_program(PYLINT "pylint")

--- a/cmake/defaults.cmake
+++ b/cmake/defaults.cmake
@@ -5,3 +5,5 @@
 
 set(CMAKE_BUILD_TYPE "Release")
 set(STATIC_LINKING True CACHE BOOL "Static linking of executables")
+set(ENABLE_TARGETS_NON_PYTHON True CACHE BOOL "Enable targets for non Python code")
+set(ENABLE_TARGETS_QA True CACHE BOOL "Enable targets for QA targets")

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,0 +1,10 @@
+enable_testing()
+# Run python code tests
+find_program(PYTHON "python")
+if (NOT PYTHON)
+    message(FATAL_ERROR "Couldn't find Python in your system. Please, install it and try again.")
+endif()
+
+add_test(NAME qiskit_python
+    COMMAND ${PYTHON} -m unittest discover -s test -v
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/doc/dev_introduction.rst
+++ b/doc/dev_introduction.rst
@@ -194,3 +194,6 @@ Windows:
 
     C:\..\> set LOG_LEVEL="INFO"
     C:\..\> python -m unittest test/python/test_apps.py
+
+Additionally, an environment variable ``SKIP_ONLINE_TESTS`` can be used for
+toggling the execution of the tests that require network access to the API.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pylint>=1.8
-sphinx
+pycodestyle
+Sphinx>=1.6,<1.7
 better-apidoc==0.1.2
 sphinxcontrib-fulltoc==1.2.0
-pycodestyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ networkx>=1.11,<2.1
 numpy>=1.13,<1.15
 ply==3.10
 scipy>=0.19,<1.1
-Sphinx>=1.6,<1.7
 sympy>=1.0
 pillow>=4.2.1

--- a/setup.py.in
+++ b/setup.py.in
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+import sys
 import os
 import platform
 from distutils.command.build import build
@@ -15,7 +33,6 @@ requirements = [
     "numpy>=1.13,<1.15",
     "ply==3.10",
     "scipy>=0.19,<1.1",
-    "Sphinx>=1.6,<1.7",
     "sympy>=1.0"
 ]
 

--- a/test/python/test_job_processor.py
+++ b/test/python/test_job_processor.py
@@ -16,11 +16,11 @@
 # limitations under the License.
 # =============================================================================
 
-import os
 import pprint
 import unittest
 
 from IBMQuantumExperience.IBMQuantumExperience import IBMQuantumExperience
+
 from qiskit import (ClassicalRegister, QuantumCircuit, QuantumProgram,
                     QuantumRegister, QISKitError)
 from qiskit import _openquantumcompiler as openquantumcompiler
@@ -29,7 +29,7 @@ import qiskit.backends
 from qiskit import QuantumJob
 
 from ._random_circuit_generator import RandomCircuitGenerator
-from .common import QiskitTestCase, TRAVIS_FORK_PULL_REQUEST
+from .common import requires_qe_access, QiskitTestCase
 
 
 def mock_run_local_backend(self):
@@ -39,22 +39,12 @@ def mock_run_local_backend(self):
 
 class TestJobProcessor(QiskitTestCase):
     """
-    Test job_pocessor module.
+    Test job_processor module.
     """
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
-        try:
-            import Qconfig
-            cls.QE_TOKEN = Qconfig.APItoken
-            cls.QE_URL = Qconfig.config['url']
-        except ImportError:
-            if 'QE_TOKEN' in os.environ:
-                cls.QE_TOKEN = os.environ['QE_TOKEN']
-            if 'QE_URL' in os.environ:
-                cls.QE_URL = os.environ['QE_URL']
 
         n_circuits = 20
         min_depth = 1
@@ -68,11 +58,6 @@ class TestJobProcessor(QiskitTestCase):
                                                  max_depth=max_depth)
         random_circuits.add_circuits(n_circuits)
         cls.rqg = random_circuits
-        if hasattr(cls, 'QE_TOKEN'):
-            cls._api = IBMQuantumExperience(cls.QE_TOKEN,
-                                            {"url": cls.QE_URL},
-                                            verify=True)
-            qiskit.backends.discover_remote_backends(cls._api)
 
     def setUp(self):
         self.seed = 88
@@ -113,6 +98,10 @@ class TestJobProcessor(QiskitTestCase):
                      ]}
         self.job_processor_exception = Exception()
         self.job_processor_finished = False
+
+    def _init_api(self, QE_TOKEN, QE_URL):
+        api = IBMQuantumExperience(QE_TOKEN, {"url": QE_URL}, verify=True)
+        qiskit.backends.discover_remote_backends(api)
 
     def test_load_unroll_qasm_file(self):
         _ = openquantumcompiler.load_unroll_qasm_file(self.qasm_filename)
@@ -156,8 +145,10 @@ class TestJobProcessor(QiskitTestCase):
                                  backend='local_unitary_simulator')
         jobprocessor.run_backend(quantum_job)
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_run_remote_simulator(self):
+    @requires_qe_access
+    def test_run_remote_simulator(self, QE_TOKEN, QE_URL):
+        self._init_api(QE_TOKEN, QE_URL)
+
         compiled_circuit = openquantumcompiler.compile(self.qc.qasm())
         quantum_job = QuantumJob(compiled_circuit, do_compile=False,
                                  backend='ibmqx_qasm_simulator')
@@ -168,8 +159,10 @@ class TestJobProcessor(QiskitTestCase):
                                  backend='local_qasm_simulator')
         jobprocessor.run_backend(quantum_job)
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_run_remote_simulator_compile(self):
+    @requires_qe_access
+    def test_run_remote_simulator_compile(self, QE_TOKEN, QE_URL):
+        self._init_api(QE_TOKEN, QE_URL)
+
         quantum_job = QuantumJob(self.qc, do_compile=True,
                                  backend='ibmqx_qasm_simulator')
         jobprocessor.run_backend(quantum_job)
@@ -193,8 +186,10 @@ class TestJobProcessor(QiskitTestCase):
         jp = jobprocessor.JobProcessor(job_list, callback=None)
         jp.submit()
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_run_job_processor_online(self):
+    @requires_qe_access
+    def test_run_job_processor_online(self, QE_TOKEN, QE_URL):
+        self._init_api(QE_TOKEN, QE_URL)
+
         njobs = 1
         job_list = []
         for _ in range(njobs):
@@ -205,8 +200,10 @@ class TestJobProcessor(QiskitTestCase):
         jp = jobprocessor.JobProcessor(job_list, callback=None)
         jp.submit()
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_quantum_program_online(self):
+    @requires_qe_access
+    def test_quantum_program_online(self, QE_TOKEN, QE_URL):
+        self._init_api(QE_TOKEN, QE_URL)
+
         qp = QuantumProgram()
         qr = qp.create_quantum_register('qr', 2)
         cr = qp.create_classical_register('cr', 2)
@@ -215,7 +212,7 @@ class TestJobProcessor(QiskitTestCase):
         qc.measure(qr[0], cr[0])
         backend = 'ibmqx_qasm_simulator'  # the backend to run on
         shots = 1024  # the number of shots in the experiment.
-        qp.set_api(self.QE_TOKEN, self.QE_URL)
+        qp.set_api(QE_TOKEN, QE_URL)
         _ = qp.execute(['qc'], backend=backend, shots=shots, seed=78)
 
     def test_run_job_processor_local_parallel(self):
@@ -263,8 +260,8 @@ class TestJobProcessor(QiskitTestCase):
         jp = jobprocessor.JobProcessor(job_list, max_workers=1, callback=None)
         jp.submit()
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_mix_local_remote_jobs(self):
+    @requires_qe_access
+    def test_mix_local_remote_jobs(self, QE_TOKEN, QE_URL):
         """test mixing local and remote jobs
 
         Internally local jobs execute in seperate processes since
@@ -272,6 +269,8 @@ class TestJobProcessor(QiskitTestCase):
         since they are I/O bound. The module gets results from potentially
         both kinds in one list. Test that this works.
         """
+        self._init_api(QE_TOKEN, QE_URL)
+
         njobs = 6
         job_list = []
         backend_type = ['local_qasm_simulator', 'ibmqx_qasm_simulator']
@@ -324,8 +323,10 @@ class TestJobProcessor(QiskitTestCase):
         if self.job_processor_exception:
             raise self.job_processor_exception
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_backend_not_found(self):
+    @requires_qe_access
+    def test_backend_not_found(self, QE_TOKEN, QE_URL):
+        self._init_api(QE_TOKEN, QE_URL)
+
         compiled_circuit = openquantumcompiler.compile(self.qc.qasm())
         job = QuantumJob(compiled_circuit,
                          backend='non_existing_backend')

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -28,21 +28,7 @@ from qiskit import (ClassicalRegister, QISKitError, QuantumCircuit,
                     QuantumRegister, QuantumProgram, Result,
                     RegisterSizeError)
 from qiskit.tools import file_io
-from .common import QiskitTestCase, TRAVIS_FORK_PULL_REQUEST, Path
-
-# We need the environment variable for Travis.
-try:
-    import Qconfig
-
-    QE_TOKEN = Qconfig.APItoken
-    # TODO: Why "APItoken" is in the root (the unique) and
-    # "url" inside "config"?
-    # (also unique) -> make it consistent.
-    QE_URL = Qconfig.config["url"]
-except ImportError:
-    if 'QE_TOKEN' in os.environ and 'QE_URL' in os.environ:
-        QE_TOKEN = os.environ["QE_TOKEN"]
-        QE_URL = os.environ["QE_URL"]
+from .common import requires_qe_access, QiskitTestCase, Path
 
 
 class TestQuantumProgram(QiskitTestCase):
@@ -99,8 +85,8 @@ class TestQuantumProgram(QiskitTestCase):
         result = QuantumProgram()
         self.assertIsInstance(result, QuantumProgram)
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_config_scripts_file(self):
+    @requires_qe_access
+    def test_config_scripts_file(self, QE_TOKEN, QE_URL):
         """Test Qconfig.
 
         in this case we check if the QE_URL API is defined.
@@ -109,6 +95,7 @@ class TestQuantumProgram(QiskitTestCase):
             Libraries:
                 import Qconfig
         """
+        # pylint: disable=unused-argument
         self.assertEqual(
             QE_URL,
             "https://quantumexperience.ng.bluemix.net/api")
@@ -573,8 +560,8 @@ class TestQuantumProgram(QiskitTestCase):
     # Tests for working with backends
     ###############################################################
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_setup_api(self):
+    @requires_qe_access
+    def test_setup_api(self, QE_TOKEN, QE_URL):
         """Check the api is set up.
 
         If all correct is should be true.
@@ -584,8 +571,8 @@ class TestQuantumProgram(QiskitTestCase):
         config = q_program.get_api_config()
         self.assertTrue(config)
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_available_backends_exist(self):
+    @requires_qe_access
+    def test_available_backends_exist(self, QE_TOKEN, QE_URL):
         """Test if there are available backends.
 
         If all correct some should exists (even if offline).
@@ -604,8 +591,8 @@ class TestQuantumProgram(QiskitTestCase):
         local_backends = qiskit.backends.local_backends()
         self.assertTrue(local_backends)
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_online_backends_exist(self):
+    @requires_qe_access
+    def test_online_backends_exist(self, QE_TOKEN, QE_URL):
         """Test if there are online backends.
 
         If all correct some should exists.
@@ -617,8 +604,8 @@ class TestQuantumProgram(QiskitTestCase):
         self.log.info(online_backends)
         self.assertTrue(online_backends)
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_online_devices(self):
+    @requires_qe_access
+    def test_online_devices(self, QE_TOKEN, QE_URL):
         """Test if there are online backends (which are devices).
 
         If all correct some should exists. NEED internet connection for this.
@@ -630,8 +617,8 @@ class TestQuantumProgram(QiskitTestCase):
         self.log.info(online_devices)
         self.assertTrue(isinstance(online_devices, list))
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_online_simulators(self):
+    @requires_qe_access
+    def test_online_simulators(self, QE_TOKEN, QE_URL):
         """Test if there are online backends (which are simulators).
 
         If all correct some should exists. NEED internet connection for this.
@@ -681,8 +668,8 @@ class TestQuantumProgram(QiskitTestCase):
         # qp.get_backend_configuration("fail")
         self.assertRaises(LookupError, qp.get_backend_configuration, "fail")
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_get_backend_calibration(self):
+    @requires_qe_access
+    def test_get_backend_calibration(self, QE_TOKEN, QE_URL):
         """Test get_backend_calibration.
 
         If all correct should return dictionay on length 4.
@@ -696,8 +683,8 @@ class TestQuantumProgram(QiskitTestCase):
         self.log.info(result)
         self.assertEqual(len(result), 4)
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_get_backend_parameters(self):
+    @requires_qe_access
+    def test_get_backend_parameters(self, QE_TOKEN, QE_URL):
         """Test get_backend_parameters.
 
         If all correct should return dictionay on length 4.
@@ -1217,8 +1204,8 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertAlmostEqual(meanzi, 0, places=1)
         self.assertAlmostEqual(meaniz, 0, places=1)
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_execute_one_circuit_simulator_online(self):
+    @requires_qe_access
+    def test_execute_one_circuit_simulator_online(self, QE_TOKEN, QE_URL):
         """Test execute_one_circuit_simulator_online.
 
         If all correct should return the data.
@@ -1239,8 +1226,8 @@ class TestQuantumProgram(QiskitTestCase):
         counts = result.get_counts('qc')
         self.assertEqual(counts, {'0': 498, '1': 526})
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_simulator_online_size(self):
+    @requires_qe_access
+    def test_simulator_online_size(self, QE_TOKEN, QE_URL):
         """Test test_simulator_online_size.
 
         If all correct should return the data.
@@ -1261,8 +1248,8 @@ class TestQuantumProgram(QiskitTestCase):
                       cm.output[0])
         self.assertRaises(RegisterSizeError, result.get_data, 'qc')
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_execute_several_circuits_simulator_online(self):
+    @requires_qe_access
+    def test_execute_several_circuits_simulator_online(self, QE_TOKEN, QE_URL):
         """Test execute_several_circuits_simulator_online.
 
         If all correct should return the data.
@@ -1291,8 +1278,8 @@ class TestQuantumProgram(QiskitTestCase):
                                    '00': 251})
         self.assertEqual(counts2, {'11': 515, '00': 509})
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_execute_one_circuit_real_online(self):
+    @requires_qe_access
+    def test_execute_one_circuit_real_online(self, QE_TOKEN, QE_URL):
         """Test execute_one_circuit_real_online.
 
         If all correct should return a result object
@@ -1347,8 +1334,8 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertEqual(result1, {'00 01': 1024})
         self.assertEqual(result2, {'10 00': 1024})
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_online_qasm_simulator_two_registers(self):
+    @requires_qe_access
+    def test_online_qasm_simulator_two_registers(self, QE_TOKEN, QE_URL):
         """Test online_qasm_simulator_two_registers.
 
         If all correct should the data.
@@ -1497,8 +1484,8 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertEqual(ghzresult.get_counts("ghz"),
                          {'00000': 1047, '11111': 1001})
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_example_swap_bits(self):
+    @requires_qe_access
+    def test_example_swap_bits(self, QE_TOKEN, QE_URL):
         """Test a toy example swapping a set bit around.
 
         Uses the mapper. Pass if results are correct.
@@ -1741,8 +1728,8 @@ class TestQuantumProgram(QiskitTestCase):
             self.assertEqual(
                 ex.message, 'Error waiting for Job results: Timeout after 0.01 seconds.')
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_hpc_parameter_is_correct(self):
+    @requires_qe_access
+    def test_hpc_parameter_is_correct(self, QE_TOKEN, QE_URL):
         """Test for checking HPC parameter in compile() method.
         It must be only used when the backend is ibmqx_hpc_qasm_simulator.
         It will warn the user if the parameter is passed correctly but the
@@ -1766,8 +1753,8 @@ class TestQuantumProgram(QiskitTestCase):
                                       'omp_num_threads': 16})
         self.assertTrue(qobj)
 
-    @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')
-    def test_hpc_parameter_is_incorrect(self):
+    @requires_qe_access
+    def test_hpc_parameter_is_incorrect(self, QE_TOKEN, QE_URL):
         """Test for checking HPC parameter in compile() method.
         It must be only used when the backend is ibmqx_hpc_qasm_simulator.
         If the parameter format is incorrect, it will raise a QISKitError.

--- a/test/python/test_visualization.py
+++ b/test/python/test_visualization.py
@@ -25,11 +25,11 @@ from qiskit import QuantumProgram
 from qiskit import QuantumCircuit
 from qiskit import QuantumRegister
 from qiskit import ClassicalRegister
-from qiskit.tools.visualization import circuit_drawer
 from .common import QiskitTestCase
 
 try:
     from qiskit.tools.visualization import latex_drawer
+    from qiskit.tools.visualization import circuit_drawer
     VALID_MATPLOTLIB = True
 except RuntimeError:
     # Under some combinations (travis osx vms, or headless configurations)
@@ -120,6 +120,7 @@ class TestLatexDrawer(QiskitTestCase):
             raise
 
 
+@unittest.skipIf(not VALID_MATPLOTLIB, 'osx matplotlib backend not avaiable')
 class TestCircuitDrawer(QiskitTestCase):
     """QISKit circuit drawer tests."""
 

--- a/test/python/test_visualization.py
+++ b/test/python/test_visualization.py
@@ -25,7 +25,6 @@ from qiskit import QuantumProgram
 from qiskit import QuantumCircuit
 from qiskit import QuantumRegister
 from qiskit import ClassicalRegister
-from qiskit.tools.visualization import latex_drawer
 from qiskit.tools.visualization import circuit_drawer
 from .common import QiskitTestCase
 

--- a/test/python/test_visualization.py
+++ b/test/python/test_visualization.py
@@ -29,7 +29,18 @@ from qiskit.tools.visualization import latex_drawer
 from qiskit.tools.visualization import circuit_drawer
 from .common import QiskitTestCase
 
+try:
+    from qiskit.tools.visualization import latex_drawer
+    VALID_MATPLOTLIB = True
+except RuntimeError:
+    # Under some combinations (travis osx vms, or headless configurations)
+    # matplotlib might not be fully, raising:
+    # RuntimeError: Python is not installed as a framework.
+    # when importing. If that is the case, the full test is skipped.
+    VALID_MATPLOTLIB = False
 
+
+@unittest.skipIf(not VALID_MATPLOTLIB, 'osx matplotlib backend not avaiable')
 class TestLatexDrawer(QiskitTestCase):
     """QISKit latex drawer tests."""
 

--- a/tools/ghpages_documentation_deploy.sh
+++ b/tools/ghpages_documentation_deploy.sh
@@ -42,7 +42,6 @@ cd $TARGET_REPOSITORY_NAME
 
 echo "Replacing $TARGET_DOC_DIR with the new contents ..."
 git rm -rf $TARGET_DOC_DIR
-# git rm -rf $TARGET_DOC_DIR_JA
 cp -r $SOURCE_DIR/$SOURCE_DOC_DIR $TARGET_DOC_DIR
 cp -r $SOURCE_DIR/$SOURCE_DOC_DIR_JA $TARGET_DOC_DIR_JA
 git add $TARGET_DOC_DIR

--- a/tools/ghpages_documentation_deploy.sh
+++ b/tools/ghpages_documentation_deploy.sh
@@ -33,7 +33,7 @@ SOURCE_DOC_DIR_JA="doc/_build/ja/html"
 SOURCE_DIR=`pwd`
 
 # Build the documentation.
-make doc
+make -C out doc
 
 echo "Cloning the Github Pages repository ..."
 cd ..
@@ -42,7 +42,7 @@ cd $TARGET_REPOSITORY_NAME
 
 echo "Replacing $TARGET_DOC_DIR with the new contents ..."
 git rm -rf $TARGET_DOC_DIR
-git rm -rf $TARGET_DOC_DIR_JA
+# git rm -rf $TARGET_DOC_DIR_JA
 cp -r $SOURCE_DIR/$SOURCE_DOC_DIR $TARGET_DOC_DIR
 cp -r $SOURCE_DIR/$SOURCE_DOC_DIR_JA $TARGET_DOC_DIR_JA
 git add $TARGET_DOC_DIR


### PR DESCRIPTION
## Description

* Revise the travis configuration for using `cmake` for the several
  targets, and use "stages" instead of parallel jobs:
  * define three stages that are executed if the previous one suceeds:
    1. "linter and pure python test": executes the linter and a test
       without compiling the binaries, with the idea of providing quick
       feedback for PRs.
    2. "test": launch the test, including the compilation of binaries,
       under GNU/Linux Python 3.6 and 3.6; and osx Python 3.6.
    3. "deploy doc and pypi": for the stable branch, deploy the docs
       to the landing page, and when using a specific commit message,
       build the GNU/Linux and osx wheels, uploading them to test.pypi.
  * use yaml anchors and definitions to avoid repeating code (and
    working around travis limitations).
* Modify the `cmake``configuration to accomodate the stages flow:
  * allow conditional creation of compilation and QA targets, mainly
    for saving some time in some jobs.
  * move the tests to `cmake/tests.cmake`.
* Update the tests:
  * add a `requires_qe_access` decorator that retrieves QE_TOKEN and
    QE_URL and appends them to the parameters in an unified manner.
  * add an environment variable `SKIP_ONLINE_TESTS` that allows to
    skip the tests that need network access.
  * replace `TRAVIS_FORK_PULL_REQUEST` with the previous two
    mechanisms, adding support for AppVeyor as well.
  * fix a problem with matplotlib under osx headless, effectively
    skipping `test_visualization.py` during the travis osx jobs.

<!--- Provide a general summary of your changes in the Title above -->


## Motivation and Context

This PR paves the way towards a system that automatically:
* launches the tests in multiple platforms (finally osx is included)
* compiles the binaries, and uses them in the tests
* generates the distributables (python wheels and source distribution) for the releases
* uses `cmake` internally for all the steps
* provides more control over "which job is run depending on conditions" due to the use of stages

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

The build matrix with the full steps (ie. for the stable branch during a commit that invokes a release) would be similar to:

![ci-stages](https://user-images.githubusercontent.com/418311/36120798-9fb9d2b8-1044-11e8-8511-100f582b0f73.png)

## Next steps

Please note that this PR will be followed up by other PRs that implement the remaining functionality, as it touches several related issues (cmake, shared libraries, multiplatform support). The following features are still not fully functional:
* generation of the wheels: currently the wheels are being generated but not uploaded to the test repository, as some issues with the static linking need to be solved during the move to shared libraries.
* job times are lower in the case of a PR that fails the linter/the lite test, but higher for a complete run: mostly due to the installation of the dependencies for building the binaries. Alternatives such as using a docker image or further tweaking the installation needs to be checked.
