### PR TITLE
Sync example and authors for translated README, docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ qc.h(qr[0])
 # the qubits in a Bell state.
 qc.cx(qr[0], qr[1])
 # Add a Measure gate to see the state.
-# (Ommiting the index applies an operation on all qubits of the register(s))
+# (Omitting the index applies an operation on all qubits of the register(s))
 qc.measure(qr, cr)
 
 # Create a Quantum Program for execution 

--- a/doc/ko/README.md
+++ b/doc/ko/README.md
@@ -56,38 +56,40 @@ QISKit SDK 레파지토리를 여러분의 로컬 머신에 Clone하는 다른 �
 SDK 설치가 끝났습니다. 이제 QISKit으로 작업을 해볼 차례입니다. 우리는 이미 QASM예제를 로컬 시뮬레이터 상에서 실행할 준비를 마쳤습니다. 이것은 간단한 중첩 예제 입니다. 
 
 ```python
-from qiskit import QuantumProgram
+# Import the QISKit SDK
+import qiskit
 
-# Creating Programs create your first QuantumProgram object instance.
-Q_program = QuantumProgram()
+# Create a Quantum Register called "qr" with 2 qubits
+qr = qiskit.QuantumRegister("qr", 2)
+# Create a Classical Register called "cr" with 2 bits
+cr = qiskit.ClassicalRegister("cr", 2)
+# Create a Quantum Circuit called involving "qr" and "cr"
+qc = qiskit.QuantumCircuit(qr, cr)
 
-try:
-  # Creating Registers create your first Quantum Register called "qr" with 2 qubits
-  qr = Q_program.create_quantum_register("qr", 2)
-  # create your first Classical Register called "cr" with 2 bits
-  cr = Q_program.create_classical_register("cr", 2)
-  # Creating Circuits create your first Quantum Circuit called "qc" involving your Quantum Register "qr"
-  # and your Classical Register "cr"
-  qc = Q_program.create_circuit("superposition", [qr], [cr])
+# Add a H gate on the 0th qubit in "qr", putting this qubit in superposition.
+qc.h(qr[0])
+# Add a CX (CNOT) gate on control qubit 0 and target qubit 1, putting
+# the qubits in a Bell state.
+qc.cx(qr[0], qr[1])
+# Add a Measure gate to see the state.
+# (Omitting the index applies an operation on all qubits of the register(s))
+qc.measure(qr, cr)
 
-  # add the H gate in the Qubit 0, we put this Qubit in superposition
-  qc.h(qr[0])
+# Create a Quantum Program for execution 
+qp = qiskit.QuantumProgram()
+# Add the circuit you created to it, and call it the "bell" circuit.
+# (You can add multiple circuits to the same program, for batch execution)
+qp.add_circuit("bell", qc)
 
-  # add measure to see the state
-  qc.measure(qr, cr)
+# See a list of available local simulators
+print("Local backends: ", qiskit.backends.discover_local_backends())
 
-  # Compiled  and execute in the local_qasm_simulator
+# Compile and run the Quantum Program on a simulator backend
+sim_result = qp.execute("bell", backend='local_qasm_simulator', shots=1024, seed=1)
 
-  result = Q_program.execute(["superposition"], backend='local_qasm_simulator', shots=1024)
-
-  # Show the results
-  print(result)
-  print(result.get_data("superposition"))
-
-except QISKitError as ex:
-  print('There was an error in the circuit!. Error = {}'.format(ex))
-except RegisterSizeError as ex:
-  print('Error in the number of registers!. Error = {}'.format(ex))
+# Show the results
+print("simulation: ", sim_result)
+print(sim_result.get_counts("bell"))
 ```
 
 이 경우에 결과물은 다음과 같을 것입니다(불규칙 변동으로 인해):
