### PR TITLE
Some CMake fixes

### DIFF
--- a/src/qiskit-simulator/CMakeLists.txt
+++ b/src/qiskit-simulator/CMakeLists.txt
@@ -46,7 +46,13 @@ enable_cxx_compiler_flag_if_supported("-fopenmp")
 
 # We force static linking on Windows
 if(STATIC_LINKING OR MINGW)
-	enable_cxx_compiler_flag_if_supported("-static")
+	# Hack: Seems like enable_cxx_compiler_flag_if_supported() is not properly
+	# working on MacOS, when a flag is not supported, it cascades errors
+	# to the rest of the flgas being tested... and -static compilation on Mac
+	# with gcc is failing...
+	if(NOT APPLE)
+		enable_cxx_compiler_flag_if_supported("-static")
+	endif()
 	enable_cxx_compiler_flag_if_supported("-static-libstdc++")
 	enable_cxx_compiler_flag_if_supported("-static-libgcc")
 endif()


### PR DESCRIPTION
  * Add a previous step for pypi_package_sdit target, so the 
     qiskit_simulator binary is removed before creating sdist
     distributable package.
* Simplified CMake dependencies
* Fixed MacOS builds for semi-static compilation
* Fixed Linux platform-tag for wheels distributable

## How Has This Been Tested?
These changes are related to the build system, so I have test the locally following these steps:
* Creating an out directory and moving into it.
* Linux: $ cmake .. 
   Mac: $ cmake .. -DCMAKE_CXX_COMPILER=g++-7 ..
* make pypi_package
* Check that distributable packages meet these conditions:
    * qiskit-0.4.9.tar.gz doesn't include the simulator binary (qiskit/backends/qiskit_simulator)
    * qiskit-0.4.9....whl has the correct platform tag on Linux and Mac
    * qiskit_simulator included in Mac wheel, is statically linked with gcc/stdc++ libraries.
  
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.