### PR TITLE
Fixed circuit drawing

### DIFF
--- a/qiskit/tools/visualization.py
+++ b/qiskit/tools/visualization.py
@@ -683,7 +683,7 @@ def plot_wigner_data(wigner_data, phis=None, method=None):
 ###############################################################
 
 
-def plot_circuit(circuit, basis="u1,u2,u3,id,cx,x,y,z,h,s,sdg,t,tdg,rx,ry,rz"):
+def plot_circuit(circuit, basis="u1,u2,u3,id,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,cx,cy,cz,swap,ch,ccx,crz,cu1,cu3"):
     """Plot and show circuit (opens new window, cannot inline in Jupyter)
     Defaults to an overcomplete basis, in order to not alter gates.
     Requires pdflatex installed (to compile Latex)
@@ -696,7 +696,7 @@ def plot_circuit(circuit, basis="u1,u2,u3,id,cx,x,y,z,h,s,sdg,t,tdg,rx,ry,rz"):
         im.show()
 
 
-def circuit_drawer(circuit, basis="u1,u2,u3,id,cx,x,y,z,h,s,sdg,t,tdg,rx,ry,rz"):
+def circuit_drawer(circuit, basis="u1,u2,u3,id,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,cx,cy,cz,swap,ch,ccx,crz,cu1,cu3"):
     """Obtain the circuit in image format (output can be inlined in Jupyter)
     Defaults to an overcomplete basis, in order to not alter gates.
     Requires pdflatex installed (to compile Latex)
@@ -1244,7 +1244,7 @@ class QCircuitImage(object):
                                     self._latex[pos_2][columns] = "\\gate{H}"
                                 elif nm == "swap":
                                     self._latex[pos_1][columns] = "\\qswap"
-                                    self._latex[pos_2][columns] = "\\qwx"
+                                    self._latex[pos_2][columns] = "\\qswap \\qwx[" + str(pos_1 - pos_2) + "]"
                                 elif nm == "crz":
                                     self._latex[pos_1][columns] = \
                                         "\\ctrl{" + str(pos_2 - pos_1) + "}"
@@ -1302,7 +1302,7 @@ class QCircuitImage(object):
                                     self._latex[pos_2][columns] = "\\gate{H}"
                                 elif nm == "swap":
                                     self._latex[pos_1][columns] = "\\qswap"
-                                    self._latex[pos_2][columns] = "\\qwx"
+                                    self._latex[pos_2][columns] = "\\qswap \\qwx[" + str(pos_2 - pos_1) + "]"
                                 elif nm == "crz":
                                     self._latex[pos_1][columns] = \
                                         "\\ctrl{" + str(pos_1 - pos_2) + "}"
@@ -1361,7 +1361,7 @@ class QCircuitImage(object):
                                 self._latex[pos_2][columns] = "\\gate{H}"
                             elif nm == "swap":
                                 self._latex[pos_1][columns] = "\\qswap"
-                                self._latex[pos_2][columns] = "\\qwx"
+                                self._latex[pos_2][columns] = "\\qswap \\qwx[" + str(pos_1 - pos_2) + "]"
                             elif nm == "crz":
                                 self._latex[pos_1][columns] = "\\ctrl{" + str(pos_2 - pos_1) + "}"
                                 self._latex[pos_2][columns] = \

--- a/qiskit/tools/visualization.py
+++ b/qiskit/tools/visualization.py
@@ -683,7 +683,9 @@ def plot_wigner_data(wigner_data, phis=None, method=None):
 ###############################################################
 
 
-def plot_circuit(circuit, basis="u1,u2,u3,id,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,cx,cy,cz,swap,ch,ccx,crz,cu1,cu3"):
+def plot_circuit(circuit, basis="id,u0,u1,u2,u3,"
+                                "x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
+                                "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx"):
     """Plot and show circuit (opens new window, cannot inline in Jupyter)
     Defaults to an overcomplete basis, in order to not alter gates.
     Requires pdflatex installed (to compile Latex)
@@ -696,7 +698,9 @@ def plot_circuit(circuit, basis="u1,u2,u3,id,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,cx,cy,
         im.show()
 
 
-def circuit_drawer(circuit, basis="u1,u2,u3,id,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,cx,cy,cz,swap,ch,ccx,crz,cu1,cu3"):
+def circuit_drawer(circuit, basis="id,u0,u1,u2,u3,"
+                                  "x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
+                                  "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx"):
     """Obtain the circuit in image format (output can be inlined in Jupyter)
     Defaults to an overcomplete basis, in order to not alter gates.
     Requires pdflatex installed (to compile Latex)
