### PR TITLE
Sympy in dag

### DIFF
--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -357,13 +357,7 @@ class DAGCircuit:
         self._check_bits(qargs, self.output_map, False)
         self._check_bits(all_cbits, self.output_map, True)
 
-        # params is a list of sympy symbols and the str() method
-        # will return Python expressions. To get the correct
-        # OpenQASM expression, we need to replace "**" with "^".
-        node_params = list(map(lambda x: x.replace("**", "^"),
-                               map(str, params)))
-        self._add_op_node(name, qargs, cargs, node_params,
-                          condition)
+        self._add_op_node(name, qargs, cargs, params, condition)
         # Add new in-edges from predecessors of the output nodes to the
         # operation node while deleting the old in-edges of the output nodes
         # and adding new edges from the operation node to each output node
@@ -396,12 +390,7 @@ class DAGCircuit:
         self._check_bits(qargs, self.input_map, False)
         self._check_bits(all_cbits, self.input_map, True)
 
-        # params is a list of sympy symbols and the str() method
-        # will return Python expressions. To get the correct
-        # OpenQASM expression, we need to replace "**" with "^".
-        node_params = list(map(lambda x: x.replace("**", "^"),
-                               map(str, params)))
-        self._add_op_node(name, qargs, cargs, node_params,
+        self._add_op_node(name, qargs, cargs, params,
                           condition)
         # Add new out-edges to successors of the input nodes from the
         # operation node while deleting the old out-edges of the input nodes
@@ -786,7 +775,8 @@ class DAGCircuit:
                                 param = ",".join(map(lambda x: str(sympy.N(x)),
                                                      nd["params"]))
                             else:
-                                param = ",".join(nd["params"])
+                                param = ",".join(map(lambda x: x.replace("**", "^"),
+                                                     map(str, nd["params"])))
                             out += "%s(%s) %s;\n" % (nm, param, qarg)
                         else:
                             out += "%s %s;\n" % (nm, qarg)

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -477,13 +477,13 @@ def test_trig_solution(theta, phi, lamb, xi, theta1, theta2):
     as a Max symbol. See:
     http://docs.sympy.org/latest/modules/functions/elementary.html?highlight=max
     """
-    delta1 = sympy.Abs(sympy.cos(phi + lamb) * sympy.cos(theta) - \
+    delta1 = sympy.Abs(sympy.cos(phi + lamb) * sympy.cos(theta) -
                        sympy.cos(xi) * sympy.cos(theta1 + theta2))
-    delta2 = sympy.Abs(sympy.sin(phi + lamb) * sympy.cos(theta) - \
+    delta2 = sympy.Abs(sympy.sin(phi + lamb) * sympy.cos(theta) -
                        sympy.sin(xi) * sympy.cos(theta1 - theta2))
-    delta3 = sympy.Abs(sympy.cos(phi - lamb) * sympy.sin(theta) - \
+    delta3 = sympy.Abs(sympy.cos(phi - lamb) * sympy.sin(theta) -
                        sympy.cos(xi) * sympy.sin(theta1 + theta2))
-    delta4 = sympy.Abs(sympy.sin(phi - lamb) * sympy.sin(theta) - \
+    delta4 = sympy.Abs(sympy.sin(phi - lamb) * sympy.sin(theta) -
                        sympy.sin(xi) * sympy.sin(-theta1 + theta2))
 
     return sympy.Max(delta1, delta2, delta3, delta4)

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -35,7 +35,6 @@ from ._mappererror import MapperError
 
 logger = logging.getLogger(__name__)
 
-
 # Notes:
 # Measurements may occur and be followed by swaps that result in repeated
 # measurement of the same qubit. Near-term experiments cannot implement
@@ -656,12 +655,11 @@ def optimize_1q_gates(circuit):
             left_name = nd["name"]
             assert left_name in ["u1", "u2", "u3", "id"], "internal error"
             if left_name == "u1":
-                left_parameters = (N(0), N(0), sympy.sympify(nd["params"][0]))
+                left_parameters = (N(0), N(0), nd["params"][0])
             elif left_name == "u2":
-                left_parameters = (sympy.pi / 2, sympy.sympify(nd["params"][0]),
-                                   sympy.sympify(nd["params"][1]))
+                left_parameters = (sympy.pi / 2, nd["params"][0], nd["params"][1])
             elif left_name == "u3":
-                left_parameters = tuple(sympy.sympify(nd["params"]))
+                left_parameters = tuple(nd["params"])
             else:
                 left_name = "u1"  # replace id with u1
                 left_parameters = (N(0), N(0), N(0))

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -485,7 +485,7 @@ def test_trig_solution(theta, phi, lamb, xi, theta1, theta2):
     delta4 = sympy.sin(phi - lamb) * sympy.sin(theta) - \
         sympy.sin(xi) * sympy.sin(-theta1 + theta2)
 
-    [delta1, delta2, delta3, delta4] = map(lambda x: sympy.Abs(x.simplify()),
+    [delta1, delta2, delta3, delta4] = map(lambda x: sympy.Abs(x),
                                            [delta1, delta2, delta3, delta4])
 
     return sympy.Max(delta1, delta2, delta3, delta4)

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -35,6 +35,7 @@ from ._mappererror import MapperError
 
 logger = logging.getLogger(__name__)
 
+
 # Notes:
 # Measurements may occur and be followed by swaps that result in repeated
 # measurement of the same qubit. Near-term experiments cannot implement
@@ -476,17 +477,14 @@ def test_trig_solution(theta, phi, lamb, xi, theta1, theta2):
     as a Max symbol. See:
     http://docs.sympy.org/latest/modules/functions/elementary.html?highlight=max
     """
-    delta1 = sympy.cos(phi + lamb) * sympy.cos(theta) - \
-        sympy.cos(xi) * sympy.cos(theta1 + theta2)
-    delta2 = sympy.sin(phi + lamb) * sympy.cos(theta) - \
-        sympy.sin(xi) * sympy.cos(theta1 - theta2)
-    delta3 = sympy.cos(phi - lamb) * sympy.sin(theta) - \
-        sympy.cos(xi) * sympy.sin(theta1 + theta2)
-    delta4 = sympy.sin(phi - lamb) * sympy.sin(theta) - \
-        sympy.sin(xi) * sympy.sin(-theta1 + theta2)
-
-    [delta1, delta2, delta3, delta4] = map(lambda x: sympy.Abs(x),
-                                           [delta1, delta2, delta3, delta4])
+    delta1 = sympy.Abs(sympy.cos(phi + lamb) * sympy.cos(theta) - \
+                       sympy.cos(xi) * sympy.cos(theta1 + theta2))
+    delta2 = sympy.Abs(sympy.sin(phi + lamb) * sympy.cos(theta) - \
+                       sympy.sin(xi) * sympy.cos(theta1 - theta2))
+    delta3 = sympy.Abs(sympy.cos(phi - lamb) * sympy.sin(theta) - \
+                       sympy.cos(xi) * sympy.sin(theta1 + theta2))
+    delta4 = sympy.Abs(sympy.sin(phi - lamb) * sympy.sin(theta) - \
+                       sympy.sin(xi) * sympy.sin(-theta1 + theta2))
 
     return sympy.Max(delta1, delta2, delta3, delta4)
 


### PR DESCRIPTION
## Motivation and Context
The parser creates symbolic objects from the parameters. However, when the dag was created, they used to be saved as strings for avoiding incompatibilities issues. This created a situation that, when the dag parameters need to be used, they are sympified. You can imagine, tons of overhead. This PR fixes this. We have better tests than we used to have in the past. The improvement in the mapper performance is noticeable.

## How Has This Been Tested?
`make test`