### PR TITLE
supporting non-string identifiers

### DIFF
--- a/qiskit/_classicalregister.py
+++ b/qiskit/_classicalregister.py
@@ -26,7 +26,7 @@ class ClassicalRegister(Register):
 
     def qasm(self):
         """Return OPENQASM string for this register."""
-        return "creg %s[%d];" % (self.name, self.size)
+        return "creg %s[%d];" % (self.openqasm_name, self.size)
 
     def __str__(self):
         """Return a string representing the register."""

--- a/qiskit/_instruction.py
+++ b/qiskit/_instruction.py
@@ -78,4 +78,4 @@ class Instruction(object):
         """Print an if statement if needed."""
         if self.control is None:
             return string
-        return "if(%s==%d) " % (self.control[0].name, self.control[1]) + string
+        return "if(%s==%d) " % (self.control[0].openqasm_name, self.control[1]) + string

--- a/qiskit/_measure.py
+++ b/qiskit/_measure.py
@@ -32,9 +32,9 @@ class Measure(Instruction):
         """Return OPENQASM string."""
         qubit = self.arg[0]
         bit = self.arg[1]
-        return self._qasmif("measure %s[%d] -> %s[%d];" % (qubit[0].name,
+        return self._qasmif("measure %s[%d] -> %s[%d];" % (qubit[0].openqasm_name,
                                                            qubit[1],
-                                                           bit[0].name,
+                                                           bit[0].openqasm_name,
                                                            bit[1]))
 
     def reapply(self, circuit):

--- a/qiskit/_quantumcircuit.py
+++ b/qiskit/_quantumcircuit.py
@@ -35,8 +35,9 @@ class QuantumCircuit(object):
     # Class variable OPENQASM header
     header = "OPENQASM 2.0;"
 
-    def __init__(self, *regs):
+    def __init__(self, *regs, name=None):
         """Create a new circuit."""
+        self.name = name
         # Data contains a list of instructions in the order they were applied.
         self.data = []
         # This is a map of registers bound to this circuit, by name.
@@ -81,11 +82,15 @@ class QuantumCircuit(object):
 
         Return self + rhs as a new object.
         """
+        if self.name is not None and rhs.name is not None:
+            circuit_name = "c%sN%s" % (self.name, rhs.name)
+        else:
+            circuit_name = None
         for register in rhs.regs.values():
             if not self.has_register(register):
                 raise QISKitError("circuits are not compatible")
         circuit = QuantumCircuit(
-            *[register for register in self.regs.values()])
+            *[register for register in self.regs.values()], name=circuit_name)
         for gate in itertools.chain(self.data, rhs.data):
             gate.reapply(circuit)
         return circuit

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -29,6 +29,7 @@ from threading import Event
 import copy
 
 # use the external IBMQuantumExperience Library
+import itertools
 from IBMQuantumExperience import IBMQuantumExperience
 
 # Local Simulator Modules
@@ -109,6 +110,7 @@ class QuantumProgram(object):
         self.__init_circuit = None  # stores the intial quantum circuit of the program
         self.__ONLINE_BACKENDS = []  # pylint: disable=invalid-name
         self.__LOCAL_BACKENDS = qiskit.backends.local_backends()  # pylint: disable=invalid-name
+        self.__counter = itertools.count()
         self.mapper = mapper
         if specs:
             self.__init_specs(specs)
@@ -177,17 +179,18 @@ class QuantumProgram(object):
                     circuit["quantum_registers"])
                 classicalr = self.create_classical_registers(
                     circuit["classical_registers"])
-                self.create_circuit(name=circuit["name"], qregisters=quantumr,
+                self.create_circuit(name=circuit.get("name"), qregisters=quantumr,
                                     cregisters=classicalr)
-        # TODO: Jay: I think we should return function handles for the
-        # registers and circuit. So that we dont need to get them after we
-        # create them with get_quantum_register etc
+                # TODO: Jay: I think we should return function handles for the
+                # registers and circuit. So that we dont need to get them after we
+                # create them with get_quantum_register etc
 
-    def create_quantum_register(self, name, size):
+    def create_quantum_register(self, name=None, size=1):
         """Create a new Quantum Register.
 
         Args:
-            name (str): the name of the quantum register
+            name (hashable or None): the name of the quantum register. If None, an
+            identifier will be assigned.
             size (int): the size of the quantum register
 
         Returns:
@@ -197,14 +200,18 @@ class QuantumProgram(object):
         Raises:
             QISKitError: if the register already exists in the program.
         """
-        if name in self.__quantum_registers:
+        if name is not None and name in self.__quantum_registers:
             if size != len(self.__quantum_registers[name]):
                 raise QISKitError("Can't make this register: Already in"
                                   " program with different size")
             logger.info(">> quantum_register exists: %s %s", name, size)
-        else:
-            self.__quantum_registers[name] = QuantumRegister(name, size)
-            logger.info(">> new quantum_register created: %s %s", name, size)
+            return self.__quantum_registers[name]
+
+        if name is None:
+            name = self._create_id('q%i', self.__quantum_registers)
+
+        self.__quantum_registers[name] = QuantumRegister(name, size)
+        logger.info(">> new quantum_register created: %s %s", name, size)
         return self.__quantum_registers[name]
 
     def destroy_quantum_register(self, name):
@@ -227,22 +234,20 @@ class QuantumProgram(object):
 
         Args:
             register_array (list[dict]): An array of quantum registers in
-                dictionary format::
-
-                    "quantum_registers": [
-                        {
-                        "name": "qr",
-                        "size": 4
-                        },
+                dictionary format. For example:
+                    [{"name": "qr", "size": 4},
                         ...
                     ]
+                Any other key in the dictionary will be ignored. If "name"
+                is not defined (or None) a random name wil be assigned.
+
         Returns:
             list(QuantumRegister): Array of quantum registers objects
         """
         new_registers = []
         for register in register_array:
             register = self.create_quantum_register(
-                register["name"], register["size"])
+                register.get('name'), register["size"])
             new_registers.append(register)
         return new_registers
 
@@ -251,25 +256,21 @@ class QuantumProgram(object):
 
         Args:
             register_array (list[dict]): An array of quantum registers in
-                dictionary format::
-
-                    "quantum_registers": [
-                        {
-                        "name": "qr",
-                        },
+                dictionary format. For example:
+                    [{"name": "qr"},
                         ...
                     ]
-
-                "size" may be a key for compatibility, but is ignored.
+                Any other key in the dictionary will be ignored.
         """
         for register in register_array:
             self.destroy_quantum_register(register["name"])
 
-    def create_classical_register(self, name, size):
+    def create_classical_register(self, name=None, size=1):
         """Create a new Classical Register.
 
         Args:
-            name (str): the name of the classical register
+            name (hashable or None): the name of the classical register. If None, an
+             identifier will be assigned.
             size (int): the size of the classical register
         Returns:
             ClassicalRegister: internal reference to a classical register
@@ -278,14 +279,18 @@ class QuantumProgram(object):
         Raises:
             QISKitError: if the register already exists in the program.
         """
-        if name in self.__classical_registers:
+        if name is not None and name in self.__classical_registers:
             if size != len(self.__classical_registers[name]):
                 raise QISKitError("Can't make this register: Already in"
                                   " program with different size")
             logger.info(">> classical register exists: %s %s", name, size)
-        else:
-            logger.info(">> new classical register created: %s %s", name, size)
-            self.__classical_registers[name] = ClassicalRegister(name, size)
+            return self.__classical_registers[name]
+
+        if name is None:
+            name = self._create_id('c%i', self.__classical_registers)
+
+        self.__classical_registers[name] = ClassicalRegister(name, size)
+        logger.info(">> new classical register created: %s %s", name, size)
         return self.__classical_registers[name]
 
     def create_classical_registers(self, registers_array):
@@ -293,22 +298,20 @@ class QuantumProgram(object):
 
         Args:
             registers_array (list[dict]): An array of classical registers in
-                dictionary format::
-
-                    "classical_registers": [
-                        {
-                        "name": "qr",
-                        "size": 4
-                        },
+                dictionary format. For example:
+                    [{"name": "cr", "size": 4},
                         ...
                     ]
+                Any other key in the dictionary will be ignored. If "name"
+                is not defined (or None) a random name wil be assigned.
+
         Returns:
             list(ClassicalRegister): Array of clasical registers objects
         """
         new_registers = []
         for register in registers_array:
             new_registers.append(self.create_classical_register(
-                register["name"], register["size"]))
+                register.get("name"), register["size"]))
         return new_registers
 
     def destroy_classical_register(self, name):
@@ -331,25 +334,21 @@ class QuantumProgram(object):
 
         Args:
             registers_array (list[dict]): An array of classical registers in