@@ -1133,6 +1137,9 @@ class QCircuitImage(object):
                                 self._latex[pos_1][columns] = "\\gate{T}"
                             elif nm == "tdg":
                                 self._latex[pos_1][columns] = "\\gate{T^\\dag}"
+                            elif nm == "u0":
+                                self._latex[pos_1][columns] = "\\gate{U_0(%s)}" % (
+                                    op["texparams"][0])
                             elif nm == "u1":
                                 self._latex[pos_1][columns] = "\\gate{U_1(%s)}" % (
                                     op["texparams"][0])
@@ -1188,6 +1195,9 @@ class QCircuitImage(object):
                                 self._latex[pos_1][columns] = "\\gate{T}"
                             elif nm == "tdg":
                                 self._latex[pos_1][columns] = "\\gate{T^\\dag}"
+                            elif nm == "u0":
+                                self._latex[pos_1][columns] = "\\gate{U_0(%s)}" % (
+                                    op["texparams"][0])
                             elif nm == "u1":
                                 self._latex[pos_1][columns] = "\\gate{U_1(%s)}" % (
                                     op["texparams"][0])
@@ -1244,7 +1254,8 @@ class QCircuitImage(object):
                                     self._latex[pos_2][columns] = "\\gate{H}"
                                 elif nm == "swap":
                                     self._latex[pos_1][columns] = "\\qswap"
-                                    self._latex[pos_2][columns] = "\\qswap \\qwx[" + str(pos_1 - pos_2) + "]"
+                                    self._latex[pos_2][columns] = \
+                                        "\\qswap \\qwx[" + str(pos_1 - pos_2) + "]"
                                 elif nm == "crz":
                                     self._latex[pos_1][columns] = \
                                         "\\ctrl{" + str(pos_2 - pos_1) + "}"
@@ -1302,7 +1313,8 @@ class QCircuitImage(object):
                                     self._latex[pos_2][columns] = "\\gate{H}"
                                 elif nm == "swap":
                                     self._latex[pos_1][columns] = "\\qswap"
-                                    self._latex[pos_2][columns] = "\\qswap \\qwx[" + str(pos_2 - pos_1) + "]"
+                                    self._latex[pos_2][columns] = \
+                                        "\\qswap \\qwx[" + str(pos_2 - pos_1) + "]"
                                 elif nm == "crz":
                                     self._latex[pos_1][columns] = \
                                         "\\ctrl{" + str(pos_1 - pos_2) + "}"
@@ -1361,7 +1373,8 @@ class QCircuitImage(object):
                                 self._latex[pos_2][columns] = "\\gate{H}"
                             elif nm == "swap":
                                 self._latex[pos_1][columns] = "\\qswap"
-                                self._latex[pos_2][columns] = "\\qswap \\qwx[" + str(pos_1 - pos_2) + "]"
+                                self._latex[pos_2][columns] = \
+                                    "\\qswap \\qwx[" + str(pos_1 - pos_2) + "]"
                             elif nm == "crz":
                                 self._latex[pos_1][columns] = "\\ctrl{" + str(pos_2 - pos_1) + "}"
                                 self._latex[pos_2][columns] = \

--- a/qiskit/tools/visualization.py
+++ b/qiskit/tools/visualization.py
@@ -683,7 +683,7 @@ def plot_wigner_data(wigner_data, phis=None, method=None):
 ###############################################################
 
 
-def plot_circuit(circuit, basis="u1,u2,u3,id,cx,x,y,z,h,s,t,rx,ry,rz"):
+def plot_circuit(circuit, basis="u1,u2,u3,id,cx,x,y,z,h,s,sdg,t,tdg,rx,ry,rz"):
     """Plot and show circuit (opens new window, cannot inline in Jupyter)
     Defaults to an overcomplete basis, in order to not alter gates.
     Requires pdflatex installed (to compile Latex)
@@ -696,7 +696,7 @@ def plot_circuit(circuit, basis="u1,u2,u3,id,cx,x,y,z,h,s,t,rx,ry,rz"):
         im.show()
 
 
-def circuit_drawer(circuit, basis="u1,u2,u3,id,cx,x,y,z,h,s,t,rx,ry,rz"):
+def circuit_drawer(circuit, basis="u1,u2,u3,id,cx,x,y,z,h,s,sdg,t,tdg,rx,ry,rz"):
     """Obtain the circuit in image format (output can be inlined in Jupyter)
     Defaults to an overcomplete basis, in order to not alter gates.
     Requires pdflatex installed (to compile Latex)
