### PR TITLE
Fix cmake for Mac

### DIFF
--- a/src/qiskit-simulator/CMakeLists.txt
+++ b/src/qiskit-simulator/CMakeLists.txt
@@ -52,9 +52,9 @@ if(STATIC_LINKING OR MINGW)
 	# with gcc is failing...
 	if(NOT APPLE)
 		enable_cxx_compiler_flag_if_supported("-static")
+    	enable_cxx_compiler_flag_if_supported("-static-libgcc")        
 	endif()
 	enable_cxx_compiler_flag_if_supported("-static-libstdc++")
-	enable_cxx_compiler_flag_if_supported("-static-libgcc")
 endif()
 
 # Warnings and Errors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
One line about static linking in the CMake does not work on mac. I have received a couple messages about this, so submitting this patch. I know that this may break cross-platform compatibility, but that is fine since this is used for local build only. The PIP build should use a different CMakeLists.txt

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.