### PR TITLE
test_simulator_online_size with assertLog

### DIFF
--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1254,9 +1254,11 @@ class TestQuantumProgram(QiskitTestCase):
         shots = 1  # the number of shots in the experiment.
         q_program.set_api(QE_TOKEN, QE_URL)
         backend = 'ibmqx_qasm_simulator'
-        result = q_program.execute(['qc'], backend=backend,
-                                   shots=shots, max_credits=3,
-                                   seed=73846087)
+        with self.assertLogs('IBMQuantumExperience', level='WARNING') as cm:
+            result = q_program.execute(['qc'], backend=backend, shots=shots, max_credits=3,
+                                       seed=73846087)
+        self.assertIn('The registers exceed the number of qubits, it can\'t be greater than 24.',
+                      cm.output[0])
         self.assertRaises(RegisterSizeError, result.get_data, 'qc')
 
     @unittest.skipIf(TRAVIS_FORK_PULL_REQUEST, 'Travis fork pull request')


### PR DESCRIPTION
## Description
The test `test.python.test_quantumprogram.test_simulator_online_size` generates a warning from `IBMQuantumExperience`. It can be cleaned (and checked) with `assertLog`.

## Motivation and Context
I recently learnt about `assertLog`. It allows to clean the output of the tests and, on top of that, make sure that is generated and with the "right" message.

## How Has This Been Tested?
`make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)