### PR TITLE
Fix hub tests, add safety against empty hubs

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -702,10 +702,14 @@ class QuantumProgram(object):
         try:
             config_dict = {
                 'url': url,
-                'hub': hub,
-                'group': group,
-                'project': project
             }
+            # Only append hub/group/project if they are different than None.
+            if all([hub, group, project]):
+                config_dict.update({
+                    'hub': hub,
+                    'group': group,
+                    'project': project
+                })
             if proxies:
                 config_dict['proxies'] = proxies
             self.__api = IBMQuantumExperience(token, config_dict, verify)


### PR DESCRIPTION
Fix #367 by revising the tests. Additionally, adds an extra check at `QuantumProgram.set_api()` for not passing the parameters to the API if all of them are `None` (as, even if it is to be deprecated soon, it should help avoid confusion). We should have a similar measure in `IBMQuantumExperience` directly - 

@ajavadia or @jaygambetta : can you test the changes manually with your `Qconfig`s? Following up on Ali's comment in the issue, the tests are not performed in travis as we don't have the environment variables for them set.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix the `test_api_ibmq.py` tests:
* adjust them to the new style for using the API directly instead of
  going through QuantumProgram.
* revise tests that were failing due to assertions no longer valid, and
  relaxed the assertions in a couple of cases.
* remove the test for updating the hub parameters on the fly, as it is
  rendered deprecated if using the API directly.

Add an extra check to `QuantumProgram.set_api()`, as users using a
Qconfig where the hub parameters were set, but with the value `None`
might have encountered problems.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.