### PR TITLE
Clarified usage of qasm package in docstrings.

### DIFF
--- a/qiskit/qasm/__init__.py
+++ b/qiskit/qasm/__init__.py
@@ -15,7 +15,10 @@
 # limitations under the License.
 # =============================================================================
 
-"""Tools for QASM."""
+"""Tools for QASM.
+
+Use Unrollers in qiskit.unroll to convert a QASM specification to a qiskit circuit.
+"""
 
 from sympy import pi
 

--- a/qiskit/unroll/_dagbackend.py
+++ b/qiskit/unroll/_dagbackend.py
@@ -24,7 +24,14 @@ from ..dagcircuit import DAGCircuit
 
 
 class DAGBackend(UnrollerBackend):
-    """Backend for the unroller that creates a DAGCircuit object."""
+    """Backend for the unroller that creates a DAGCircuit object.
+
+    Example::
+
+        qasm = Qasm(filename = "teleport.qasm").parse()
+        dagcircuit = Unroller(qasm, DAGBackend()).execute()
+        print(dagcircuit.qasm())
+    """
 
     def __init__(self, basis=None):
         """Setup this backend.


### PR DESCRIPTION
Some very minor docstring improvements that I had sitting around.

* Added reference to unroll package from qasm.
* Added code example to DAGBackend.

## Motivation and Context
The usage of the qasm package is not obvious from the docstrings.

## How Has This Been Tested?
I ran `make doc` and checked the docs.

## Screenshots (if appropriate):
<img width="755" alt="screen shot 2018-03-15 at 12 17 54" src="https://user-images.githubusercontent.com/25747714/37476205-eef62034-284a-11e8-938f-1c02919866ab.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.