### PR TITLE
Do Python version check in init

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -16,12 +16,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
+
+"""Main QISKit public functionality."""
+
 import sys
 # Check for Python version 3.5+
 if sys.version_info < (3, 5):
     raise Exception('QISKit requires Python version 3.5 or greater.')
 
-"""Main QISKit public functionality."""
+# Check for required ibmqe version
+from ._util import _check_ibmqe_version
+_check_ibmqe_version()
 
 from IBMQuantumExperience import RegisterSizeError
 
@@ -45,8 +50,5 @@ from ._jobprocessor import JobProcessor
 from ._quantumjob import QuantumJob
 from ._quantumprogram import QuantumProgram
 from ._result import Result
-from ._util import _check_ibmqe_version
 
 __version__ = '0.5.0'
-
-_check_ibmqe_version()

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -15,8 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
+import sys
+# Check for Python version 3.5+
+if sys.version_info < (3,5):
+    raise Exception('QISKit requires Python version 3.5 or greater.')
 
 """Main QISKit public functionality."""
+
 from IBMQuantumExperience import RegisterSizeError
 
 from ._qiskiterror import QISKitError

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=wrong-import-order
+# pylint: disable=wrong-import-position
 
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #
@@ -17,7 +18,7 @@
 # =============================================================================
 import sys
 # Check for Python version 3.5+
-if sys.version_info < (3,5):
+if sys.version_info < (3, 5):
     raise Exception('QISKit requires Python version 3.5 or greater.')
 
 """Main QISKit public functionality."""


### PR DESCRIPTION
Check Python version in __init__ as done by NumPy and SciPy for equivalent checks.

## Description
Do Python version check at import, as opposed to a manual assert (as done in the tutorials).

## Motivation and Context
Having a manual assert in the tutorials is silly.  Checks in tutorials can be removed after commit.

## How Has This Been Tested?
I ran it.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.