### PR TITLE
Bump IBMQuantumExperience dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-IBMQuantumExperience>=1.8.26
+IBMQuantumExperience>=1.8.28
 matplotlib>=2.1,<2.2
 networkx>=1.11,<2.1
 numpy>=1.13,<1.15

--- a/setup.py.in
+++ b/setup.py.in
@@ -27,7 +27,7 @@ from setuptools.dist import Distribution
 
 
 requirements = [
-    "IBMQuantumExperience>=1.8.26",
+    "IBMQuantumExperience>=1.8.28",
     "matplotlib>=2.1,<2.2",
     "networkx>=1.11,<2.1",
     "numpy>=1.13,<1.15",


### PR DESCRIPTION
Bump the required version of `IBMQuantumExperience` version to `1.8.28`, as it
includes a fix for the latest errors with hpc and ibmqx2 backends.

This needs to be included in the next stable release - in the meantime, please use `pip install -U qiskit` to automatically update the dependencies to their latest versions.