### PR TITLE
nicer default names for unnamed registers

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1486,30 +1486,20 @@ class QuantumProgram(object):
                 "The name of %s needs to be explicitly indicated, as there is "
                 "more than one available" % item_description)
 
-    def _create_id(self, infix, existing_ids):
+    def _create_id(self, prefix, existing_ids):
         """
-        Return an automatically generated identifier. First, check if infix
-        exists as in existings_ids and returns it if not. If infix exists in
-        existing_ids, creates an identifier "autoid_[infix][counter]", where
-        counter is a sequncial value (using the internal `__counter` generator)
-        (ie. "autoid_q2").
-
+        Return an automatically generated identifier, increased sequentially
+        based on the internal `_counter` generator, with the form
+        "[prefix][numeric_id]" (ie. "q2", where the prefix is "q").
         Args:
-            infix (str): string to use if possible or to be prepended to the
-                numeric id.
+            prefix (str): string to be prepended to the numeric id.
             existing_ids (iterable): list of ids that should be checked for
                 duplicates.
-
         Returns:
             str: the new identifier.
-
-        Raises:
-            QISKitError: if the identifier is already in `existing_ids`.
         """
-        if infix not in existing_ids:
-            return infix
         i = next(self.__counter)
-        identifier = "autoid_%s%i" % (infix, i)
+        identifier = "%s%i" % (prefix, i)
         if identifier not in existing_ids:
             return identifier
         raise QISKitError("The automatically generated identifier '%s' already "

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1488,12 +1488,15 @@ class QuantumProgram(object):
 
     def _create_id(self, infix, existing_ids):
         """
-        Return an automatically generated identifier, increased sequentially
-        based on the internal `_counter` generator, with the form
-        "autoid_[infix][numeric_id]" (ie. "autoid_q2").
+        Return an automatically generated identifier. First, check if infix
+        exists as in existings_ids and returns it if not. If infix exists in
+        existing_ids, creates an identifier "autoid_[infix][counter]", where
+        counter is a sequncial value (using the internal `__counter` generator)
+        (ie. "autoid_q2").
 
         Args:
-            infix (str): string to be prepended to the numeric id.
+            infix (str): string to use if possible or to be prepended to the
+                numeric id.
             existing_ids (iterable): list of ids that should be checked for
                 duplicates.
 
@@ -1503,6 +1506,8 @@ class QuantumProgram(object):
         Raises:
             QISKitError: if the identifier is already in `existing_ids`.
         """
+        if infix not in existing_ids:
+            return infix
         i = next(self.__counter)
         identifier = "autoid_%s%i" % (infix, i)
         if identifier not in existing_ids:

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1495,8 +1495,12 @@ class QuantumProgram(object):
             prefix (str): string to be prepended to the numeric id.
             existing_ids (iterable): list of ids that should be checked for
                 duplicates.
+        
         Returns:
             str: the new identifier.
+        
+        Raises:
+            QISKitError: if the identifier is already in `existing_ids`.
         """
         i = next(self.__counter)
         identifier = "%s%i" % (prefix, i)

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1495,10 +1495,10 @@ class QuantumProgram(object):
             prefix (str): string to be prepended to the numeric id.
             existing_ids (iterable): list of ids that should be checked for
                 duplicates.
-        
+
         Returns:
             str: the new identifier.
-        
+
         Raises:
             QISKitError: if the identifier is already in `existing_ids`.
         """

--- a/test/python/test_identifiers.py
+++ b/test/python/test_identifiers.py
@@ -87,8 +87,8 @@ class TestAnonymousIds(QiskitTestCase):
         """Test create_circuit with no name
         """
         q_program = QuantumProgram()
-        qr = q_program.create_quantum_register("qr", 3)
-        cr = q_program.create_classical_register("cr", 3)
+        qr = q_program.create_quantum_register(size=3)
+        cr = q_program.create_classical_register(size=3)
         qc = q_program.create_circuit(qregisters=[qr], cregisters=[cr])
         self.assertIsInstance(qc, QuantumCircuit)
 
@@ -96,10 +96,10 @@ class TestAnonymousIds(QiskitTestCase):
         """Test create_circuit with several inputs and without names.
         """
         q_program = QuantumProgram()
-        qr1 = q_program.create_quantum_register("qr1", 3)
-        cr1 = q_program.create_classical_register("cr1", 3)
-        qr2 = q_program.create_quantum_register("qr2", 3)
-        cr2 = q_program.create_classical_register("cr2", 3)
+        qr1 = q_program.create_quantum_register(size=3)
+        cr1 = q_program.create_classical_register(size=3)
+        qr2 = q_program.create_quantum_register(size=3)
+        cr2 = q_program.create_classical_register(size=3)
         qc1 = q_program.create_circuit(qregisters=[qr1], cregisters=[cr1])
         qc2 = q_program.create_circuit(qregisters=[qr2], cregisters=[cr2])
         qc3 = q_program.create_circuit(qregisters=[qr1, qr2], cregisters=[cr1, cr2])


### PR DESCRIPTION
@ajavadia noticed that the unnamed registers look ugly when `plot_circuit` is called:
![b](https://user-images.githubusercontent.com/766693/37576431-c06a6ba2-2b02-11e8-8b07-b734fc743b99.jpg)

He convinced me that `infix` can be used as identifier when it is available. The result looks nicer:
![a](https://user-images.githubusercontent.com/766693/37576438-c583ed34-2b02-11e8-88d7-ee11edad4c8a.jpg)