-                dictionary format::
-
-                    "classical_registers": [
-                        {
-                        "name": "qr",
-                        },
+                dictionary format. For example:
+                    [{"name": "cr"},
                         ...
                     ]
-
-                "size" may be a key for compatibility, but is ignored.
+                Any other key in the dictionary will be ignored.
         """
         for register in registers_array:
             self.destroy_classical_register(register["name"])
 
-    def create_circuit(self, name, qregisters=None, cregisters=None):
+    def create_circuit(self, name=None, qregisters=None, cregisters=None):
         """Create a empty Quantum Circuit in the Quantum Program.
 
         Args:
-            name (str): the name of the circuit.
+            name (hashable or None): the name of the circuit. If None, an
+                identifier will be assigned.
             qregisters (list(QuantumRegister)): is an Array of Quantum
                 Registers by object reference
             cregisters (list(ClassicalRegister)): is an Array of Classical
@@ -359,11 +358,13 @@ class QuantumProgram(object):
             QuantumCircuit: A quantum circuit is created and added to the
                 Quantum Program
         """
+        if name is None:
+            name = self._create_id('qc%i', self.__quantum_program.keys())
         if not qregisters:
             qregisters = []
         if not cregisters:
             cregisters = []
-        quantum_circuit = QuantumCircuit()
+        quantum_circuit = QuantumCircuit(name=name)
         if not self.__init_circuit:
             self.__init_circuit = quantum_circuit
         for register in qregisters:
@@ -387,14 +388,20 @@ class QuantumProgram(object):
             raise QISKitError("Can't destroy this circuit: Not present")
         del self.__quantum_program[name]
 
-    def add_circuit(self, name, quantum_circuit):
+    def add_circuit(self, name=None, quantum_circuit=None):
         """Add a new circuit based on an Object representation.
 
         Args:
-            name (str): the name of the circuit to add.
+            name (hashable or None): the name of the circuit to add. If None, an
+                identifier will be assigned.
             quantum_circuit (QuantumCircuit): a quantum circuit to add to the
                 program-name
         """
+        if name is None:
+            if quantum_circuit.name:
+                name = quantum_circuit.name
+            else:
+                name = quantum_circuit.name = self._create_id('qc%i', self.__quantum_program.keys())
         for qname, qreg in quantum_circuit.get_qregs().items():
             self.create_quantum_register(qname, len(qreg))
         for cname, creg in quantum_circuit.get_cregs().items():
@@ -448,7 +455,7 @@ class QuantumProgram(object):
         node_circuit = qasm.Qasm(data=qasm_string).parse()  # Node (AST)
         if not name:
             # Get a random name if none is given
-            name = "".join([random.choice(string.ascii_letters+string.digits)
+            name = "".join([random.choice(string.ascii_letters + string.digits)
                             for n in range(10)])
         logger.info("circuit name: %s", name)
         logger.info("******************************")
@@ -464,53 +471,78 @@ class QuantumProgram(object):
     # methods to get elements from a QuantumProgram
     ###############################################################
 
-    def get_quantum_register(self, name):
+    def get_quantum_register(self, name=None):
         """Return a Quantum Register by name.
 
         Args:
-            name (str): the name of the quantum register
+            name (hashable or None): the name of the quantum register. If None and there is only
+                one quantum register available, returns that one.
         Returns:
-            QuantumRegister: The quantum register with this name
+            QuantumRegister: The quantum register with this name.
         Raises:
             KeyError: if the quantum register is not on the quantum program.
+            QISKitError: if the register does not exist in the program.
         """
+        if name is None:
+            name = self.get_single_name(self.get_quantum_register_names(), "a quantum register")
         try:
             return self.__quantum_registers[name]
         except KeyError:
             raise KeyError('No quantum register "{0}"'.format(name))
 
-    def get_classical_register(self, name):
+    def get_classical_register(self, name=None):
         """Return a Classical Register by name.
 
         Args:
-            name (str): the name of the classical register
+            name (hashable or None): the name of the classical register. If None and there is only
+                one classical register available, returns that one.
         Returns:
-            ClassicalRegister: The classical register with this name
+            ClassicalRegister: The classical register with this name.
+
         Raises:
             KeyError: if the classical register is not on the quantum program.
+            QISKitError: if the register does not exist in the program.
         """
+        if name is None:
+            name = self.get_single_name(self.get_classical_register_names(), "a classical register")
         try:
             return self.__classical_registers[name]
         except KeyError:
             raise KeyError('No classical register "{0}"'.format(name))
 
+    @staticmethod
+    def get_single_name(list_of_names, str_what="from the list"):
+        '''Selects the only element of the list list_of_names or raise if there is more than one
+        (or None)'''
+        if len(list_of_names) == 1:
+            return list_of_names[0]
+        else:
+            raise QISKitError("You have to select %s to get when there is more"
+                              "than one available" % str_what)
+
     def get_quantum_register_names(self):
         """Return all the names of the quantum Registers."""
-        return self.__quantum_registers.keys()
+        return list(self.__quantum_registers.keys())
 
     def get_classical_register_names(self):
         """Return all the names of the classical Registers."""
-        return self.__classical_registers.keys()
+        return list(self.__classical_registers.keys())
 
-    def get_circuit(self, name):
+    def get_circuit(self, name=None):
         """Return a Circuit Object by name
         Args:
-            name (str): the name of the quantum circuit
+            name (hashable or None): the name of the quantum circuit.
+                If None and there is only one circuit available, returns
+                that one.
         Returns:
             QuantumCircuit: The quantum circuit with this name
+
         Raises:
             KeyError: if the circuit is not on the quantum program.
+            QISKitError: if the register does not exist in the program.
         """
+        if name is None:
+            name = self.get_single_name(self.get_circuit_names(), "a circuit")
         try:
             return self.__quantum_program[name]
         except KeyError:
@@ -518,30 +550,42 @@ class QuantumProgram(object):
 
     def get_circuit_names(self):
         """Return all the names of the quantum circuits."""
-        return self.__quantum_program.keys()
+        return list(self.__quantum_program.keys())
 
-    def get_qasm(self, name):
+    def get_qasm(self, name=None):
         """Get qasm format of circuit by name.
 
         Args:
-            name (str): name of the circuit
+            name (hashable or None): name of the circuit. If None and only one circuit is
+                available, that one is selected.
 
         Returns:
             str: The quantum circuit in qasm format
+
+        Raises:
+            QISKitError: if the register does not exist in the program.
         """
+        if name is None:
+            name = self.get_single_name(self.get_circuit_names(), "a circuit")
         quantum_circuit = self.get_circuit(name)
         return quantum_circuit.qasm()
 
-    def get_qasms(self, list_circuit_name):
+    def get_qasms(self, list_circuit_name=None):
         """Get qasm format of circuit by list of names.
 
         Args:
-            list_circuit_name (list[str]): names of the circuit
+            list_circuit_name (list[str] or None): names of the circuit. If None, it gets all the
+                circuits in the program.
 
         Returns:
             list(QuantumCircuit): List of quantum circuit in qasm format
+
+        Raises:
+            QISKitError: if the register does not exist in the program.
         """
         qasm_source = []
+        if list_circuit_name is None:
+            list_circuit_name = self.get_circuit_names()
         for name in list_circuit_name:
             qasm_source.append(self.get_qasm(name))
         return qasm_source
@@ -908,7 +952,7 @@ class QuantumProgram(object):
     # methods to compile quantum programs into qobj
     ###############################################################
 
-    def compile(self, name_of_circuits, backend="local_qasm_simulator",
+    def compile(self, name_of_circuits=None, backend="local_qasm_simulator",
                 config=None, basis_gates=None, coupling_map=None,
                 initial_layout=None, shots=1024, max_credits=10, seed=None,
                 qobj_id=None, hpc=None):
@@ -918,12 +962,13 @@ class QuantumProgram(object):
         circuits to run on different backends.
 
         Args:
-            name_of_circuits (list[str]): circuit names to be compiled.
+            name_of_circuits (list[hashable] or None): circuit names to be compiled. If None, all
+                the circuits will be compiled.
             backend (str): a string representing the backend to compile to.
             config (dict): a dictionary of configurations parameters for the
                 compiler.
             basis_gates (str): a comma separated string and are the base gates,
-                               which by default are provided by the backend.
+                which by default are provided by the backend.
             coupling_map (dict): A directed graph of coupling::
 
                 {
@@ -1008,7 +1053,7 @@ class QuantumProgram(object):
         # them to go into the config.
         qobj = {}
         if not qobj_id:
-            qobj_id = "".join([random.choice(string.ascii_letters+string.digits)
+            qobj_id = "".join([random.choice(string.ascii_letters + string.digits)
                                for n in range(30)])
         qobj['id'] = qobj_id
         qobj["config"] = {"max_credits": max_credits, 'backend': backend,
@@ -1047,7 +1092,8 @@ class QuantumProgram(object):
         if not coupling_map:
             coupling_map = backend_conf['coupling_map']
         if not name_of_circuits:
-            raise ValueError('"name_of_circuits" must be specified')
+            logger.info('Since not circuits was specified, all the circuits will be compiled.')
+            name_of_circuits = self.get_circuit_names()
         if isinstance(name_of_circuits, str):
             name_of_circuits = [name_of_circuits]
         for name in name_of_circuits:
@@ -1141,7 +1187,7 @@ class QuantumProgram(object):
             instead of the stdout.
 
         Returns:
-            list(str): names of the circuits in `qobj`
+            list(hashable): names of the circuits in `qobj`
         """
         if not qobj:
             print_func("no executions to run")
@@ -1155,7 +1201,7 @@ class QuantumProgram(object):
                 print_func(' ' + key + ': ' + str(qobj['config'][key]))
         for circuit in qobj['circuits']:
             execution_list.append(circuit["name"])
-            print_func('  circuit name: ' + circuit["name"])
+            print_func('  circuit name: ' + str(circuit["name"]))
             print_func('  circuit config:')
             for key in circuit['config']:
                 print_func('   ' + key + ': ' + str(circuit['config'][key]))
@@ -1339,7 +1385,14 @@ class QuantumProgram(object):
                                      callback=callback)
         job_processor.submit()
 
