### PR TITLE
DAGCircuit layer functions yield generators

### DIFF
--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1140,7 +1140,7 @@ class DAGCircuit:
                 self._remove_op_node(n)
 
     def layers(self):
-        """Return a list of layers for all d layers of this circuit.
+        """Yield a layer for all d layers of this circuit.
 
         A layer is a circuit whose gates act on disjoint qubits, i.e.
         a layer has depth 1. The total number of layers equals the
@@ -1154,7 +1154,6 @@ class DAGCircuit:
         layers as this is currently implemented. This may not be
         the desired behavior.
         """
-        layers_list = []
         # node_map contains an input node or previous layer node for
         # each wire in the circuit.
         node_map = copy.deepcopy(self.input_map)
@@ -1227,21 +1226,18 @@ class DAGCircuit:
                         emit = True
             if emit:
                 l_dict = {"graph": new_layer, "partition": support_list}
-                layers_list.append(l_dict)
+                yield l_dict
                 emit = False
             else:
                 if wires_with_ops_remaining:
                     raise QISKitError("not finished but empty?")
 
-        return layers_list
-
     def serial_layers(self):
-        """Return a list of layers for all gates of this circuit.
+        """Yield a layer for all gates of this circuit.
 
         A serial layer is a circuit with one gate. The layers have the
         same structure as in layers().
         """
-        layers_list = []
         for n in nx.topological_sort(self.multi_graph):
             nxt_nd = self.multi_graph.node[n]
             if nxt_nd["type"] == "op":
@@ -1268,8 +1264,7 @@ class DAGCircuit:
                     # support_list.append(list(set(qa) | set(ca) | set(cob)))
                     support_list.append(list(qa))
                 l_dict = {"graph": new_layer, "partition": support_list}
-                layers_list.append(l_dict)
-        return layers_list
+                yield l_dict
 
     def collect_runs(self, namelist):
         """Return a set of runs of "op" nodes with the given names.

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -456,7 +456,7 @@ def swap_mapper(circuit_graph, coupling_graph,
         raise MapperError("Not enough qubits in CouplingGraph")
 
     # Schedule the input circuit
-    layerlist = circuit_graph.layers()
+    layerlist = list(circuit_graph.layers())
     logger.debug("schedule:")
     for i, v in enumerate(layerlist):
         logger.debug("    %d: %s", i, v["partition"])
@@ -520,7 +520,7 @@ def swap_mapper(circuit_graph, coupling_graph,
         if not success_flag:
             logger.debug("swap_mapper: failed, layer %d, "
                          "retrying sequentially", i)
-            serial_layerlist = layer["graph"].serial_layers()
+            serial_layerlist = list(layer["graph"].serial_layers())
 
             # Go through each gate in the layer
             for j, serial_layer in enumerate(serial_layerlist):


### PR DESCRIPTION
* DAGCircuit.layers changed to yield a generator
* DAGCircuit.serial_layers changed to yield a generator
* Mapper has been adjust to consume generators instead of lists for
layers

The layers function in DAGCircuit was eager, producing a full list of layers on its call. This is not necessary. It has been changed to lazily emit values instead.

## Description
Where a result was appended to the output list now instead a value is emitted through `yield` resulting in a generator.

## Motivation and Context
For writing my own mapper I would like to request the first layer of the DAGCircuit, but calling `layers()` constructs the complete list. This wastes resources and is actually blocking for large DAGCircuits (think 10s of thousands of instructions).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran `make test` with `SKIP_ONLINE_TESTS=1` and passed all tests. I found all usages of layers and wrapped them with a `list` constructor as a quick fix.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.