### PR TITLE
Fix installation issue with simulator compilation

### DIFF
--- a/setup.py.in
+++ b/setup.py.in
@@ -1,12 +1,11 @@
-import sys
 import os
-from setuptools import setup
-from setuptools.command.install import install
-from setuptools.dist import Distribution
+import platform
 from distutils.command.build import build
 from multiprocessing import cpu_count
 from subprocess import call
-import platform
+
+from setuptools import setup
+from setuptools.dist import Distribution
 
 
 requirements = [
@@ -41,48 +40,58 @@ packages = ["qiskit",
 # C++ components compilation
 class QiskitSimulatorBuild(build):
     def run(self):
-        build.run(self)
-        supported_platforms = ['Linux', 'Darwin', 'Windows']
-        current_platform = platform.system()
-        if not current_platform in supported_platforms:
-            print('WARNING: QISKit cpp simulator is ment to be built with these '
-                  'platforms: {}. We will support other platforms soon!'
-                  .format(supported_platforms))
-            return
-
-        cmd_cmake = ['cmake', '-vvv']
-        if 'USER_LIB_PATH' in os.environ:
-            cmd_cmake.append('-DUSER_LIB_PATH={}'.format(os.environ['USER_LIB_PATH']))
-        if current_platform == 'Windows':
-            # We only support MinGW so far
-            cmd_cmake.append("-GMinGW Makefiles")
-        cmd_cmake.append('..')
-
-        cmd_make = ['make', 'pypi_package_copy_qiskit_simulator']
+        super().run()
+        # Store the current working directory, as invoking cmake involves
+        # an out of source build and might interfere with the rest of the steps.
+        current_directory = os.getcwd()
 
         try:
-            cmd_make.append('-j%d' % cpu_count())
-        except NotImplementedError:
-            print('WARNING: Unable to determine number of CPUs. Using single threaded make.')
+            supported_platforms = ['Linux', 'Darwin', 'Windows']
+            current_platform = platform.system()
+            if current_platform not in supported_platforms:
+                # TODO: stdout is silenced by pip if the full setup.py invocation is
+                # successful, unless using '-v' - hence the warnings are not printed.
+                print('WARNING: QISKit cpp simulator is meant to be built with these '
+                      'platforms: {}. We will support other platforms soon!'
+                      .format(supported_platforms))
+                return
 
-        def compile():
-            self.mkpath('out')
-            os.chdir('out')
-            call(cmd_cmake)
-            call(cmd_make)
-            os.chdir('..')
+            cmd_cmake = ['cmake', '-vvv']
+            if 'USER_LIB_PATH' in os.environ:
+                cmd_cmake.append('-DUSER_LIB_PATH={}'.format(os.environ['USER_LIB_PATH']))
+            if current_platform == 'Windows':
+                # We only support MinGW so far
+                cmd_cmake.append("-GMinGW Makefiles")
+            cmd_cmake.append('..')
 
-        try:
-            self.execute(compile, [], 'Compiling QISKit C++ Simulator')
-        except:
+            cmd_make = ['make', 'pypi_package_copy_qiskit_simulator']
+
+            try:
+                cmd_make.append('-j%d' % cpu_count())
+            except NotImplementedError:
+                print('WARNING: Unable to determine number of CPUs. Using single threaded make.')
+
+            def compile_simulator():
+                self.mkpath('out')
+                os.chdir('out')
+                call(cmd_cmake)
+                call(cmd_make)
+
+            self.execute(compile_simulator, [], 'Compiling QISKit C++ Simulator')
+        except Exception as e:
+            print(str(e))
             print("WARNING: Seems like the cpp simulator can't be built, Qiskit will "
                   "install anyway, but won't have this simulator support.")
-            return
+
+        # Restore working directory.
+        os.chdir(current_directory)
+
 
 # This is for creating wheel specific platforms
 class BinaryDistribution(Distribution):
     def has_ext_modules(self):
         return True
+
 
 setup(
     name="qiskit",


### PR DESCRIPTION
Fix a problem that prevented the installation of the package to succeed
if there was a problem when building the simulator during
`QiskitSimulatorBuild`. The `try`...`except` block could fail leaving
the current working directory modified, as seen in #292: now it is
more robust and ensures the change is undone in case of any failure.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.