-    def execute(self, name_of_circuits, backend="local_qasm_simulator",
+    def _create_id(self, formatstring, existing):
+        i = next(self.__counter)
+        formatstring = "autoid_" + formatstring
+        if formatstring % i not in existing:
+            return formatstring % i
+        raise QISKitError("Anonymous identifier was not possible to be created")
+
+    def execute(self, name_of_circuits=None, backend="local_qasm_simulator",
                 config=None, wait=5, timeout=60, basis_gates=None,
                 coupling_map=None, initial_layout=None, shots=1024,
                 max_credits=3, seed=None, hpc=None):
@@ -1350,14 +1403,15 @@ class QuantumProgram(object):
         circuits to run on different backends.
 
         Args:
-            name_of_circuits (list[str]): circuit names to be compiled.
-            backend (str): a string representing the backend to compile to
+            name_of_circuits (list[str] or None): circuit names to be executed.
+                If None, all the circuits will be executed.
+            backend (str): a string representing the backend to compile to.
             config (dict): a dictionary of configurations parameters for the
-                compiler
+                compiler.
             wait (int): Time interval to wait between requests for results
             timeout (int): Total time to wait until the execution stops
             basis_gates (str): a comma separated string and are the base gates,
-                               which by default are: u1,u2,u3,cx,id
+                               which by default are: u1,u2,u3,cx,id.
             coupling_map (dict): A directed graph of coupling::
 
                                 {
@@ -1404,7 +1458,7 @@ class QuantumProgram(object):
         # TODO: Jay: currently basis_gates, coupling_map, intial_layout, shots,
         # max_credits, and seed are extra inputs but I would like them to go
         # into the config
-        qobj = self.compile(name_of_circuits, backend=backend, config=config,
+        qobj = self.compile(name_of_circuits=name_of_circuits, backend=backend, config=config,
                             basis_gates=basis_gates,
                             coupling_map=coupling_map, initial_layout=initial_layout,
                             shots=shots, max_credits=max_credits, seed=seed,

--- a/qiskit/_quantumregister.py
+++ b/qiskit/_quantumregister.py
@@ -26,7 +26,7 @@ class QuantumRegister(Register):
 
     def qasm(self):
         """Return OPENQASM string for this register."""
-        return "qreg %s[%d];" % (self.name, self.size)
+        return "qreg %s[%d];" % (self.openqasm_name, self.size)
 
     def __str__(self):
         """Return a string representing the register."""

--- a/qiskit/_register.py
+++ b/qiskit/_register.py
@@ -19,7 +19,11 @@
 Base register reference object.
 """
 import re
+import logging
+
 from ._qiskiterror import QISKitError
+
+logger = logging.getLogger(__name__)
 
 
 class Register(object):
@@ -27,11 +31,9 @@ class Register(object):
 
     def __init__(self, name, size):
         """Create a new generic register."""
-        test = re.compile('[a-z][a-zA-Z0-9_]*')
-        if test.match(name) is None:
-            raise QISKitError("invalid OPENQASM register name")
         self.name = name
         self.size = size
+        self._openqasm_name = None
         if size <= 0:
             raise QISKitError("register size must be positive")
 
@@ -47,6 +49,21 @@ class Register(object):
         """Check that j is a valid index into self."""
         if j < 0 or j >= self.size:
             raise QISKitError("register index out of range")
+
+    @property
+    def openqasm_name(self):
+        """Converts names to strings that are OpenQASM 2.0 complain."""
+        if self._openqasm_name is not None:
+            return self._openqasm_name
+        test = re.compile('[a-z][a-zA-Z0-9_]*')
+        if test.match(str(self.name)) is None:
+            oq_name = "id%i" % id(self.name)
+            logger.info("The name %s is an invalid OpenQASM register name."
+                        "Coverting it to %s", self.name, oq_name)
+            self._openqasm_name = oq_name
+            return oq_name
+        self._openqasm_name = self.name
+        return str(self.name)
 
     def __getitem__(self, key):
         """Return tuple (self, key) if key is valid."""

--- a/qiskit/_reset.py
+++ b/qiskit/_reset.py
@@ -31,7 +31,7 @@ class Reset(Instruction):
     def qasm(self):
         """Return OPENQASM string."""
         qubit = self.arg[0]
-        return self._qasmif("reset %s[%d];" % (qubit[0].name, qubit[1]))
+        return self._qasmif("reset %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
     def reapply(self, circ):
         """Reapply this gate to corresponding qubits in circ."""

--- a/qiskit/_result.py
+++ b/qiskit/_result.py
@@ -159,7 +159,7 @@ class Result(object):
             pass
         raise QISKitError('No  qasm for circuit "{0}"'.format(name))
 
-    def get_data(self, name):
+    def get_data(self, name=None):
         """Get the data of circuit name.
 
         The data format will depend on the backend. For a real device it
@@ -205,6 +205,14 @@ class Result(object):
             else:
                 raise QISKitError(str(exception))
 
+        if name is None:
+            circuits = list([i['name'] for i in self._qobj['circuits']])
+            if len(circuits) == 1:
+                name = circuits[0]
+            else:
+                raise QISKitError("You have to select a circuit when there is more than"
+                                  "one available")
+
         try:
             qobj = self._qobj
             for index in range(len(qobj['circuits'])):
@@ -214,14 +222,16 @@ class Result(object):
             pass
         raise QISKitError('No data for circuit "{0}"'.format(name))
 
-    def get_counts(self, name):
+    def get_counts(self, name=None):
         """Get the histogram data of circuit name.
 
         The data from the a qasm circuit is dictionary of the format
         {'00000': XXXX, '00001': XXXXX}.
 
         Args:
-            name (str): the name of the quantum circuit.
+            name (hashable or None): the name of the quantum circuit.
+                If None and there is only one circuit available, returns
+                that one.
 
         Returns:
             Dictionary: Counts {'00000': XXXX, '00001': XXXXX}.

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -472,13 +472,12 @@ class DAGCircuit:
             if k[0] in keyregs:
                 reg_frag_chk[k[0]][k[1]] = True
         for k, v in reg_frag_chk.items():
-            rname = ",".join(map(str, k))
             s = set(v.values())
             if len(s) == 2:
-                raise DAGCircuitError("wire_map fragments reg %s" % rname)
+                raise DAGCircuitError("wire_map fragments reg %s" % k)
             elif s == set([False]):
                 if k in self.qregs or k in self.cregs:
-                    raise DAGCircuitError("unmapped duplicate reg %s" % rname)
+                    raise DAGCircuitError("unmapped duplicate reg %s" % k)
                 else:
                     # Add registers that appear only in keyregs
                     add_regs.add((k, keyregs[k]))

--- a/qiskit/extensions/standard/barrier.py
+++ b/qiskit/extensions/standard/barrier.py
@@ -42,9 +42,9 @@ class Barrier(Instruction):
         string = "barrier "
         for j in range(len(self.arg)):
             if len(self.arg[j]) == 1:
-                string += "%s" % self.arg[j].name
+                string += "%s" % self.arg[j].openqasm_name
             else:
-                string += "%s[%d]" % (self.arg[j][0].name, self.arg[j][1])
+                string += "%s[%d]" % (self.arg[j][0].openqasm_name, self.arg[j][1])
             if j != len(self.arg) - 1:
                 string += ","
         string += ";"

--- a/qiskit/extensions/standard/ccx.py
+++ b/qiskit/extensions/standard/ccx.py
@@ -36,11 +36,11 @@ class ToffoliGate(Gate):
         ctl1 = self.arg[0]
         ctl2 = self.arg[1]
         tgt = self.arg[2]
-        return self._qasmif("ccx %s[%d],%s[%d],%s[%d];" % (ctl1[0].name,
+        return self._qasmif("ccx %s[%d],%s[%d],%s[%d];" % (ctl1[0].openqasm_name,
                                                            ctl1[1],
-                                                           ctl2[0].name,
+                                                           ctl2[0].openqasm_name,
                                                            ctl2[1],
-                                                           tgt[0].name,
+                                                           tgt[0].openqasm_name,
                                                            tgt[1]))
 
     def inverse(self):

--- a/qiskit/extensions/standard/ch.py
+++ b/qiskit/extensions/standard/ch.py
@@ -38,8 +38,8 @@ class CHGate(Gate):
         """Return OPENQASM string."""
         ctl = self.arg[0]
         tgt = self.arg[1]
-        return self._qasmif("ch %s[%d],%s[%d];" % (ctl[0].name, ctl[1],
-                                                   tgt[0].name, tgt[1]))
+        return self._qasmif("ch %s[%d],%s[%d];" % (ctl[0].openqasm_name, ctl[1],
+                                                   tgt[0].openqasm_name, tgt[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/crz.py
+++ b/qiskit/extensions/standard/crz.py
@@ -38,8 +38,8 @@ class CrzGate(Gate):
         ctl = self.arg[0]
         tgt = self.arg[1]
         theta = self.param[0]
-        return self._qasmif("crz(%s) %s[%d],%s[%d];" % (theta, ctl[0].name, ctl[1],
-                                                        tgt[0].name, tgt[1]))
+        return self._qasmif("crz(%s) %s[%d],%s[%d];" % (theta, ctl[0].openqasm_name, ctl[1],
+                                                        tgt[0].openqasm_name, tgt[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/cu1.py
+++ b/qiskit/extensions/standard/cu1.py
@@ -38,8 +38,8 @@ class Cu1Gate(Gate):
         ctl = self.arg[0]
         tgt = self.arg[1]
         theta = self.param[0]
-        return self._qasmif("cu1(%s) %s[%d],%s[%d];" % (theta, ctl[0].name, ctl[1],
-                                                        tgt[0].name, tgt[1]))
+        return self._qasmif("cu1(%s) %s[%d],%s[%d];" % (theta, ctl[0].openqasm_name, ctl[1],
+                                                        tgt[0].openqasm_name, tgt[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/cu3.py
+++ b/qiskit/extensions/standard/cu3.py
@@ -41,8 +41,8 @@ class Cu3Gate(Gate):
         phi = self.param[1]
         lam = self.param[2]
         return self._qasmif("cu3(%s,%s,%s) %s[%d],%s[%d];" % (theta, phi, lam,
-                                                              ctl[0].name, ctl[1],
-                                                              tgt[0].name, tgt[1]))
+                                                              ctl[0].openqasm_name, ctl[1],
+                                                              tgt[0].openqasm_name, tgt[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/cx.py
+++ b/qiskit/extensions/standard/cx.py
@@ -38,8 +38,8 @@ class CnotGate(Gate):
         """Return OPENQASM string."""
         ctl = self.arg[0]
         tgt = self.arg[1]
-        return self._qasmif("cx %s[%d],%s[%d];" % (ctl[0].name, ctl[1],
-                                                   tgt[0].name, tgt[1]))
+        return self._qasmif("cx %s[%d],%s[%d];" % (ctl[0].openqasm_name, ctl[1],
+                                                   tgt[0].openqasm_name, tgt[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/cxbase.py
+++ b/qiskit/extensions/standard/cxbase.py
@@ -35,8 +35,8 @@ class CXBase(Gate):
         """Return OPENQASM string."""
         ctl = self.arg[0]
         tgt = self.arg[1]
-        return self._qasmif("CX %s[%d],%s[%d];" % (ctl[0].name, ctl[1],
-                                                   tgt[0].name, tgt[1]))
+        return self._qasmif("CX %s[%d],%s[%d];" % (ctl[0].openqasm_name, ctl[1],
+                                                   tgt[0].openqasm_name, tgt[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/cy.py
+++ b/qiskit/extensions/standard/cy.py
@@ -38,8 +38,8 @@ class CyGate(Gate):
         """Return OPENQASM string."""
         ctl = self.arg[0]
         tgt = self.arg[1]
-        return self._qasmif("cy %s[%d],%s[%d];" % (ctl[0].name, ctl[1],
-                                                   tgt[0].name, tgt[1]))
+        return self._qasmif("cy %s[%d],%s[%d];" % (ctl[0].openqasm_name, ctl[1],
+                                                   tgt[0].openqasm_name, tgt[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/cz.py
+++ b/qiskit/extensions/standard/cz.py
@@ -37,8 +37,8 @@ class CzGate(Gate):
         """Return OPENQASM string."""
         ctl = self.arg[0]
         tgt = self.arg[1]
-        return self._qasmif("cz %s[%d],%s[%d];" % (ctl[0].name, ctl[1],
-                                                   tgt[0].name, tgt[1]))
+        return self._qasmif("cz %s[%d],%s[%d];" % (ctl[0].openqasm_name, ctl[1],
+                                                   tgt[0].openqasm_name, tgt[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/h.py
+++ b/qiskit/extensions/standard/h.py
@@ -37,7 +37,7 @@ class HGate(Gate):
     def qasm(self):
         """Return OPENQASM string."""
         qubit = self.arg[0]
-        return self._qasmif("h %s[%d];" % (qubit[0].name, qubit[1]))
+        return self._qasmif("h %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/iden.py
+++ b/qiskit/extensions/standard/iden.py
@@ -37,7 +37,7 @@ class IdGate(Gate):
     def qasm(self):
         """Return OPENQASM string."""
         qubit = self.arg[0]
-        return self._qasmif("id %s[%d];" % (qubit[0].name, qubit[1]))
+        return self._qasmif("id %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/rx.py
+++ b/qiskit/extensions/standard/rx.py
@@ -38,7 +38,7 @@ class RXGate(Gate):
         """Return OPENQASM string."""
         qubit = self.arg[0]
         theta = self.param[0]
-        return self._qasmif("rx(%s) %s[%d];" % (theta, qubit[0].name,
+        return self._qasmif("rx(%s) %s[%d];" % (theta, qubit[0].openqasm_name,
                                                 qubit[1]))
 
     def inverse(self):

--- a/qiskit/extensions/standard/ry.py
+++ b/qiskit/extensions/standard/ry.py
@@ -38,7 +38,7 @@ class RYGate(Gate):
         """Return OPENQASM string."""
         qubit = self.arg[0]
         theta = self.param[0]
-        return self._qasmif("ry(%s) %s[%d];" % (theta, qubit[0].name,
+        return self._qasmif("ry(%s) %s[%d];" % (theta, qubit[0].openqasm_name,
                                                 qubit[1]))
 
     def inverse(self):

--- a/qiskit/extensions/standard/rz.py
+++ b/qiskit/extensions/standard/rz.py
@@ -38,7 +38,7 @@ class RZGate(Gate):
         """Return OPENQASM string."""
         qubit = self.arg[0]
         phi = self.param[0]
-        return self._qasmif("rz(%s) %s[%d];" % (phi, qubit[0].name, qubit[1]))
+        return self._qasmif("rz(%s) %s[%d];" % (phi, qubit[0].openqasm_name, qubit[1]))
 
     def inverse(self):
         """Invert this gate.

--- a/qiskit/extensions/standard/s.py
+++ b/qiskit/extensions/standard/s.py
@@ -44,9 +44,9 @@ class SGate(CompositeGate):
         qubit = self.data[0].arg[0]
         phi = self.data[0].param[0]
         if phi > 0:
-            return self.data[0]._qasmif("s %s[%d];" % (qubit[0].name, qubit[1]))
+            return self.data[0]._qasmif("s %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
-        return self.data[0]._qasmif("sdg %s[%d];" % (qubit[0].name, qubit[1]))
+        return self.data[0]._qasmif("sdg %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
 
 def s(self, q):

--- a/qiskit/extensions/standard/swap.py
+++ b/qiskit/extensions/standard/swap.py
@@ -36,8 +36,8 @@ class SwapGate(Gate):
         """Return OPENQASM string."""
         ctl = self.arg[0]
         tgt = self.arg[1]
-        return self._qasmif("swap %s[%d],%s[%d];" % (ctl[0].name, ctl[1],
-                                                     tgt[0].name, tgt[1]))
+        return self._qasmif("swap %s[%d],%s[%d];" % (ctl[0].openqasm_name, ctl[1],
+                                                     tgt[0].openqasm_name, tgt[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/t.py
+++ b/qiskit/extensions/standard/t.py
@@ -44,9 +44,9 @@ class TGate(CompositeGate):
         qubit = self.data[0].arg[0]
         phi = self.data[0].param[0]
         if phi > 0:
-            return self.data[0]._qasmif("t %s[%d];" % (qubit[0].name, qubit[1]))
+            return self.data[0]._qasmif("t %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
-        return self.data[0]._qasmif("tdg %s[%d];" % (qubit[0].name, qubit[1]))
+        return self.data[0]._qasmif("tdg %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
 
 def t(self, q):

--- a/qiskit/extensions/standard/u0.py
+++ b/qiskit/extensions/standard/u0.py
@@ -38,7 +38,7 @@ class U0Gate(Gate):
         qubit = self.arg[0]
         m = self.param[0]
         return self._qasmif("u0(%f) %s[%d];" % (m,
-                                                qubit[0].name,
+                                                qubit[0].openqasm_name,
                                                 qubit[1]))
 
     def inverse(self):

--- a/qiskit/extensions/standard/u1.py
+++ b/qiskit/extensions/standard/u1.py
@@ -39,7 +39,7 @@ class U1Gate(Gate):
         qubit = self.arg[0]
         theta = self.param[0]
         return self._qasmif("u1(%s) %s[%d];" % (
-            theta, qubit[0].name, qubit[1]))
+            theta, qubit[0].openqasm_name, qubit[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/u2.py
+++ b/qiskit/extensions/standard/u2.py
@@ -41,7 +41,7 @@ class U2Gate(Gate):
         phi = self.param[0]
         lam = self.param[1]
         return self._qasmif("u2(%s,%s) %s[%d];" % (phi, lam,
-                                                   qubit[0].name,
+                                                   qubit[0].openqasm_name,
                                                    qubit[1]))
 
     def inverse(self):

--- a/qiskit/extensions/standard/u3.py
+++ b/qiskit/extensions/standard/u3.py
@@ -41,7 +41,7 @@ class U3Gate(Gate):
         phi = self.param[1]
         lam = self.param[2]
         return self._qasmif("u3(%s,%s,%s) %s[%d];" % (theta, phi, lam,
-                                                      qubit[0].name,
+                                                      qubit[0].openqasm_name,
                                                       qubit[1]))
 
     def inverse(self):

--- a/qiskit/extensions/standard/ubase.py
+++ b/qiskit/extensions/standard/ubase.py
@@ -38,7 +38,7 @@ class UBase(Gate):
         lamb = self.param[2]
         qubit = self.arg[0]
         return self._qasmif("U(%s,%s,%s) %s[%d];" % (
-            theta, phi, lamb, qubit[0].name, qubit[1]))
+            theta, phi, lamb, qubit[0].openqasm_name, qubit[1]))
 
     def inverse(self):
         """Invert this gate.

--- a/qiskit/extensions/standard/x.py
+++ b/qiskit/extensions/standard/x.py
@@ -37,7 +37,7 @@ class XGate(Gate):
     def qasm(self):
         """Return OPENQASM string."""
         qubit = self.arg[0]
-        return self._qasmif("x %s[%d];" % (qubit[0].name, qubit[1]))
+        return self._qasmif("x %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/y.py
+++ b/qiskit/extensions/standard/y.py
@@ -37,7 +37,7 @@ class YGate(Gate):
     def qasm(self):
         """Return OPENQASM string."""
         qubit = self.arg[0]
-        return self._qasmif("y %s[%d];" % (qubit[0].name, qubit[1]))
+        return self._qasmif("y %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/z.py
+++ b/qiskit/extensions/standard/z.py
@@ -37,7 +37,7 @@ class ZGate(Gate):
     def qasm(self):
         """Return OPENQASM string."""
         qubit = self.arg[0]
-        return self._qasmif("z %s[%d];" % (qubit[0].name, qubit[1]))
+        return self._qasmif("z %s[%d];" % (qubit[0].openqasm_name, qubit[1]))
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/unroll/_jsonbackend.py
+++ b/qiskit/unroll/_jsonbackend.py
@@ -46,6 +46,7 @@ The input is a AST and a basis set and returns a json memory object::
 """
 from qiskit.unroll import BackendError
 from qiskit.unroll import UnrollerBackend
+from qiskit import QISKitError
 
 
 class JsonBackend(UnrollerBackend):
@@ -302,10 +303,9 @@ class JsonBackend(UnrollerBackend):
 
     def get_output(self):
         """Returns the generated circuit."""
-        assert self._is_circuit_valid(), """Invalid circuit!
-            Please check the syntax of your circuit.
-            Has the Qasm parsing been called?. e.g: unroller.execute().
-        """
+        if not self._is_circuit_valid():
+            raise QISKitError("Invalid circuit! Please check the syntax of your circuit."
+                              "Has the Qasm parsing been called?. e.g: unroller.execute().")
         return self.circuit
 
     def _is_circuit_valid(self):

--- a/test/python/test_identifiers.py
+++ b/test/python/test_identifiers.py
@@ -1,0 +1,1341 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring,broad-except
+
+# Copyright 2018 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+"""Non-string identifiers for circuit and record identifiers test"""
+
+import unittest
+
+from qiskit import (ClassicalRegister, QISKitError, QuantumCircuit,
+                    QuantumRegister, QuantumProgram)
+from .common import QiskitTestCase
+
+
+class TestAnonymousIds(QiskitTestCase):
+    """Circuits and records can have no name"""
+
+    def setUp(self):
+        self.QPS_SPECS_NONAMES = {
+            "circuits": [{
+                "quantum_registers": [{
+                    "size": 3}],
+                "classical_registers": [{
+                    "size": 3}]
+            }]
+        }
+
+    ###############################################################
+    # Tests to initiate an build a quantum program with anonymous ids
+    ###############################################################
+
+    def test_create_program_with_specsnonames(self):
+        """Test Quantum Object Factory creation using Specs definition
+        object with no names for circuit nor records.
+        """
+        result = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        self.assertIsInstance(result, QuantumProgram)
+
+    def test_create_anonymous_classical_register(self):
+        """Test create_classical_register with no name.
+        """
+        q_program = QuantumProgram()
+        cr = q_program.create_classical_register(size=3)
+        self.assertIsInstance(cr, ClassicalRegister)
+
+    def test_create_anonymous_quantum_register(self):
+        """Test create_quantum_register with no name.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(size=3)
+        self.assertIsInstance(qr, QuantumRegister)
+
+    def test_create_classical_registers_noname(self):
+        """Test create_classical_registers with no name
+        """
+        q_program = QuantumProgram()
+        classical_registers = [{"size": 4},
+                               {"size": 2}]
+        crs = q_program.create_classical_registers(classical_registers)
+        for i in crs:
+            self.assertIsInstance(i, ClassicalRegister)
+
+    def test_create_quantum_registers_noname(self):
+        """Test create_quantum_registers with no name.
+        """
+        q_program = QuantumProgram()
+        quantum_registers = [{"size": 4},
+                             {"size": 2}]
+        qrs = q_program.create_quantum_registers(quantum_registers)
+        for i in qrs:
+            self.assertIsInstance(i, QuantumRegister)
+
+    def test_create_circuit_noname(self):
+        """Test create_circuit with no name
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register("qr", 3)
+        cr = q_program.create_classical_register("cr", 3)
+        qc = q_program.create_circuit(qregisters=[qr], cregisters=[cr])
+        self.assertIsInstance(qc, QuantumCircuit)
+
+    def test_create_several_circuits_noname(self):
+        """Test create_circuit with several inputs and without names.
+        """
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register("qr1", 3)
+        cr1 = q_program.create_classical_register("cr1", 3)
+        qr2 = q_program.create_quantum_register("qr2", 3)
+        cr2 = q_program.create_classical_register("cr2", 3)
+        qc1 = q_program.create_circuit(qregisters=[qr1], cregisters=[cr1])
+        qc2 = q_program.create_circuit(qregisters=[qr2], cregisters=[cr2])
+        qc3 = q_program.create_circuit(qregisters=[qr1, qr2], cregisters=[cr1, cr2])
+        self.assertIsInstance(qc1, QuantumCircuit)
+        self.assertIsInstance(qc2, QuantumCircuit)
+        self.assertIsInstance(qc3, QuantumCircuit)
+
+    def test_get_register_and_circuit_names_nonames(self):
+        """Get the names of the circuits and registers after create them without a name
+        """
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register(size=3)
+        cr1 = q_program.create_classical_register(size=3)
+        qr2 = q_program.create_quantum_register(size=3)
+        cr2 = q_program.create_classical_register(size=3)
+        q_program.create_circuit(qregisters=[qr1], cregisters=[cr1])
+        q_program.create_circuit(qregisters=[qr2], cregisters=[cr2])
+        q_program.create_circuit(qregisters=[qr1, qr2], cregisters=[cr1, cr2])
+        qrn = q_program.get_quantum_register_names()
+        crn = q_program.get_classical_register_names()
+        qcn = q_program.get_circuit_names()
+        self.assertEqual(len(qrn), 2)
+        self.assertEqual(len(crn), 2)
+        self.assertEqual(len(qcn), 3)
+
+    def test_get_circuit_noname(self):
+        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        qc = q_program.get_circuit()
+        self.assertIsInstance(qc, QuantumCircuit)
+
+    def test_get_quantum_register_noname(self):
+        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        qr = q_program.get_quantum_register()
+        self.assertIsInstance(qr, QuantumRegister)
+
+    def test_get_classical_register_noname(self):
+        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        cr = q_program.get_classical_register()
+        self.assertIsInstance(cr, ClassicalRegister)
+
+    def test_get_qasm_noname(self):
+        """Test the get_qasm using an specification without names.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        qc = q_program.get_circuit()
+
+        qrn = list(q_program.get_quantum_register_names())
+        self.assertEqual(len(qrn), 1)
+        qr = q_program.get_quantum_register(qrn[0])
+
+        crn = list(q_program.get_classical_register_names())
+        self.assertEqual(len(crn), 1)
+        cr = q_program.get_classical_register(crn[0])
+
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.cx(qr[1], qr[2])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        qc.measure(qr[2], cr[2])
+        result = q_program.get_qasm()
+        self.assertEqual(len(result), len(qrn[0]) * 9 + len(crn[0]) * 4 + 147)
+
+    def test_get_qasms_noname(self):
+        """Test the get_qasms from a qprogram without names.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(size=3)
+        cr = q_program.create_classical_register(size=3)
+        qc1 = q_program.create_circuit(qregisters=[qr], cregisters=[cr])
+        qc2 = q_program.create_circuit(qregisters=[qr], cregisters=[cr])
+        qc1.h(qr[0])
+        qc1.cx(qr[0], qr[1])
+        qc1.cx(qr[1], qr[2])
+        qc1.measure(qr[0], cr[0])
+        qc1.measure(qr[1], cr[1])
+        qc1.measure(qr[2], cr[2])
+        qc2.h(qr)
+        qc2.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        qc2.measure(qr[2], cr[2])
+        results = dict(zip(q_program.get_circuit_names(), q_program.get_qasms()))
+        qr_name_len = len(qr.openqasm_name)
+        cr_name_len = len(cr.openqasm_name)
+        self.assertEqual(len(results[qc1.name]), qr_name_len * 9 + cr_name_len * 4 + 147)
+        self.assertEqual(len(results[qc2.name]), qr_name_len * 7 + cr_name_len * 4 + 137)
+
+    def test_get_qasm_all_gates(self):
+        """Test the get_qasm for more gates, using an specification without names.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        qc = q_program.get_circuit()
+        qr = q_program.get_quantum_register()
+        cr = q_program.get_classical_register()
+        qc.u1(0.3, qr[0])
+        qc.u2(0.2, 0.1, qr[1])
+        qc.u3(0.3, 0.2, 0.1, qr[2])
+        qc.s(qr[1])
+        qc.s(qr[2]).inverse()
+        qc.cx(qr[1], qr[2])
+        qc.barrier()
+        qc.cx(qr[0], qr[1])
+        qc.h(qr[0])
+        qc.x(qr[2]).c_if(cr, 0)
+        qc.y(qr[2]).c_if(cr, 1)
+        qc.z(qr[2]).c_if(cr, 2)
+        qc.barrier(qr)
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        qc.measure(qr[2], cr[2])
+        result = q_program.get_qasm()
+        self.assertEqual(len(result), (len(qr.openqasm_name) * 23 +
+                                       len(cr.openqasm_name) * 7 +
+                                       385))
+
+    ###############################################################
+    # Test for compile
+    ###############################################################
+
+    def test_compile_program_noname(self):
+        """Test compile with a no name.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        qc = q_program.get_circuit()
+        qr = q_program.get_quantum_register()
+        cr = q_program.get_classical_register()
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        out = q_program.compile()
+        self.log.info(out)
+        self.assertEqual(len(out), 3)
+
+    def test_get_execution_list_noname(self):
+        """Test get_execution_list for circuits without name.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        qc = q_program.get_circuit()
+        qr = q_program.get_quantum_register()
+        cr = q_program.get_classical_register()
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        qobj = q_program.compile()
+        result = q_program.get_execution_list(qobj, print_func=self.log.info)
+        self.assertEqual(len(result), 1)
+
+    def test_change_circuit_qobj_after_compile_noname(self):
+        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        qr = q_program.get_quantum_register()
+        cr = q_program.get_classical_register()
+        qc2 = q_program.create_circuit(qregisters=[qr], cregisters=[cr])
+        qc3 = q_program.create_circuit(qregisters=[qr], cregisters=[cr])
+        qc2.h(qr[0])
+        qc2.cx(qr[0], qr[1])
+        qc2.cx(qr[0], qr[2])
+        qc3.h(qr)
+        qc2.measure(qr, cr)
+        qc3.measure(qr, cr)
+        circuits = [qc2.name, qc3.name]
+        shots = 1024  # the number of shots in the experiment.
+        backend = 'local_qasm_simulator'
+        config = {'seed': 10, 'shots': 1, 'xvals': [1, 2, 3, 4]}
+        qobj1 = q_program.compile(circuits, backend=backend, shots=shots, seed=88, config=config)
+        qobj1['circuits'][0]['config']['shots'] = 50
+        qobj1['circuits'][0]['config']['xvals'] = [1, 1, 1]
+        config['shots'] = 1000
+        config['xvals'][0] = 'only for qobj2'
+        qobj2 = q_program.compile(circuits, backend=backend, shots=shots, seed=88, config=config)
+        self.assertTrue(qobj1['circuits'][0]['config']['shots'] == 50)
+        self.assertTrue(qobj1['circuits'][1]['config']['shots'] == 1)
+        self.assertTrue(qobj1['circuits'][0]['config']['xvals'] == [1, 1, 1])
+        self.assertTrue(qobj1['circuits'][1]['config']['xvals'] == [1, 2, 3, 4])
+        self.assertTrue(qobj1['config']['shots'] == 1024)
+        self.assertTrue(qobj2['circuits'][0]['config']['shots'] == 1000)
+        self.assertTrue(qobj2['circuits'][1]['config']['shots'] == 1000)
+        self.assertTrue(qobj2['circuits'][0]['config']['xvals'] == [
+            'only for qobj2', 2, 3, 4])
+        self.assertTrue(qobj2['circuits'][1]['config']['xvals'] == [
+            'only for qobj2', 2, 3, 4])
+
+    def test_add_circuit_noname(self):
+        """Test add two circuits without names. Also tests get_counts without circuit name.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(size=2)
+        cr = q_program.create_classical_register(size=2)
+        qc1 = q_program.create_circuit(qregisters=[qr], cregisters=[cr])
+        qc2 = q_program.create_circuit(qregisters=[qr], cregisters=[cr])
+        qc1.h(qr[0])
+        qc1.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        new_circuit = qc1 + qc2
+        q_program.add_circuit(quantum_circuit=new_circuit)
+        backend = 'local_qasm_simulator'  # the backend to run on
+        shots = 1024  # the number of shots in the experiment.
+        result = q_program.execute(backend=backend, shots=shots, seed=78)
+        self.assertEqual(result.get_counts(new_circuit.name), {'01': 544, '00': 480})
+        self.assertRaises(QISKitError, result.get_counts)
+
+
+class TestZeroIds(QiskitTestCase):
+    """Circuits and records can have zero as names"""
+
+    def setUp(self):
+        self.QPS_SPECS_ZEROS = {
+            "circuits": [{
+                "name": 0,
+                "quantum_registers": [{
+                    "name": 0,
+                    "size": 3}],
+                "classical_registers": [{
+                    "name": "",
+                    "size": 3}]
+            }]
+        }
+
+    ###############################################################
+    # Tests to initiate an build a quantum program with zeros ids
+    ###############################################################
+
+    def test_create_program_with_specs(self):
+        """Test Quantum Object Factory creation using Specs definition
+        object with zeros names for circuit nor records.
+        """
+        result = QuantumProgram(specs=self.QPS_SPECS_ZEROS)
+        self.assertIsInstance(result, QuantumProgram)
+
+    def test_create_classical_register(self):
+        """Test create_classical_register with zero name
+        """
+        q_program = QuantumProgram()
+        cr = q_program.create_classical_register(0, 3)
+        self.assertIsInstance(cr, ClassicalRegister)
+
+    def test_create_quantum_register(self):
+        """Test create_quantum_register with zero name.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(0, 3)
+        self.assertIsInstance(qr, QuantumRegister)
+
+    def test_fail_create_classical_register_name(self):
+        """Test duplicated create_quantum_register with zeros as names.
+        """
+        q_program = QuantumProgram()
+        cr1 = q_program.create_classical_register(0, 3)
+        self.assertIsInstance(cr1, ClassicalRegister)
+        self.assertRaises(QISKitError,
+                          q_program.create_classical_register, 0, 2)
+
+    def test_create_quantum_register_same(self):
+        """Test create_quantum_register of same name (a zero) and size.
+
+        """
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register(0, 3)
+        qr2 = q_program.create_quantum_register(0, 3)
+        self.assertIs(qr1, qr2)
+
+    def test_create_classical_register_same(self):
+        """Test create_classical_register of same name (a zero) and size.
+        """
+        q_program = QuantumProgram()
+        cr1 = q_program.create_classical_register(0, 3)
+        cr2 = q_program.create_classical_register(0, 3)
+        self.assertIs(cr1, cr2)
+
+    def test_create_classical_registers(self):
+        """Test create_classical_registers with 0 as a name.
+        """
+        q_program = QuantumProgram()
+        classical_registers = [{"name": 0, "size": 4},
+                               {"name": "", "size": 2}]
+        crs = q_program.create_classical_registers(classical_registers)
+        for i in crs:
+            self.assertIsInstance(i, ClassicalRegister)
+
+    def test_create_quantum_registers(self):
+        """Test create_quantum_registers with 0 as names
+        """
+        q_program = QuantumProgram()
+        quantum_registers = [{"name": 0, "size": 4},
+                             {"name": "", "size": 2}]
+        qrs = q_program.create_quantum_registers(quantum_registers)
+        for i in qrs:
+            self.assertIsInstance(i, QuantumRegister)
+
+    def test_destroy_classical_register(self):
+        """Test destroy_classical_register with 0 as name."""
+        q_program = QuantumProgram()
+        _ = q_program.create_classical_register(0, 3)
+        self.assertIn(0, q_program.get_classical_register_names())
+        q_program.destroy_classical_register(0)
+        self.assertNotIn(0, q_program.get_classical_register_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            q_program.destroy_classical_register(0)
+        self.assertIn('Not present', str(context.exception))
+
+    def test_destroy_quantum_register(self):
+        """Test destroy_quantum_register with 0 as name."""
+        q_program = QuantumProgram()
+        _ = q_program.create_quantum_register(0, 3)
+        self.assertIn(0, q_program.get_quantum_register_names())
+        q_program.destroy_quantum_register(0)
+        self.assertNotIn(0, q_program.get_quantum_register_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            q_program.destroy_quantum_register(0)
+        self.assertIn('Not present', str(context.exception))
+
+    def test_create_circuit(self):
+        """Test create_circuit with 0 as a name.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(0, 3)
+        cr = q_program.create_classical_register("", 3)
+        qc = q_program.create_circuit(0, [qr], [cr])
+        self.assertIsInstance(qc, QuantumCircuit)
+
+    def test_create_several_circuits(self):
+        """Test create_circuit with several inputs with int names.
+        """
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register(10, 3)
+        cr1 = q_program.create_classical_register(20, 3)
+        qr2 = q_program.create_quantum_register(11, 3)
+        cr2 = q_program.create_classical_register(21, 3)
+        qc1 = q_program.create_circuit(30, [qr1], [cr1])
+        qc2 = q_program.create_circuit(31, [qr2], [cr2])
+        qc3 = q_program.create_circuit(32, [qr1, qr2], [cr1, cr2])
+        self.assertIsInstance(qc1, QuantumCircuit)
+        self.assertIsInstance(qc2, QuantumCircuit)
+        self.assertIsInstance(qc3, QuantumCircuit)
+
+    def test_destroy_circuit(self):
+        """Test destroy_circuit with an int name."""
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(2, 3)
+        cr = q_program.create_classical_register(1, 3)
+        _ = q_program.create_circuit(10, [qr], [cr])
+        self.assertIn(10, q_program.get_circuit_names())
+        q_program.destroy_circuit(10)
+        self.assertNotIn(10, q_program.get_circuit_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            q_program.destroy_circuit(10)
+        self.assertIn('Not present', str(context.exception))
+
+    def test_get_register_and_circuit_names(self):
+        """Get the names of the circuits and registers when their names are ints.
+        """
+        qr1n = 10
+        qr2n = 11
+        cr1n = 12
+        cr2n = 13
+        qc1n = 14
+        qc2n = 15
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register(qr1n, 3)
+        cr1 = q_program.create_classical_register(cr1n, 3)
+        qr2 = q_program.create_quantum_register(qr2n, 3)
+        cr2 = q_program.create_classical_register(cr2n, 3)
+        q_program.create_circuit(qc1n, [qr1], [cr1])
+        q_program.create_circuit(qc2n, [qr2], [cr2])
+        q_program.create_circuit(qc2n, [qr1, qr2], [cr1, cr2])
+        qrn = q_program.get_quantum_register_names()
+        crn = q_program.get_classical_register_names()
+        qcn = q_program.get_circuit_names()
+        self.assertCountEqual(qrn, [qr1n, qr2n])
+        self.assertCountEqual(crn, [cr1n, cr2n])
+        self.assertCountEqual(qcn, [qc1n, qc2n])
+
+    def test_get_qasm(self):
+        """Test the get_qasm with int name. They need to be coverted to OpenQASM format.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_ZEROS)
+        qc = q_program.get_circuit(0)
+        qr = q_program.get_quantum_register(0)
+        cr = q_program.get_classical_register("")
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.cx(qr[1], qr[2])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        qc.measure(qr[2], cr[2])
+        result = q_program.get_qasm(0)
+        self.assertEqual(len(result), (147 +
+                                       len(qr.openqasm_name) * 9 +
+                                       len(cr.openqasm_name) * 4))
+
+    def test_get_qasms(self):
+        """Test the get_qasms with int names. They need to be coverted to OpenQASM format.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(10, 3)
+        cr = q_program.create_classical_register(20, 3)
+        qc1 = q_program.create_circuit(101, [qr], [cr])
+        qc2 = q_program.create_circuit(102, [qr], [cr])
+        qc1.h(qr[0])
+        qc1.cx(qr[0], qr[1])
+        qc1.cx(qr[1], qr[2])
+        qc1.measure(qr[0], cr[0])
+        qc1.measure(qr[1], cr[1])
+        qc1.measure(qr[2], cr[2])
+        qc2.h(qr)
+        qc2.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        qc2.measure(qr[2], cr[2])
+        result = q_program.get_qasms([101, 102])
+        self.assertEqual(len(result[0]), (147 +
+                                          len(qr.openqasm_name) * 9 +
+                                          len(cr.openqasm_name) * 4))
+        self.assertEqual(len(result[1]), (137 +
+                                          len(qr.openqasm_name) * 7 +
+                                          len(cr.openqasm_name) * 4))
+
+    def test_get_qasm_all_gates(self):
+        """Test the get_qasm for more gates. Names are ints.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_ZEROS)
+        qc = q_program.get_circuit(0)
+        qr = q_program.get_quantum_register(0)
+        cr = q_program.get_classical_register("")
+        qc.u1(0.3, qr[0])
+        qc.u2(0.2, 0.1, qr[1])
+        qc.u3(0.3, 0.2, 0.1, qr[2])
+        qc.s(qr[1])
+        qc.s(qr[2]).inverse()
+        qc.cx(qr[1], qr[2])
+        qc.barrier()
+        qc.cx(qr[0], qr[1])
+        qc.h(qr[0])
+        qc.x(qr[2]).c_if(cr, 0)
+        qc.y(qr[2]).c_if(cr, 1)
+        qc.z(qr[2]).c_if(cr, 2)
+        qc.barrier(qr)
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        qc.measure(qr[2], cr[2])
+        result = q_program.get_qasm(0)
+        self.assertEqual(len(result), (385 +
+                                       len(qr.openqasm_name) * 23 +
+                                       len(cr.openqasm_name) * 7))
+
+    ###############################################################
+    # Test for compile when names are integers
+    ###############################################################
+
+    def test_compile_program(self):
+        """Test compile_program. Names are integers
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_ZEROS)
+        qc = q_program.get_circuit(0)
+        qr = q_program.get_quantum_register(0)
+        cr = q_program.get_classical_register("")
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        backend = 'local_qasm_simulator'
+        coupling_map = None
+        out = q_program.compile([0], backend=backend,
+                                coupling_map=coupling_map, qobj_id='cooljob')
+        self.log.info(out)
+        self.assertEqual(len(out), 3)
+
+    def test_get_execution_list(self):
+        """Test get_execution_list with int names.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_ZEROS)
+        qc = q_program.get_circuit(0)
+        qr = q_program.get_quantum_register(0)
+        cr = q_program.get_classical_register("")
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        backend = 'local_qasm_simulator'
+        coupling_map = None
+        qobj = q_program.compile([0], backend=backend,
+                                 coupling_map=coupling_map, qobj_id='cooljob')
+        result = q_program.get_execution_list(qobj, print_func=self.log.info)
+        self.log.info(result)
+        self.assertEqual(result, [0])
+
+    def test_change_circuit_qobj_after_compile(self):
+        q_program = QuantumProgram(specs=self.QPS_SPECS_ZEROS)
+        qr = q_program.get_quantum_register(0)
+        cr = q_program.get_classical_register("")
+        qc2 = q_program.create_circuit(102, [qr], [cr])
+        qc3 = q_program.create_circuit(103, [qr], [cr])
+        qc2.h(qr[0])
+        qc2.cx(qr[0], qr[1])
+        qc2.cx(qr[0], qr[2])
+        qc3.h(qr)
+        qc2.measure(qr, cr)
+        qc3.measure(qr, cr)
+        circuits = [102, 103]
+        shots = 1024  # the number of shots in the experiment.
+        backend = 'local_qasm_simulator'
+        config = {'seed': 10, 'shots': 1, 'xvals': [1, 2, 3, 4]}
+        qobj1 = q_program.compile(circuits, backend=backend, shots=shots,
+                                  seed=88, config=config)
+        qobj1['circuits'][0]['config']['shots'] = 50
+        qobj1['circuits'][0]['config']['xvals'] = [1, 1, 1]
+        config['shots'] = 1000
+        config['xvals'][0] = 'only for qobj2'
+        qobj2 = q_program.compile(circuits, backend=backend, shots=shots,
+                                  seed=88, config=config)
+        self.assertTrue(qobj1['circuits'][0]['config']['shots'] == 50)
+        self.assertTrue(qobj1['circuits'][1]['config']['shots'] == 1)
+        self.assertTrue(qobj1['circuits'][0]['config']['xvals'] == [1, 1, 1])
+        self.assertTrue(qobj1['circuits'][1]['config']['xvals'] == [1, 2, 3, 4])
+        self.assertTrue(qobj1['config']['shots'] == 1024)
+        self.assertTrue(qobj2['circuits'][0]['config']['shots'] == 1000)
+        self.assertTrue(qobj2['circuits'][1]['config']['shots'] == 1000)
+        self.assertTrue(qobj2['circuits'][0]['config']['xvals'] == [
+            'only for qobj2', 2, 3, 4])
+        self.assertTrue(qobj2['circuits'][1]['config']['xvals'] == [
+            'only for qobj2', 2, 3, 4])
+
+    def test_add_circuit(self):
+        """Test add two circuits with zero names.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(0, 2)
+        cr = q_program.create_classical_register("", 2)
+        qc1 = q_program.create_circuit(0, [qr], [cr])
+        qc2 = q_program.create_circuit("", [qr], [cr])
+        qc1.h(qr[0])
+        qc1.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        new_circuit = qc1 + qc2
+        q_program.add_circuit(1001, new_circuit)
+        circuits = [1001]
+        backend = 'local_qasm_simulator'  # the backend to run on
+        shots = 1024  # the number of shots in the experiment.
+        result = q_program.execute(circuits, backend=backend, shots=shots, seed=78)
+        self.assertEqual(result.get_counts(1001), {'01': 544, '00': 480})
+
+
+class TestIntegerIds(QiskitTestCase):
+    """Circuits and records can have integers as names"""
+
+    def setUp(self):
+        self.QPS_SPECS_INT = {
+            "circuits": [{
+                "name": 1,
+                "quantum_registers": [{
+                    "name": 40,
+                    "size": 3}],
+                "classical_registers": [{
+                    "name": 50,
+                    "size": 3}]
+            }]
+        }
+
+    ###############################################################
+    # Tests to initiate an build a quantum program with integer ids
+    ###############################################################
+
+    def test_create_program_with_specs(self):
+        """Test Quantum Object Factory creation using Specs definition
+        object with int names for circuit nor records.
+        """
+        result = QuantumProgram(specs=self.QPS_SPECS_INT)
+        self.assertIsInstance(result, QuantumProgram)
+
+    def test_create_classical_register(self):
+        """Test create_classical_register with int name
+        """
+        q_program = QuantumProgram()
+        cr = q_program.create_classical_register(42, 3)
+        self.assertIsInstance(cr, ClassicalRegister)
+
+    def test_create_quantum_register(self):
+        """Test create_quantum_register with int name.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(32, 3)
+        self.assertIsInstance(qr, QuantumRegister)
+
+    def test_fail_create_classical_register_name(self):
+        """Test duplicated create_quantum_register with int as names.
+        """
+        q_program = QuantumProgram()
+        cr1 = q_program.create_classical_register(2, 3)
+        self.assertIsInstance(cr1, ClassicalRegister)
+        self.assertRaises(QISKitError,
+                          q_program.create_classical_register, 2, 2)
+
+    def test_create_quantum_register_same(self):
+        """Test create_quantum_register of same int name and size.
+
+        """
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register(1, 3)
+        qr2 = q_program.create_quantum_register(1, 3)
+        self.assertIs(qr1, qr2)
+
+    def test_create_classical_register_same(self):
+        """Test create_classical_register of same int name and size.
+        """
+        q_program = QuantumProgram()
+        cr1 = q_program.create_classical_register(2, 3)
+        cr2 = q_program.create_classical_register(2, 3)
+        self.assertIs(cr1, cr2)
+
+    def test_create_classical_registers(self):
+        """Test create_classical_registers with int name.
+        """
+        q_program = QuantumProgram()
+        classical_registers = [{"name": 1, "size": 4},
+                               {"name": 2, "size": 2}]
+        crs = q_program.create_classical_registers(classical_registers)
+        for i in crs:
+            self.assertIsInstance(i, ClassicalRegister)
+
+    def test_create_quantum_registers(self):
+        """Test create_quantum_registers with int names
+        """
+        q_program = QuantumProgram()
+        quantum_registers = [{"name": 1, "size": 4},
+                             {"name": 2, "size": 2}]
+        qrs = q_program.create_quantum_registers(quantum_registers)
+        for i in qrs:
+            self.assertIsInstance(i, QuantumRegister)
+
+    def test_destroy_classical_register(self):
+        """Test destroy_classical_register with int name."""
+        q_program = QuantumProgram()
+        _ = q_program.create_classical_register(1, 3)
+        self.assertIn(1, q_program.get_classical_register_names())
+        q_program.destroy_classical_register(1)
+        self.assertNotIn(1, q_program.get_classical_register_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            q_program.destroy_classical_register(1)
+        self.assertIn('Not present', str(context.exception))
+
+    def test_destroy_quantum_register(self):
+        """Test destroy_quantum_register with int name."""
+        q_program = QuantumProgram()
+        _ = q_program.create_quantum_register(1, 3)
+        self.assertIn(1, q_program.get_quantum_register_names())
+        q_program.destroy_quantum_register(1)
+        self.assertNotIn(1, q_program.get_quantum_register_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            q_program.destroy_quantum_register(1)
+        self.assertIn('Not present', str(context.exception))
+
+    def test_create_circuit(self):
+        """Test create_circuit with int names.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(1, 3)
+        cr = q_program.create_classical_register(2, 3)
+        qc = q_program.create_circuit(3, [qr], [cr])
+        self.assertIsInstance(qc, QuantumCircuit)
+
+    def test_create_several_circuits(self):
+        """Test create_circuit with several inputs with int names.
+        """
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register(10, 3)
+        cr1 = q_program.create_classical_register(20, 3)
+        qr2 = q_program.create_quantum_register(11, 3)
+        cr2 = q_program.create_classical_register(21, 3)
+        qc1 = q_program.create_circuit(30, [qr1], [cr1])
+        qc2 = q_program.create_circuit(31, [qr2], [cr2])
+        qc3 = q_program.create_circuit(32, [qr1, qr2], [cr1, cr2])
+        self.assertIsInstance(qc1, QuantumCircuit)
+        self.assertIsInstance(qc2, QuantumCircuit)
+        self.assertIsInstance(qc3, QuantumCircuit)
+
+    def test_destroy_circuit(self):
+        """Test destroy_circuit with an int name."""
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(2, 3)
+        cr = q_program.create_classical_register(1, 3)
+        _ = q_program.create_circuit(10, [qr], [cr])
+        self.assertIn(10, q_program.get_circuit_names())
+        q_program.destroy_circuit(10)
+        self.assertNotIn(10, q_program.get_circuit_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            q_program.destroy_circuit(10)
+        self.assertIn('Not present', str(context.exception))
+
+    def test_get_register_and_circuit_names(self):
+        """Get the names of the circuits and registers when their names are ints.
+        """
+        qr1n = 10
+        qr2n = 11
+        cr1n = 12
+        cr2n = 13
+        qc1n = 14
+        qc2n = 15
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register(qr1n, 3)
+        cr1 = q_program.create_classical_register(cr1n, 3)
+        qr2 = q_program.create_quantum_register(qr2n, 3)
+        cr2 = q_program.create_classical_register(cr2n, 3)
+        q_program.create_circuit(qc1n, [qr1], [cr1])
+        q_program.create_circuit(qc2n, [qr2], [cr2])
+        q_program.create_circuit(qc2n, [qr1, qr2], [cr1, cr2])
+        qrn = q_program.get_quantum_register_names()
+        crn = q_program.get_classical_register_names()
+        qcn = q_program.get_circuit_names()
+        self.assertCountEqual(qrn, [qr1n, qr2n])
+        self.assertCountEqual(crn, [cr1n, cr2n])
+        self.assertCountEqual(qcn, [qc1n, qc2n])
+
+    def test_get_qasm(self):
+        """Test the get_qasm with int name. They need to be coverted to OpenQASM format.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_INT)
+        qc = q_program.get_circuit(1)
+        qr = q_program.get_quantum_register(40)
+        cr = q_program.get_classical_register(50)
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.cx(qr[1], qr[2])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        qc.measure(qr[2], cr[2])
+        result = q_program.get_qasm(1)
+        self.assertEqual(len(result), (147 +
+                                       len(qr.openqasm_name) * 9 +
+                                       len(cr.openqasm_name) * 4))
+
+    def test_get_qasms(self):
+        """Test the get_qasms with int names. They need to be coverted to OpenQASM format.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(10, 3)
+        cr = q_program.create_classical_register(20, 3)
+        qc1 = q_program.create_circuit(101, [qr], [cr])
+        qc2 = q_program.create_circuit(102, [qr], [cr])
+        qc1.h(qr[0])
+        qc1.cx(qr[0], qr[1])
+        qc1.cx(qr[1], qr[2])
+        qc1.measure(qr[0], cr[0])
+        qc1.measure(qr[1], cr[1])
+        qc1.measure(qr[2], cr[2])
+        qc2.h(qr)
+        qc2.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        qc2.measure(qr[2], cr[2])
+        result = q_program.get_qasms([101, 102])
+        self.assertEqual(len(result[0]), (147 +
+                                          len(qr.openqasm_name) * 9 +
+                                          len(cr.openqasm_name) * 4))
+        self.assertEqual(len(result[1]), (137 +
+                                          len(qr.openqasm_name) * 7 +
+                                          len(cr.openqasm_name) * 4))
+
+    def test_get_qasm_all_gates(self):
+        """Test the get_qasm for more gates. Names are ints.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_INT)
+        qc = q_program.get_circuit(1)
+        qr = q_program.get_quantum_register(40)
+        cr = q_program.get_classical_register(50)
+        qc.u1(0.3, qr[0])
+        qc.u2(0.2, 0.1, qr[1])
+        qc.u3(0.3, 0.2, 0.1, qr[2])
+        qc.s(qr[1])
+        qc.s(qr[2]).inverse()
+        qc.cx(qr[1], qr[2])
+        qc.barrier()
+        qc.cx(qr[0], qr[1])
+        qc.h(qr[0])
+        qc.x(qr[2]).c_if(cr, 0)
+        qc.y(qr[2]).c_if(cr, 1)
+        qc.z(qr[2]).c_if(cr, 2)
+        qc.barrier(qr)
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        qc.measure(qr[2], cr[2])
+        result = q_program.get_qasm(1)
+        self.assertEqual(len(result), (385 +
+                                       len(qr.openqasm_name) * 23 +
+                                       len(cr.openqasm_name) * 7))
+
+    ###############################################################
+    # Test for compile when names are integers
+    ###############################################################
+
+    def test_compile_program(self):
+        """Test compile_program. Names are integers
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_INT)
+        qc = q_program.get_circuit(1)
+        qr = q_program.get_quantum_register(40)
+        cr = q_program.get_classical_register(50)
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        backend = 'local_qasm_simulator'
+        coupling_map = None
+        out = q_program.compile([1], backend=backend,
+                                coupling_map=coupling_map, qobj_id='cooljob')
+        self.log.info(out)
+        self.assertEqual(len(out), 3)
+
+    def test_get_execution_list(self):
+        """Test get_execution_list with int names.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_INT)
+        qc = q_program.get_circuit(1)
+        qr = q_program.get_quantum_register(40)
+        cr = q_program.get_classical_register(50)
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        backend = 'local_qasm_simulator'
+        coupling_map = None
+        qobj = q_program.compile([1], backend=backend,
+                                 coupling_map=coupling_map, qobj_id='cooljob')
+        result = q_program.get_execution_list(qobj, print_func=self.log.info)
+        self.log.info(result)
+        self.assertEqual(result, [1])
+
+    def test_change_circuit_qobj_after_compile(self):
+        q_program = QuantumProgram(specs=self.QPS_SPECS_INT)
+        qr = q_program.get_quantum_register(40)
+        cr = q_program.get_classical_register(50)
+        qc2 = q_program.create_circuit(102, [qr], [cr])
+        qc3 = q_program.create_circuit(103, [qr], [cr])
+        qc2.h(qr[0])
+        qc2.cx(qr[0], qr[1])
+        qc2.cx(qr[0], qr[2])
+        qc3.h(qr)
+        qc2.measure(qr, cr)
+        qc3.measure(qr, cr)
+        circuits = [102, 103]
+        shots = 1024  # the number of shots in the experiment.
+        backend = 'local_qasm_simulator'
+        config = {'seed': 10, 'shots': 1, 'xvals': [1, 2, 3, 4]}
+        qobj1 = q_program.compile(circuits, backend=backend, shots=shots,
+                                  seed=88, config=config)
+        qobj1['circuits'][0]['config']['shots'] = 50
+        qobj1['circuits'][0]['config']['xvals'] = [1, 1, 1]
+        config['shots'] = 1000
+        config['xvals'][0] = 'only for qobj2'
+        qobj2 = q_program.compile(circuits, backend=backend, shots=shots,
+                                  seed=88, config=config)
+        self.assertTrue(qobj1['circuits'][0]['config']['shots'] == 50)
+        self.assertTrue(qobj1['circuits'][1]['config']['shots'] == 1)
+        self.assertTrue(qobj1['circuits'][0]['config']['xvals'] == [1, 1, 1])
+        self.assertTrue(qobj1['circuits'][1]['config']['xvals'] == [1, 2, 3, 4])
+        self.assertTrue(qobj1['config']['shots'] == 1024)
+        self.assertTrue(qobj2['circuits'][0]['config']['shots'] == 1000)
+        self.assertTrue(qobj2['circuits'][1]['config']['shots'] == 1000)
+        self.assertTrue(qobj2['circuits'][0]['config']['xvals'] == [
+            'only for qobj2', 2, 3, 4])
+        self.assertTrue(qobj2['circuits'][1]['config']['xvals'] == [
+            'only for qobj2', 2, 3, 4])
+
+    def test_add_circuit(self):
+        """Test add two circuits with int names.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(1, 2)
+        cr = q_program.create_classical_register(2, 2)
+        qc1 = q_program.create_circuit(10, [qr], [cr])
+        qc2 = q_program.create_circuit(20, [qr], [cr])
+        qc1.h(qr[0])
+        qc1.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        new_circuit = qc1 + qc2
+        q_program.add_circuit(1001, new_circuit)
+        # new_circuit.measure(qr[0], cr[0])
+        circuits = [1001]
+        backend = 'local_qasm_simulator'  # the backend to run on
+        shots = 1024  # the number of shots in the experiment.
+        result = q_program.execute(circuits, backend=backend, shots=shots,
+                                   seed=78)
+        self.assertEqual(result.get_counts(1001), {'01': 544, '00': 480})
+
+
+class TestTupleIds(QiskitTestCase):
+    """Circuits and records can have tuples as names"""
+
+    def setUp(self):
+        self.QPS_SPECS_TUPLE = {
+            "circuits": [{
+                "name": (1.1, 1j),
+                "quantum_registers": [{
+                    "name": (40.1, 40j),
+                    "size": 3}],
+                "classical_registers": [{
+                    "name": (50.1, 50j),
+                    "size": 3}]
+            }]
+        }
+
+    ###############################################################
+    # Tests to initiate an build a quantum program with tuple ids
+    ###############################################################
+
+    def test_create_program_with_specs(self):
+        """Test Quantum Object Factory creation using Specs definition
+        object with tuple names for circuit nor records.
+        """
+        result = QuantumProgram(specs=self.QPS_SPECS_TUPLE)
+        self.assertIsInstance(result, QuantumProgram)
+
+    def test_create_classical_register(self):
+        """Test create_classical_register with tuple name
+        """
+        q_program = QuantumProgram()
+        cr = q_program.create_classical_register((50.1, 50j), 3)
+        self.assertIsInstance(cr, ClassicalRegister)
+
+    def test_create_quantum_register(self):
+        """Test create_quantum_register with tuple name.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register((32.1, 32j), 3)
+        self.assertIsInstance(qr, QuantumRegister)
+
+    def test_fail_create_classical_register_name(self):
+        """Test duplicated create_quantum_register with int as names.
+        """
+        q_program = QuantumProgram()
+        cr1 = q_program.create_classical_register((2.1, 2j), 3)
+        self.assertIsInstance(cr1, ClassicalRegister)
+        self.assertRaises(QISKitError,
+                          q_program.create_classical_register, (2.1, 2j), 2)
+
+    def test_create_quantum_register_same(self):
+        """Test create_quantum_register of same tuple name and size.
+
+        """
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register((1.1, 1j), 3)
+        qr2 = q_program.create_quantum_register((1.1, 1j), 3)
+        self.assertIs(qr1, qr2)
+
+    def test_create_classical_register_same(self):
+        """Test create_classical_register of same tuple name and size.
+        """
+        q_program = QuantumProgram()
+        cr1 = q_program.create_classical_register((2.1, 2j), 3)
+        cr2 = q_program.create_classical_register((2.1, 2j), 3)
+        self.assertIs(cr1, cr2)
+
+    def test_create_classical_registers(self):
+        """Test create_classical_registers with tuple name.
+        """
+        q_program = QuantumProgram()
+        classical_registers = [{"name": (1.1, 1j), "size": 4},
+                               {"name": (2.1, 2j), "size": 2}]
+        crs = q_program.create_classical_registers(classical_registers)
+        for i in crs:
+            self.assertIsInstance(i, ClassicalRegister)
+
+    def test_create_quantum_registers(self):
+        """Test create_quantum_registers with tuple names
+        """
+        q_program = QuantumProgram()
+        quantum_registers = [{"name": (1.1, 1j), "size": 4},
+                             {"name": (2.1, 2j), "size": 2}]
+        qrs = q_program.create_quantum_registers(quantum_registers)
+        for i in qrs:
+            self.assertIsInstance(i, QuantumRegister)
+
+    def test_destroy_classical_register(self):
+        """Test destroy_classical_register with tuple name."""
+        q_program = QuantumProgram()
+        _ = q_program.create_classical_register((1.1, 1j), 3)
+        self.assertIn((1.1, 1j), q_program.get_classical_register_names())
+        q_program.destroy_classical_register((1.1, 1j))
+        self.assertNotIn((1.1, 1j), q_program.get_classical_register_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            q_program.destroy_classical_register((1.1, 1j))
+        self.assertIn('Not present', str(context.exception))
+
+    def test_destroy_quantum_register(self):
+        """Test destroy_quantum_register with tuple name."""
+        q_program = QuantumProgram()
+        _ = q_program.create_quantum_register((1.1, 1j), 3)
+        self.assertIn((1.1, 1j), q_program.get_quantum_register_names())
+        q_program.destroy_quantum_register((1.1, 1j))
+        self.assertNotIn((1.1, 1j), q_program.get_quantum_register_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            q_program.destroy_quantum_register((1.1, 1j))
+        self.assertIn('Not present', str(context.exception))
+
+    def test_create_circuit(self):
+        """Test create_circuit with tuple names.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register((1.1, 1j), 3)
+        cr = q_program.create_classical_register((2.1, 2j), 3)
+        qc = q_program.create_circuit((3.1, 3j), [qr], [cr])
+        self.assertIsInstance(qc, QuantumCircuit)
+
+    def test_create_several_circuits(self):
+        """Test create_circuit with several inputs with tuple names.
+        """
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register((10.1, 10j), 3)
+        cr1 = q_program.create_classical_register((20.1, 20j), 3)
+        qr2 = q_program.create_quantum_register((11.1, 11j), 3)
+        cr2 = q_program.create_classical_register((21.1, 21j), 3)
+        qc1 = q_program.create_circuit((30.1, 30j), [qr1], [cr1])
+        qc2 = q_program.create_circuit((31.1, 31j), [qr2], [cr2])
+        qc3 = q_program.create_circuit((32.1, 32j), [qr1, qr2], [cr1, cr2])
+        self.assertIsInstance(qc1, QuantumCircuit)
+        self.assertIsInstance(qc2, QuantumCircuit)
+        self.assertIsInstance(qc3, QuantumCircuit)
+
+    def test_destroy_circuit(self):
+        """Test destroy_circuit with an tuple name."""
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register((2.1, 2j), 3)
+        cr = q_program.create_classical_register((1.1, 1j), 3)
+        _ = q_program.create_circuit((10.1, 10j), [qr], [cr])
+        self.assertIn((10.1, 10j), q_program.get_circuit_names())
+        q_program.destroy_circuit((10.1, 10j))
+        self.assertNotIn((10.1, 10j), q_program.get_circuit_names())
+
+        # Destroying an invalid register should fail.
+        with self.assertRaises(QISKitError) as context:
+            q_program.destroy_circuit((10.1, 10j))
+        self.assertIn('Not present', str(context.exception))
+
+    def test_get_register_and_circuit_names(self):
+        """Get the names of the circuits and registers when their names are ints.
+        """
+        qr1n = (10.1, 10j)
+        qr2n = (11.1, 11j)
+        cr1n = (12.1, 12j)
+        cr2n = (13.1, 13j)
+        qc1n = (14.1, 14j)
+        qc2n = (15.1, 15j)
+        q_program = QuantumProgram()
+        qr1 = q_program.create_quantum_register(qr1n, 3)
+        cr1 = q_program.create_classical_register(cr1n, 3)
+        qr2 = q_program.create_quantum_register(qr2n, 3)
+        cr2 = q_program.create_classical_register(cr2n, 3)
+        q_program.create_circuit(qc1n, [qr1], [cr1])
+        q_program.create_circuit(qc2n, [qr2], [cr2])
+        q_program.create_circuit(qc2n, [qr1, qr2], [cr1, cr2])
+        qrn = q_program.get_quantum_register_names()
+        crn = q_program.get_classical_register_names()
+        qcn = q_program.get_circuit_names()
+        self.assertCountEqual(qrn, [qr1n, qr2n])
+        self.assertCountEqual(crn, [cr1n, cr2n])
+        self.assertCountEqual(qcn, [qc1n, qc2n])
+
+    def test_get_qasm(self):
+        """Test the get_qasm with tuple name. They need to be coverted to OpenQASM format.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_TUPLE)
+        qc = q_program.get_circuit((1.1, 1j))
+        qr = q_program.get_quantum_register((40.1, 40j))
+        cr = q_program.get_classical_register((50.1, 50j))
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.cx(qr[1], qr[2])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        qc.measure(qr[2], cr[2])
+        result = q_program.get_qasm((1.1, 1j))
+        self.assertEqual(len(qr.openqasm_name) * 9 +
+                         len(cr.openqasm_name) * 4 + 147, len(result))
+
+    def test_get_qasms(self):
+        """Test the get_qasms with tuple names. They need to be coverted to OpenQASM format.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register((10.1, 10j), 3)
+        cr = q_program.create_classical_register((20.1, 20j), 3)
+        qc1 = q_program.create_circuit((101.1, 101j), [qr], [cr])
+        qc2 = q_program.create_circuit((102.1, 102j), [qr], [cr])
+        qc1.h(qr[0])
+        qc1.cx(qr[0], qr[1])
+        qc1.cx(qr[1], qr[2])
+        qc1.measure(qr[0], cr[0])
+        qc1.measure(qr[1], cr[1])
+        qc1.measure(qr[2], cr[2])
+        qc2.h(qr)
+        qc2.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        qc2.measure(qr[2], cr[2])
+        result = q_program.get_qasms([(101.1, 101j), (102.1, 102j)])
+        self.assertEqual(len(qr.openqasm_name) * 9 +
+                         len(cr.openqasm_name) * 4 + 147, len(result[0]))
+        self.assertEqual(len(qr.openqasm_name) * 7 +
+                         len(cr.openqasm_name) * 4 + 137, len(result[1]))
+
+    def test_get_qasm_all_gates(self):
+        """Test the get_qasm for more gates. Names are tuples.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_TUPLE)
+        qc = q_program.get_circuit((1.1, 1j))
+        qr = q_program.get_quantum_register((40.1, 40j))
+        cr = q_program.get_classical_register((50.1, 50j))
+        qc.u1(0.3, qr[0])
+        qc.u2(0.2, 0.1, qr[1])
+        qc.u3(0.3, 0.2, 0.1, qr[2])
+        qc.s(qr[1])
+        qc.s(qr[2]).inverse()
+        qc.cx(qr[1], qr[2])
+        qc.barrier()
+        qc.cx(qr[0], qr[1])
+        qc.h(qr[0])
+        qc.x(qr[2]).c_if(cr, 0)
+        qc.y(qr[2]).c_if(cr, 1)
+        qc.z(qr[2]).c_if(cr, 2)
+        qc.barrier(qr)
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        qc.measure(qr[2], cr[2])
+        result = q_program.get_qasm((1.1, 1j))
+        self.assertEqual(len(qr.openqasm_name) * 23 +
+                         len(cr.openqasm_name) * 7 + 385, len(result))
+
+    ###############################################################
+    # Test for compile when names are tuples
+    ###############################################################
+
+    def test_compile_program(self):
+        """Test compile_program. Names are tuples
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_TUPLE)
+        qc = q_program.get_circuit((1.1, 1j))
+        qr = q_program.get_quantum_register((40.1, 40j))
+        cr = q_program.get_classical_register((50.1, 50j))
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        backend = 'local_qasm_simulator'
+        coupling_map = None
+        out = q_program.compile([(1.1, 1j)], backend=backend,
+                                coupling_map=coupling_map, qobj_id='cooljob')
+        self.log.info(out)
+        self.assertEqual(len(out), 3)
+
+    def test_get_execution_list(self):
+        """Test get_execution_list with tuple names.
+        """
+        q_program = QuantumProgram(specs=self.QPS_SPECS_TUPLE)
+        qc = q_program.get_circuit((1.1, 1j))
+        qr = q_program.get_quantum_register((40.1, 40j))
+        cr = q_program.get_classical_register((50.1, 50j))
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        backend = 'local_qasm_simulator'
+        coupling_map = None
+        qobj = q_program.compile([(1.1, 1j)], backend=backend,
+                                 coupling_map=coupling_map, qobj_id='cooljob')
+        result = q_program.get_execution_list(qobj, print_func=self.log.info)
+        self.log.info(result)
+        self.assertCountEqual(result, [(1.1, 1j)])
+
+    def test_change_circuit_qobj_after_compile(self):
+        q_program = QuantumProgram(specs=self.QPS_SPECS_TUPLE)
+        qr = q_program.get_quantum_register((40.1, 40j))
+        cr = q_program.get_classical_register((50.1, 50j))
+        qc2 = q_program.create_circuit((102.1, 102j), [qr], [cr])
+        qc3 = q_program.create_circuit((103.1, 103j), [qr], [cr])
+        qc2.h(qr[0])
+        qc2.cx(qr[0], qr[1])
+        qc2.cx(qr[0], qr[2])
+        qc3.h(qr)
+        qc2.measure(qr, cr)
+        qc3.measure(qr, cr)
+        circuits = [(102.1, 102j), (103.1, 103j)]
+        shots = 1024  # the number of shots in the experiment.
+        backend = 'local_qasm_simulator'
+        config = {'seed': 10, 'shots': 1, 'xvals': [1, 2, 3, 4]}
+        qobj1 = q_program.compile(circuits, backend=backend, shots=shots,
+                                  seed=88, config=config)
+        qobj1['circuits'][0]['config']['shots'] = 50
+        qobj1['circuits'][0]['config']['xvals'] = [1, 1, 1]
+        config['shots'] = 1000
+        config['xvals'][0] = 'only for qobj2'
+        qobj2 = q_program.compile(circuits, backend=backend, shots=shots,
+                                  seed=88, config=config)
+        self.assertTrue(qobj1['circuits'][0]['config']['shots'] == 50)
+        self.assertTrue(qobj1['circuits'][1]['config']['shots'] == 1)
+        self.assertTrue(qobj1['circuits'][0]['config']['xvals'] == [1, 1, 1])
+        self.assertTrue(qobj1['circuits'][1]['config']['xvals'] == [1, 2, 3, 4])
+        self.assertTrue(qobj1['config']['shots'] == 1024)
+        self.assertTrue(qobj2['circuits'][0]['config']['shots'] == 1000)
+        self.assertTrue(qobj2['circuits'][1]['config']['shots'] == 1000)
+        self.assertTrue(qobj2['circuits'][0]['config']['xvals'] == [
+            'only for qobj2', 2, 3, 4])
+        self.assertTrue(qobj2['circuits'][1]['config']['xvals'] == [
+            'only for qobj2', 2, 3, 4])
+
+    def test_add_circuit(self):
+        """Test add two circuits with tuple names.
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register(1, 2)
+        cr = q_program.create_classical_register(2, 2)
+        qc1 = q_program.create_circuit((10.1, 10j), [qr], [cr])
+        qc2 = q_program.create_circuit((20.1, 20j), [qr], [cr])
+        qc1.h(qr[0])
+        qc1.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        new_circuit = qc1 + qc2
+        q_program.add_circuit((1001.1, 1001j), new_circuit)
+        circuits = [(1001.1, 1001j)]
+        backend = 'local_qasm_simulator'  # the backend to run on
+        shots = 1024  # the number of shots in the experiment.
+        result = q_program.execute(circuits, backend=backend, shots=shots,
+                                   seed=78)
+        self.assertEqual(result.get_counts((1001.1, 1001j)), {'00': 480, '01': 544})
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/python/test_identifiers.py
+++ b/test/python/test_identifiers.py
@@ -42,7 +42,7 @@ class TestAnonymousIds(QiskitTestCase):
     # Tests to initiate an build a quantum program with anonymous ids
     ###############################################################
 
-    def test_create_program_with_specsnonames(self):
+    def test_create_program_with_specs_nonames(self):
         """Test Quantum Object Factory creation using Specs definition
         object with no names for circuit nor records.
         """

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -400,9 +400,9 @@ class TestQuantumProgram(QiskitTestCase):
         qrn = q_program.get_quantum_register_names()
         crn = q_program.get_classical_register_names()
         qcn = q_program.get_circuit_names()
-        self.assertEqual(qrn, {'qr1', 'qr2'})
-        self.assertEqual(crn, {'cr1', 'cr2'})
-        self.assertEqual(qcn, {'qc1', 'qc2'})
+        self.assertCountEqual(qrn, ['qr1', 'qr2'])
+        self.assertCountEqual(crn, ['cr1', 'cr2'])
+        self.assertCountEqual(qcn, ['qc1', 'qc2'])
 
     def test_get_qasm(self):
         """Test the get_qasm.


### PR DESCRIPTION
This PR allows using any kind of hashable (or `None`!) as a circuit name or register name.

## Description
 - Any kind of hashable-type can be used as an identifier. Example: `qp.create_quantum_register(2, 3)` creates a 3-bit long quantum register with name `2`, the integer.
 - Because the [OpenQASM specification](https://github.com/QISKit/openqasm/) defines clearly the regex for an identifier (`id := [a-z][A-Za-z0-9_]*`, p22), no-string-typed identifiers are converted to this format when they are dump to QASM. This conversion is notified via logger (at info level) and is only performed once per identifier. 
 - If you dont care about the names, you can just ignore that parameter.  Example: `qr = qp.create_quantum_register(size=3)` creates a 3-bit long quantum register without any specific name. Internally, a string-typed name is created (which do not collide with existing names) and can be fetch with `qr.name`.
 - Going nameless allows `QuantumProgram` and `Result` to be more intuitive in some methods. For example, if you executed only one circuit, `get_counts()` will return the counts for that circuit without requiring the name.

## Motivation and Context

One of the goals of QISKit is to provide a high-level interface to quantum programmers. Since it was so harnessed to OpenQASM it was natural to lift some of the QASM details to the user-space. As QISKit is moving out from this attachment (see, for example, #273), many of the low-level details are not necessary to expose any more. At least by default. Identifiers are one of those details.

Coders starting with QISKit see identifiers are unnecessarily or limiting (see #290). They are counter-intuitive for first timers. This PR allows, for example, to simplify the HelloWorld program from [qiskit.org](www.qiskit.org) to:

```
from qiskit import QuantumProgram
bell = QuantumProgram()
qr = bell.create_quantum_register(size=2)
cr = bell.create_classical_register(size=2)
qc = bell.create_circuit(qregisters=[qr],cregisters=[cr])
qc.h(qr[0])
qc.cx(qr[0], qr[1])
qc.measure(qr[0], cr[0])
qc.measure(qr[1], cr[1])
result = bell.execute()
print(result.get_counts())
```

In addition, it pushed the OpenQASM identifier limitations to the point where it is relevant, i.e. when the high-level code needs to be converted to a QASM format. Identifiers can be almost anything now (fixes #290).

## How Has This Been Tested?
This PR does not break backwards compatibility.
New tests were added to show and test the extra functionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)