### PR TITLE
Fix mapper issue #342

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1053,8 +1053,7 @@ class QuantumProgram(object):
         for name in name_of_circuits:
             if name not in self.__quantum_program:
                 raise QISKitError('circuit "{0}" not found in program'.format(name))
-            # TODO: The circuit object going into this is to have .qasm() method (be careful)
-            circuit = self.__quantum_program[name]
+            circuit = self.__quantum_program[name]                
             num_qubits = sum((len(qreg) for qreg in circuit.get_qregs().values()))
             # TODO: A better solution is to have options to enable/disable optimizations
             if num_qubits == 1:

--- a/qiskit/extensions/standard/barrier.py
+++ b/qiskit/extensions/standard/barrier.py
@@ -29,9 +29,9 @@ from qiskit.extensions.standard import header  # pylint: disable=unused-import
 class Barrier(Instruction):
     """Barrier instruction."""
 
-    def __init__(self, args, circ):
+    def __init__(self, arg, circ):
         """Create new barrier instruction."""
-        super().__init__("barrier", [], list(args), circ)
+        super().__init__("barrier", [], list(arg), circ)
 
     def inverse(self):
         """Special case. Return self."""

--- a/qiskit/mapper/_coupling.py
+++ b/qiskit/mapper/_coupling.py
@@ -158,7 +158,7 @@ class Coupling:
 
     def compute_distance(self):
         """
-        Compute the distance function on pairs of nodes.
+        Compute the undirected distance function on pairs of nodes.
 
         The distance map self.dist is computed from the graph using
         all_pairs_shortest_path_length.
@@ -173,7 +173,7 @@ class Coupling:
                 self.dist[i][j] = lengths[self.qubits[i]][self.qubits[j]]
 
     def distance(self, q1, q2):
-        """Return the distance between qubit q1 to qubit q2."""
+        """Return the undirected distance between qubit q1 to qubit q2."""
         if self.dist is None:
             raise CouplingError("distance has not been computed")
         if q1 not in self.qubits:

--- a/qiskit/mapper/_coupling.py
+++ b/qiskit/mapper/_coupling.py
@@ -109,8 +109,8 @@ class Coupling:
         return len(self.qubits)
 
     def get_qubits(self):
-        """Return the qubits in this graph as (qreg, index) tuples."""
-        return list(self.qubits.keys())
+        """Return the qubits in this graph as a sorted (qreg, index) tuples."""
+        return sorted(list(self.qubits.keys()))
 
     def get_edges(self):
         """Return a list of edges in the coupling graph.

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -350,7 +350,7 @@ def swap_mapper(circuit_graph, coupling_graph,
         coup_qubits = coupling_graph.get_qubits()
         qubit_subset = []
         for k, v in initial_layout.items():
-            qubit_subset.append(v)
+            qubit_subset.append(v) # AJ: this should not ignore k.
             if k not in circ_qubits:
                 raise MapperError("initial_layout qubit %s[%d] not in input "
                                   "DAGCircuit" % (k[0], k[1]))

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -350,7 +350,7 @@ def swap_mapper(circuit_graph, coupling_graph,
         coup_qubits = coupling_graph.get_qubits()
         qubit_subset = []
         for k, v in initial_layout.items():
-            qubit_subset.append(v) # AJ: this should not ignore k.
+            qubit_subset.append(v)
             if k not in circ_qubits:
                 raise MapperError("initial_layout qubit %s[%d] not in input "
                                   "DAGCircuit" % (k[0], k[1]))

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -147,70 +147,31 @@ class MapperTest(QiskitTestCase):
     def test_already_mapped(self):
         """Test that if the circuit already matches the backend topology, it is not remapped.
 
-        See: https://github.com/QISKit/qiskit-sdk-py/issues/342        
-        """
-        self.qp = QuantumProgram()
-        qr = self.qp.create_quantum_register('qr', 16)
-        cr = self.qp.create_classical_register('cr', 16)
-        qc = self.qp.create_circuit('native_cx', [qr], [cr])
-        qc.cx(qr[3],qr[14])
-        qc.cx(qr[5], qr[4])
-        qc.h(qr[9])
-        qc.cx(qr[9], qr[8])
-        qc.x(qr[11])
-        qc.cx(qr[3],qr[4])
-        qc.cx(qr[12], qr[11])
-        qc.cx(qr[13], qr[4])
-        for j in range(16):
-            qc.measure(qr[j], cr[j])
-        backend = 'local_qasm_simulator'            
-        cmap = {1: [0, 2], 2: [3], 3: [4, 14], 5: [4], 6: [5, 7, 11], 7: [10], 8: [7],
-                9: [8, 10], 11: [10], 12: [5, 11, 13], 13: [4, 14], 15: [0, 2, 14]}            
-        qobj = self.qp.compile(["native_cx"], backend=backend, coupling_map=cmap)
-        cx_qubits = [x["qubits"]
-                       for x in qobj["circuits"][0]["compiled_circuit"]["operations"]
-                       if x["name"] == "cx"]
-
-        self.assertEqual(sorted(cx_qubits), [[3, 4], [3, 14], [5, 4], [9, 8], [12, 11], [13, 4]])
-
-
-    def test_gate_after_measure(self):
-        """Test whether a qubit gets measured twice, which is not supported by real devices.
-
         See: https://github.com/QISKit/qiskit-sdk-py/issues/342
         """
         self.qp = QuantumProgram()
         qr = self.qp.create_quantum_register('qr', 16)
         cr = self.qp.create_classical_register('cr', 16)
-        qc = self.qp.create_circuit('emoticon', [qr], [cr])
-        qc.x(qr[0])
-        qc.x(qr[3])
-        qc.x(qr[5])
+        qc = self.qp.create_circuit('native_cx', [qr], [cr])
+        qc.cx(qr[3], qr[14])
+        qc.cx(qr[5], qr[4])
         qc.h(qr[9])
         qc.cx(qr[9], qr[8])
         qc.x(qr[11])
-        qc.x(qr[12])
-        qc.x(qr[13])
+        qc.cx(qr[3], qr[4])
+        qc.cx(qr[12], qr[11])
+        qc.cx(qr[13], qr[4])
         for j in range(16):
             qc.measure(qr[j], cr[j])
         backend = 'local_qasm_simulator'
         cmap = {1: [0, 2], 2: [3], 3: [4, 14], 5: [4], 6: [5, 7, 11], 7: [10], 8: [7],
                 9: [8, 10], 11: [10], 12: [5, 11, 13], 13: [4, 14], 15: [0, 2, 14]}
-        initial_layout = {('qr', 0): ('q', 1), ('qr', 1): ('q', 0),
-                  ('qr', 2): ('q', 2), ('qr', 3): ('q', 3),
-                  ('qr', 4): ('q', 4), ('qr', 5): ('q', 14),
-                  ('qr', 6): ('q', 5), ('qr', 7): ('q', 6),
-                  ('qr', 8): ('q', 7), ('qr', 9): ('q', 11),
-                  ('qr', 10): ('q', 10), ('qr', 11): ('q', 8),
-                  ('qr', 12): ('q', 9), ('qr', 13): ('q', 12),
-                  ('qr', 14): ('q', 13), ('qr', 15): ('q', 15)}
-        qobj = self.qp.compile(["emoticon"], backend=backend, 
-                               initial_layout=initial_layout, coupling_map=cmap)
-        measured_qubits = [x["qubits"][0]
-                           for x in qobj["circuits"][0]["compiled_circuit"]["operations"]
-                           if x["name"] is "measure"]
+        qobj = self.qp.compile(["native_cx"], backend=backend, coupling_map=cmap)
+        cx_qubits = [x["qubits"]
+                     for x in qobj["circuits"][0]["compiled_circuit"]["operations"]
+                     if x["name"] == "cx"]
 
-        self.assertEqual(len(measured_qubits), len(set(measured_qubits)))
+        self.assertEqual(sorted(cx_qubits), [[3, 4], [3, 14], [5, 4], [9, 8], [12, 11], [13, 4]])
 
 
 # QASMs expected by the tests.

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -853,6 +853,50 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertTrue(qobj2['circuits'][1]['config']['xvals'] == [
             'only for qobj2', 2, 3, 4])
 
+    @requires_qe_access
+    def test_gate_after_measure(self, QE_TOKEN, QE_URL):
+        """Test that no gate is inserted after measure when compiling
+        for real backends. NEED internet connection for this.
+
+        See: https://github.com/QISKit/qiskit-sdk-py/issues/342
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register('qr', 16)
+        cr = q_program.create_classical_register('cr', 16)
+        qc = q_program.create_circuit('emoticon', [qr], [cr])
+        qc.x(qr[0])
+        qc.x(qr[3])
+        qc.x(qr[5])
+        qc.h(qr[9])
+        qc.cx(qr[9], qr[8])
+        qc.x(qr[11])
+        qc.x(qr[12])
+        qc.x(qr[13])
+        for j in range(16):
+            qc.measure(qr[j], cr[j])
+        q_program.set_api(QE_TOKEN, QE_URL)
+        backend = 'ibmqx5'
+        cmap = {1: [0, 2], 2: [3], 3: [4, 14], 5: [4], 6: [5, 7, 11], 7: [10], 8: [7],
+                9: [8, 10], 11: [10], 12: [5, 11, 13], 13: [4, 14], 15: [0, 2, 14]}
+        initial_layout = {('qr', 0): ('q', 1), ('qr', 1): ('q', 0),
+                          ('qr', 2): ('q', 2), ('qr', 3): ('q', 3),
+                          ('qr', 4): ('q', 4), ('qr', 5): ('q', 14),
+                          ('qr', 6): ('q', 5), ('qr', 7): ('q', 6),
+                          ('qr', 8): ('q', 7), ('qr', 9): ('q', 11),
+                          ('qr', 10): ('q', 10), ('qr', 11): ('q', 8),
+                          ('qr', 12): ('q', 9), ('qr', 13): ('q', 12),
+                          ('qr', 14): ('q', 13), ('qr', 15): ('q', 15)}
+        qobj = q_program.compile(["emoticon"], backend=backend,
+                                 initial_layout=initial_layout, coupling_map=cmap)
+        measured_qubits = set()
+        has_gate_after_measure = False
+        for x in qobj["circuits"][0]["compiled_circuit"]["operations"]:
+            if x["name"] == "measure":
+                measured_qubits.add(x["qubits"][0])
+            elif set(x["qubits"]) & measured_qubits:
+                has_gate_after_measure = True
+        self.assertFalse(has_gate_after_measure)
+
     ###############################################################
     # Test for running programs
     ###############################################################


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The issue described in #342 is fixed (mapper bug alters already conforming circuits, and inserts operation after measurement).

This PR also resolves several other bug reports about mapper behavior:
- https://github.com/QISKit/qiskit-tutorial/issues/102
- https://github.com/QISKit/qiskit-tutorial/issues/88
- https://quantumexperience.ng.bluemix.net/qx/community/question?questionId=caf79b2243698650d38bf27321ac5991
- https://quantumexperience.ng.bluemix.net/qx/community/question?questionId=fd6d4e1c2e4a45963b4a93a87ad840dd

## Description
<!--- Describe your changes in detail -->
The default layout, if none is provided, is a layout of circuit qubit _i_ to device qubit _i_. This is reasonable since many users will hand optimize circuits and create already-conforming gates, or would like to map qubits to exact same qubits on the device.

If compilation is being performed for a real backend, the compiler inserts barriers before measurements to ensure they do not move before gates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

Also added new tests in `test_mapper.py` and `test_quantumprogram.py`. So in the likely event of changing the mapper to another, faster code base, we will hopefully not encounter these issues.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.