### PR TITLE
Update ProjectQ test to conform with recent changes

### DIFF
--- a/test/python/test_projectq_cpp_simulator.py
+++ b/test/python/test_projectq_cpp_simulator.py
@@ -45,12 +45,14 @@ else:
 @unittest.skipIf(_skip_class, 'Project Q C++ simulator unavailable')
 class TestProjectQCppSimulator(QiskitTestCase):
     """
-    Test job_pocessor module.
+    Test projectq simulator.
     """
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        # Set up random circuits
         n_circuits = 20
         min_depth = 1
         max_depth = 10
@@ -68,47 +70,6 @@ class TestProjectQCppSimulator(QiskitTestCase):
                 basis.remove('reset')
             random_circuits.add_circuits(1, basis=basis)
         cls.rqg = random_circuits
-        cls.seed = 88
-        cls.qasm_filename = cls._get_resource_path('qasm/example.qasm')
-        with open(cls.qasm_filename, 'r') as qasm_file:
-            cls.qasm_text = qasm_file.read()
-            qr1 = QuantumRegister('q1', 2)
-            qr2 = QuantumRegister('q2', 3)
-            cr = ClassicalRegister('c', 2)
-            qcs = QuantumCircuit(qr1, qr2, cr)
-            qcs.h(qr1[0])
-            qcs.h(qr2[2])
-            qcs.measure(qr1[0], cr[0])
-            cls.qcs = qcs
-            # create qobj
-        compiled_circuit1 = openquantumcompiler.compile(cls.qcs.qasm(),
-                                                        format='json')
-        compiled_circuit2 = openquantumcompiler.compile(cls.qasm_text,
-                                                        format='json')
-        cls.qobj = {'id': 'test_qobj',
-                    'config': {
-                        'max_credits': 3,
-                        'shots': 100,
-                        'backend': 'local_projectq_simulator',
-                        'seed': 1111
-                    },
-                    'circuits': [
-                        {
-                            'name': 'test_circuit1',
-                            'compiled_circuit': compiled_circuit1,
-                            'basis_gates': 'u1,u2,u3,cx,id',
-                            'layout': None,
-                        },
-                        {
-                            'name': 'test_circuit2',
-                            'compiled_circuit': compiled_circuit2,
-                            'basis_gates': 'u1,u2,u3,cx,id',
-                            'layout': None,
-                        }
-                    ]}
-        cls.q_job = QuantumJob(cls.qobj,
-                               backend='local_projectq_simulator',
-                               preformatted=True)
 
     def test_gate_x(self):
         shots = 100
@@ -147,7 +108,7 @@ class TestProjectQCppSimulator(QiskitTestCase):
         local_simulator = qasm_simulator.QasmSimulator()
         for circuit in self.rqg.get_circuits(format_='QuantumCircuit'):
             self.log.info(circuit.qasm())
-            compiled_circuit = openquantumcompiler.compile(circuit.qasm())
+            compiled_circuit = openquantumcompiler.compile(circuit)
             shots = 100
             min_cnts = int(shots / 10)
             job_pq = QuantumJob(compiled_circuit,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The `openquantumcompiler.compile()` method was recently updated to take a QuantumCircuit object, not a circuit name.

The test failure was not caught because project q is not built on Travis. I saw the failure locally.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.