### PR TITLE
Bump API version, fix check, _AssertNoLogsContext

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-IBMQuantumExperience>=1.8.28
+IBMQuantumExperience>=1.8.29
 matplotlib>=2.1,<2.2
 networkx>=2.0,<2.1
 numpy>=1.13,<1.15

--- a/setup.py.in
+++ b/setup.py.in
@@ -27,7 +27,7 @@ from setuptools.dist import Distribution
 
 
 requirements = [
-    "IBMQuantumExperience>=1.8.28",
+    "IBMQuantumExperience>=1.8.29",
     "matplotlib>=2.1,<2.2",
     "networkx>=2.0,<2.1",
     "numpy>=1.13,<1.15",

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -87,8 +87,6 @@ class QiskitTestCase(unittest.TestCase):
 class _AssertNoLogsContext(unittest.case._AssertLogsContext):
     """A context manager used to implement TestCase.assertNoLogs()."""
 
-    LOGGING_FORMAT = "%(levelname)s:%(name)s:%(message)s"
-
     # pylint: disable=inconsistent-return-statements
     def __exit__(self, exc_type, exc_value, tb):
         """
@@ -100,10 +98,16 @@ class _AssertNoLogsContext(unittest.case._AssertLogsContext):
         if exc_type is not None:
             # let unexpected exceptions pass through
             return False
-        for record in self.watcher.records:
-            self._raiseFailure(
-                "Something was logged in the logger %s by %s:%i" %
-                (record.name, record.pathname, record.lineno))
+
+        if self.watcher.records:
+            msg = 'logs of level {} or higher triggered on {}:\n'.format(
+                logging.getLevelName(self.level), self.logger.name)
+            for record in self.watcher.records:
+                msg += 'logger %s %s:%i: %s\n' % (record.name, record.pathname,
+                                                  record.lineno,
+                                                  record.getMessage())
+
+            self._raiseFailure(msg)
 
 
 def requires_qe_access(func):


### PR DESCRIPTION
* Bump `IBMQuantumExperience` dependency to 1.8.29, as it fixes a bug
  and will be required by the next sdk release.
* Fix the `_check_ibmqe_version()`, as after #286 there where cases
  where the `requirement.txt` file was not present, resulting in the
  wrong warning. Now uses a simple approach: the check is only performed
  if installed via pip, assuming in the rest of the cases the user is
  responsible for updating the dependencies (ie. `pip install -U`).
* Revise `_AssertNoLogsContext` in order to produce more informative
  failure messages.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.