@@ -136,9 +138,12 @@ QISKit은 본래 [IBM Research](http://www.research.ibm.com/)연구팀과 [IBM-Q
 
 ## Authors (alphabetical)
 
-Jim Challenger, Andrew Cross, Vincent Dwyer, Mark Everitt, Ismael Faro, Jay Gambetta, Juan Gomez, Paco Martin, Yunho Maeng, Antonio Mezzacapo, Jesus Perez, Russell Rundle, Todd Tilma, John Smolin, Erick Winston, Chris Wood
+QISKit was originally authored by
+Luciano Bello, Jim Challenger, Andrew Cross, Ismael Faro, Jay Gambetta, Juan Gomez,
+Ali Javadi-Abhari, Paco Martin, Diego Moreda, Jesus Perez, Erick Winston and Chris Wood.
 
-앞으로의 릴리즈시, 이 프로젝트의 코드에 기여한 누구라도 이곳에 이름을 적어도 좋습니다. 
+And continues to grow with the help and work of [many people](https://github.com/QISKit/qiskit-sdk-py/tree/master/CONTRIBUTORS.md) who contribute
+to the project at different levels.
 
 ## License
 

--- a/doc/zh/README.md
+++ b/doc/zh/README.md
@@ -64,41 +64,40 @@ PIP 为以下平台预装有二进制版本：
 这是一个产生叠加态的简单例子：
 
 ```python
-from qiskit import QuantumProgram, QISKitError, RegisterSizeError
+# Import the QISKit SDK
+import qiskit
 
-# Create a QuantumProgram object instance.
-q_program = QuantumProgram()
-backend = 'local_qasm_simulator'
-try:
-    # Create a Quantum Register called "qr" with 2 qubits.
-    quantum_reg = q_program.create_quantum_register("qr", 2)
-    # Create a Classical Register called "cr" with 2 bits.
-    classical_reg = q_program.create_classical_register("cr", 2)
-    # Create a Quantum Circuit called "qc" involving the Quantum Register "qr"
-    # and the Classical Register "cr".
-    quantum_circuit =
-        q_program.create_circuit("bell", [quantum_reg],[classical_reg])
+# Create a Quantum Register called "qr" with 2 qubits
+qr = qiskit.QuantumRegister("qr", 2)
+# Create a Classical Register called "cr" with 2 bits
+cr = qiskit.ClassicalRegister("cr", 2)
+# Create a Quantum Circuit called involving "qr" and "cr"
+qc = qiskit.QuantumCircuit(qr, cr)
 
-    # Add the H gate in the Qubit 0, putting this qubit in superposition.
-    quantum_circuit.h(quantum_reg[0])
-    # Add the CX gate on control qubit 0 and target qubit 1, putting
-    # the qubits in a Bell state
-    quantum_circuit.cx(quantum_reg[0], quantum_reg[1])
+# Add a H gate on the 0th qubit in "qr", putting this qubit in superposition.
+qc.h(qr[0])
+# Add a CX (CNOT) gate on control qubit 0 and target qubit 1, putting
+# the qubits in a Bell state.
+qc.cx(qr[0], qr[1])
+# Add a Measure gate to see the state.
+# (Omitting the index applies an operation on all qubits of the register(s))
+qc.measure(qr, cr)
 
-    # Add a Measure gate to see the state.
-    quantum_circuit.measure(quantum_reg, classical_reg)
+# Create a Quantum Program for execution 
+qp = qiskit.QuantumProgram()
+# Add the circuit you created to it, and call it the "bell" circuit.
+# (You can add multiple circuits to the same program, for batch execution)
+qp.add_circuit("bell", qc)
 
-    # Compile and execute the Quantum Program in the local_qasm_simulator.
-    result = q_program.execute(["bell"], backend=backend, shots=1024, seed=1)
+# See a list of available local simulators
+print("Local backends: ", qiskit.backends.discover_local_backends())
 
-    # Show the results.
-    print(result)
-    print(result.get_data("bell"))
+# Compile and run the Quantum Program on a simulator backend
+sim_result = qp.execute("bell", backend='local_qasm_simulator', shots=1024, seed=1)
 
-except QISKitError as ex:
-    print('There was an error in the circuit!. Error = {}'.format(ex))
-except RegisterSizeError as ex:
-    print('Error in the number of registers!. Error = {}'.format(ex))
+# Show the results
+print("simulation: ", sim_result)
+print(sim_result.get_counts("bell"))
 ```
 
 在这个例子中，输出是（大约是由于随机波动）：
@@ -192,11 +191,12 @@ QISKit 最早是由[IBM Research](http://www.research.ibm.com/)研究中心的
 
 ## 作者 (按字母顺序)
 
-Ismail Yunus Akhalwaya, Jim Challenger, Andrew Cross, Vincent Dwyer, Mark Everitt, Ismael Faro,
-Jay Gambetta, Juan Gomez, Yunho Maeng, Paco Martin, Antonio Mezzacapo, Diego Moreda, Jesus Perez,
-Russell Rundle, Todd Tilma, John Smolin, Erick Winston, Chris Wood.
+QISKit was originally authored by
+Luciano Bello, Jim Challenger, Andrew Cross, Ismael Faro, Jay Gambetta, Juan Gomez,
+Ali Javadi-Abhari, Paco Martin, Diego Moreda, Jesus Perez, Erick Winston and Chris Wood.
 
-在将来的版本中，欢迎将任何对此项目代码做出贡献的人的名字添加在这里。
+And continues to grow with the help and work of [many people](https://github.com/QISKit/qiskit-sdk-py/tree/master/CONTRIBUTORS.md) who contribute
+to the project at different levels.
 
 ## 版权许可证
 

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -234,10 +234,12 @@ class QuantumProgram(object):
 
         Args:
             register_array (list[dict]): An array of quantum registers in
-                dictionary format. For example:
+                dictionary format. For example::
+
                     [{"name": "qr", "size": 4},
                         ...
                     ]
+
                 Any other key in the dictionary will be ignored. If "name"
                 is not defined (or None) a random name wil be assigned.
 
@@ -256,10 +258,12 @@ class QuantumProgram(object):
 
         Args:
             register_array (list[dict]): An array of quantum registers in
-                dictionary format. For example:
+                dictionary format. For example::
+
                     [{"name": "qr"},
                         ...
                     ]
+
                 Any other key in the dictionary will be ignored.
         """
         for register in register_array:
@@ -298,10 +302,12 @@ class QuantumProgram(object):
 
         Args:
             registers_array (list[dict]): An array of classical registers in
-                dictionary format. For example:
+                dictionary format. For example::
+
                     [{"name": "cr", "size": 4},
                         ...
                     ]
+
                 Any other key in the dictionary will be ignored. If "name"
                 is not defined (or None) a random name wil be assigned.
 
@@ -334,10 +340,12 @@ class QuantumProgram(object):
 
         Args:
             registers_array (list[dict]): An array of classical registers in
-                dictionary format. For example:
+                dictionary format. For example::
+
                     [{"name": "cr"},
                         ...
                     ]
+
                 Any other key in the dictionary will be ignored.
         """
         for register in registers_array:
@@ -599,7 +607,8 @@ class QuantumProgram(object):
         return list(self.__classical_registers.keys())
 
     def get_circuit(self, name=None):
-        """Return a Circuit Object by name
+        """Return a Circuit Object by name.
+
         Args:
             name (hashable or None): the name of the quantum circuit.
                 If None and there is only one circuit available, returns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Copy the example and the authors sections on the main README.md to the translations, to synchronize them with the latest changes by #357 and  #359.
* Revise some docstrings that were raising some warnings during the generation of the sphinx docs. There are still some warnings left at `qiskit/backends/_qiskit_cpp_simulator.py`, but they have been left untouched as they might cause some conflicts with #351 (another pass will be done after that PR is merged).

## Motivation and Context

Improve documentation consistency.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make doc`