@@ -1134,14 +1134,14 @@ class QCircuitImage(object):
                             elif nm == "tdg":
                                 self._latex[pos_1][columns] = "\\gate{T^\\dag}"
                             elif nm == "u1":
-                                self._latex[pos_1][columns] = "\\gate{U(0,0,%s)}" % (
+                                self._latex[pos_1][columns] = "\\gate{U_1(%s)}" % (
                                     op["texparams"][0])
                             elif nm == "u2":
                                 self._latex[pos_1][columns] =\
-                                    "\\gate{U\\left(\\frac{\pi}{2},%s,%s\\right)}" % (
+                                    "\\gate{U_2\\left(%s,%s\\right)}" % (
                                         op["texparams"][0], op["texparams"][1])
                             elif nm == "u3":
-                                self._latex[pos_1][columns] = "\\gate{U(%s,%s,%s)}" \
+                                self._latex[pos_1][columns] = "\\gate{U_3(%s,%s,%s)}" \
                                     % (op["texparams"][0], op["texparams"][1], op["texparams"][2])
                             elif nm == "rx":
                                 self._latex[pos_1][columns] = "\\gate{R_x(%s)}" % (
@@ -1189,14 +1189,14 @@ class QCircuitImage(object):
                             elif nm == "tdg":
                                 self._latex[pos_1][columns] = "\\gate{T^\\dag}"
                             elif nm == "u1":
-                                self._latex[pos_1][columns] = "\\gate{U(0,0,%s)}" % (
+                                self._latex[pos_1][columns] = "\\gate{U_1(%s)}" % (
                                     op["texparams"][0])
                             elif nm == "u2":
                                 self._latex[pos_1][columns] = \
-                                    "\\gate{U\\left(\\frac{\pi}{2},%s,%s\\right)}" % (
+                                    "\\gate{U_2\\left(%s,%s\\right)}" % (
                                         op["texparams"][0], op["texparams"][1])
                             elif nm == "u3":
-                                self._latex[pos_1][columns] = "\\gate{U(%s,%s,%s)}" \
+                                self._latex[pos_1][columns] = "\\gate{U_3(%s,%s,%s)}" \
                                     % (op["texparams"][0], op["texparams"][1], op["texparams"][2])
                             elif nm == "rx":
                                 self._latex[pos_1][columns] = "\\gate{R_x(%s)}" % (
@@ -1463,7 +1463,7 @@ class QCircuitImage(object):
                     try:
                         self._latex[pos_1][columns] = "\\meter"
                         self._latex[pos_2][columns] = \
-                            "\\ctarg \\cw \\cwx[-" + str(pos_2 - pos_1) + "]"
+                            "\\cw \\cwx[-" + str(pos_2 - pos_1) + "]"
                     except Exception as e:
                         raise QISKitError('Error during Latex building: %s' %
                                           str(e))

--- a/setup.py.in
+++ b/setup.py.in
@@ -33,7 +33,8 @@ requirements = [
     "numpy>=1.13,<1.15",
     "ply==3.10",
     "scipy>=0.19,<1.1",
-    "sympy>=1.0"
+    "sympy>=1.0",
+    "pillow>=4.2.1"
 ]
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The circuit drawing had a couple of bugs which are fixed here.

@atilag after the merge, can you please bump the release to 4.11 so that this can be used in the tutorials?

## Description
<!--- Describe your changes in detail -->
`u1`,`u2`,`u3` were just drawn as U, even if the basis kept u1,u2,u3.
`measure` was doing a NOT instead of copy onto the cbit, in contrast to the quantum experience convention.
`swap` was not working at all.
some standard library gates were missing, such as `ch`, `crz`, etc. 

Now all gates are drawn.
<img width="878" alt="image" src="https://user-images.githubusercontent.com/8622381/37323755-240b9484-265c-11e8-860d-1952e5f7bd45.png">

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.