### PR TITLE
Updated tests that compare random counts outcomes

### DIFF
--- a/test/python/common.py
+++ b/test/python/common.py
@@ -174,4 +174,31 @@ def _is_ci_fork_pull_request():
     return False
 
 
+def compare_dicts(dict1, dict2, threshold, default=0):
+    """
+    Compare two dictionaries with numeric values.
+
+    Args:
+        dict1 (dict): a dictionary.
+        dict2 (dict): a dictionary.
+        threshold (number): threshold for comparison.
+        default (number): default value for missing keys.
+
+    Returns:
+        bool: True if for all keys abs(dict1[key] - dict2[key]) < threshold.
+    """
+    success = True
+    # check value for keys in target
+    keys1 = set(dict1.keys())
+    for key in keys1:
+        diff = abs(dict1.get(key, default) - dict2.get(key, default))
+        success &= diff < threshold
+    # check values for keys in counts, not in target
+    keys2 = set(dict2.keys()) - keys1
+    for key in keys2:
+        diff = abs(dict1.get(key, default) - dict2.get(key, default))
+        success &= diff < threshold
+    return success
+
+
 SKIP_ONLINE_TESTS = os.getenv('SKIP_ONLINE_TESTS', _is_ci_fork_pull_request())

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -22,7 +22,7 @@ import inspect
 import logging
 import os
 import unittest
-
+from unittest.util import safe_repr
 from qiskit import __path__ as qiskit_path
 
 
@@ -82,6 +82,97 @@ class QiskitTestCase(unittest.TestCase):
         """
         # pylint: disable=invalid-name
         return _AssertNoLogsContext(self, logger, level)
+
+    # pylint: disable=invalid-name
+    def assertDictAlmostEqual(self, dict1, dict2, delta=None, msg=None,
+                              places=None, default_value=0):
+        """
+        Assert two dictionaries with numeric values are almost equal.
+
+        Fail if the two dictionaries are unequal as determined by
+        comparing that the difference between values with the same key are
+        not greater than delta (default 1e-8), or that difference rounded
+        to the given number of decimal places is not zero. If a key in one
+        dictionary is not in the other the default_value keyword arugment
+        will be used for the missing value (default 0). If the two objects
+        compare equal then they will automatically compare almost equal.
+
+        Args:
+            dict1 (dict): a dictionary.
+            dict2 (dict): a dictionary.
+            delta (number): threshold for comparison (defaults to 1e-8).
+            msg (str): return a custom message on failure.
+            places (int): number of decimal places for comparison.
+            default_value (number): default value for missing keys.
+
+        Raises:
+            TypeError: raises TestCase failureException if the test fails.
+        """
+
+        if dict1 == dict2:
+            # Shortcut
+            return
+        if delta is not None and places is not None:
+            raise TypeError("specify delta or places not both")
+
+        if places is not None:
+            success = True
+            standard_msg = ''
+            # check value for keys in target
+            keys1 = set(dict1.keys())
+            for key in keys1:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if round(abs(val1 - val2), places) != 0:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            # check values for keys in counts, not in target
+            keys2 = set(dict2.keys()) - keys1
+            for key in keys2:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if round(abs(val1 - val2), places) != 0:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            if success is True:
+                return
+            standard_msg = standard_msg[:-2] + ' within %s places' % places
+
+        else:
+            if delta is None:
+                delta = 1e-8  # default delta value
+            success = True
+            standard_msg = ''
+            # check value for keys in target
+            keys1 = set(dict1.keys())
+            for key in keys1:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if abs(val1 - val2) > delta:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            # check values for keys in counts, not in target
+            keys2 = set(dict2.keys()) - keys1
+            for key in keys2:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if abs(val1 - val2) > delta:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            if success is True:
+                return
+            standard_msg = standard_msg[:-2] + ' within %s delta' % delta
+
+        msg = self._formatMessage(msg, standard_msg)
+        raise self.failureException(msg)
 
 
 class _AssertNoLogsContext(unittest.case._AssertLogsContext):
@@ -172,33 +263,6 @@ def _is_ci_fork_pull_request():
         if os.getenv('APPVEYOR_PULL_REQUEST_NUMBER'):
             return True
     return False
-
-
-def compare_dicts(dict1, dict2, threshold, default=0):
-    """
-    Compare two dictionaries with numeric values.
-
-    Args:
-        dict1 (dict): a dictionary.
-        dict2 (dict): a dictionary.
-        threshold (number): threshold for comparison.
-        default (number): default value for missing keys.
-
-    Returns:
-        bool: True if for all keys abs(dict1[key] - dict2[key]) < threshold.
-    """
-    success = True
-    # check value for keys in target
-    keys1 = set(dict1.keys())
-    for key in keys1:
-        diff = abs(dict1.get(key, default) - dict2.get(key, default))
-        success &= diff < threshold
-    # check values for keys in counts, not in target
-    keys2 = set(dict2.keys()) - keys1
-    for key in keys2:
-        diff = abs(dict1.get(key, default) - dict2.get(key, default))
-        success &= diff < threshold
-    return success
 
 
 SKIP_ONLINE_TESTS = os.getenv('SKIP_ONLINE_TESTS', _is_ci_fork_pull_request())

--- a/test/python/test_identifiers.py
+++ b/test/python/test_identifiers.py
@@ -22,7 +22,7 @@ import unittest
 
 from qiskit import (ClassicalRegister, QISKitError, QuantumCircuit,
                     QuantumRegister, QuantumProgram)
-from .common import QiskitTestCase, compare_dicts
+from .common import QiskitTestCase
 
 
 class TestAnonymousIds(QiskitTestCase):
@@ -302,7 +302,7 @@ class TestAnonymousIds(QiskitTestCase):
         counts = result.get_counts(new_circuit.name)
         target = {'00': shots / 2, '01': shots / 2}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
         self.assertRaises(QISKitError, result.get_counts)
 
 
@@ -651,7 +651,7 @@ class TestZeroIds(QiskitTestCase):
         counts = result.get_counts(1001)
         target = {'00': shots / 2, '01': shots / 2}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
 
 class TestIntegerIds(QiskitTestCase):
@@ -1001,7 +1001,7 @@ class TestIntegerIds(QiskitTestCase):
         counts = result.get_counts(1001)
         target = {'00': shots / 2, '01': shots / 2}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
 
 class TestTupleIds(QiskitTestCase):
@@ -1346,7 +1346,7 @@ class TestTupleIds(QiskitTestCase):
         counts = result.get_counts((1001.1, 1001j))
         target = {'00': shots / 2, '01': shots / 2}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
 
 if __name__ == '__main__':

--- a/test/python/test_identifiers.py
+++ b/test/python/test_identifiers.py
@@ -22,7 +22,7 @@ import unittest
 
 from qiskit import (ClassicalRegister, QISKitError, QuantumCircuit,
                     QuantumRegister, QuantumProgram)
-from .common import QiskitTestCase
+from .common import QiskitTestCase, compare_dicts
 
 
 class TestAnonymousIds(QiskitTestCase):
@@ -299,7 +299,10 @@ class TestAnonymousIds(QiskitTestCase):
         backend = 'local_qasm_simulator'  # the backend to run on
         shots = 1024  # the number of shots in the experiment.
         result = q_program.execute(backend=backend, shots=shots, seed=78)
-        self.assertEqual(result.get_counts(new_circuit.name), {'01': 519, '00': 505})
+        counts = result.get_counts(new_circuit.name)
+        target = {'00': shots / 2, '01': shots / 2}
+        threshold = 0.025 * shots
+        self.assertTrue(compare_dicts(counts, target, threshold))
         self.assertRaises(QISKitError, result.get_counts)
 
 
@@ -645,7 +648,10 @@ class TestZeroIds(QiskitTestCase):
         backend = 'local_qasm_simulator'  # the backend to run on
         shots = 1024  # the number of shots in the experiment.
         result = q_program.execute(circuits, backend=backend, shots=shots, seed=78)
-        self.assertEqual(result.get_counts(1001), {'01': 519, '00': 505})
+        counts = result.get_counts(1001)
+        target = {'00': shots / 2, '01': shots / 2}
+        threshold = 0.025 * shots
+        self.assertTrue(compare_dicts(counts, target, threshold))
 
 
 class TestIntegerIds(QiskitTestCase):
@@ -992,7 +998,10 @@ class TestIntegerIds(QiskitTestCase):
         shots = 1024  # the number of shots in the experiment.
         result = q_program.execute(circuits, backend=backend, shots=shots,
                                    seed=78)
-        self.assertEqual(result.get_counts(1001), {'01': 519, '00': 505})
+        counts = result.get_counts(1001)
+        target = {'00': shots / 2, '01': shots / 2}
+        threshold = 0.025 * shots
+        self.assertTrue(compare_dicts(counts, target, threshold))
 
 
 class TestTupleIds(QiskitTestCase):
@@ -1334,7 +1343,10 @@ class TestTupleIds(QiskitTestCase):
         shots = 1024  # the number of shots in the experiment.
         result = q_program.execute(circuits, backend=backend, shots=shots,
                                    seed=78)
-        self.assertEqual(result.get_counts((1001.1, 1001j)), {'00': 505, '01': 519})
+        counts = result.get_counts((1001.1, 1001j))
+        target = {'00': shots / 2, '01': shots / 2}
+        threshold = 0.025 * shots
+        self.assertTrue(compare_dicts(counts, target, threshold))
 
 
 if __name__ == '__main__':

--- a/test/python/test_local_qiskit_simulator.py
+++ b/test/python/test_local_qiskit_simulator.py
@@ -30,7 +30,7 @@ from qiskit import QuantumCircuit
 from qiskit import QuantumJob
 from qiskit import QuantumRegister
 from qiskit import _openquantumcompiler as openquantumcompiler
-from .common import QiskitTestCase
+from .common import QiskitTestCase, compare_dicts
 
 
 class TestLocalQiskitSimulator(QiskitTestCase):
@@ -61,7 +61,7 @@ class TestLocalQiskitSimulator(QiskitTestCase):
         self.qobj = {'id': 'test_qobj',
                      'config': {
                          'max_credits': 3,
-                         'shots': 100,
+                         'shots': 1024,
                          'backend': 'local_qiskit_simulator',
                          'seed': 1111
                      },
@@ -125,21 +125,14 @@ class TestLocalQiskitSimulator(QiskitTestCase):
             raise unittest.SkipTest(
                 'cannot find {} in path'.format(fnferr))
         result = simulator.run(self.q_job)
-
-        # TODO: reenable the assertEqual with the exact counts once the issue
-        # with the randomness is solved, as different compiler/oses seem to
-        # provide different values even for the same seed.
-        expected2 = {'000 000': 18,
-                     '001 001': 15,
-                     '010 010': 13,
-                     '011 011': 11,
-                     '100 100': 10,
-                     '101 101': 10,
-                     '110 110': 12,
-                     '111 111': 11}
-        # self.assertEqual(result.get_counts('test_circuit2'), expected2)
-        self.assertEqual(set(result.get_counts('test_circuit2').keys()),
-                         set(expected2.keys()))
+        shots = 1024
+        threshold = 0.025 * shots
+        counts = result.get_counts('test_circuit2')
+        target = {'100 100': shots / 8, '011 011': shots / 8,
+                  '101 101': shots / 8, '111 111': shots / 8,
+                  '000 000': shots / 8, '010 010': shots / 8,
+                  '110 110': shots / 8, '001 001': shots / 8}
+        self.assertTrue(compare_dicts(counts, target, threshold))
 
 
 if __name__ == '__main__':

--- a/test/python/test_local_qiskit_simulator.py
+++ b/test/python/test_local_qiskit_simulator.py
@@ -30,7 +30,7 @@ from qiskit import QuantumCircuit
 from qiskit import QuantumJob
 from qiskit import QuantumRegister
 from qiskit import _openquantumcompiler as openquantumcompiler
-from .common import QiskitTestCase, compare_dicts
+from .common import QiskitTestCase
 
 
 class TestLocalQiskitSimulator(QiskitTestCase):
@@ -132,7 +132,7 @@ class TestLocalQiskitSimulator(QiskitTestCase):
                   '101 101': shots / 8, '111 111': shots / 8,
                   '000 000': shots / 8, '010 010': shots / 8,
                   '110 110': shots / 8, '001 001': shots / 8}
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
 
 if __name__ == '__main__':

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -20,7 +20,7 @@ import unittest
 
 from qiskit import QuantumProgram
 from qiskit import qasm, unroll, mapper
-from .common import QiskitTestCase, compare_dicts
+from .common import QiskitTestCase
 
 
 class MapperTest(QiskitTestCase):
@@ -124,7 +124,7 @@ class MapperTest(QiskitTestCase):
         }
         target = {key: shots * val for key, val in expected_probs.items()}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_symbolic_unary(self):
         """Test symbolic math in DAGBackend and optimizer with a prefix.

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -20,7 +20,7 @@ import unittest
 
 from qiskit import QuantumProgram
 from qiskit import qasm, unroll, mapper
-from .common import QiskitTestCase
+from .common import QiskitTestCase, compare_dicts
 
 
 class MapperTest(QiskitTestCase):
@@ -84,33 +84,47 @@ class MapperTest(QiskitTestCase):
         """Run a circuit with randomly generated parameters."""
         self.qp.load_qasm_file(self._get_resource_path('qasm/random_n5_d5.qasm'), name='rand')
         coupling_map = [[0, 1], [1, 2], [2, 3], [3, 4]]
+        shots = 1024
         result1 = self.qp.execute(["rand"], backend="local_qasm_simulator",
-                                  coupling_map=coupling_map, seed=self.seed)
-        res = result1.get_counts("rand")
-
-        print(res)
-
-        expected_result = {'10000': 92, '10100': 27, '01000': 99, '00001': 37,
-                           '11100': 31, '01001': 27, '10111': 79, '00111': 43,
-                           '00000': 88, '00010': 104, '11111': 14, '00110': 52,
-                           '00100': 50, '01111': 21, '10010': 34, '01011': 21,
-                           '00011': 15, '01101': 53, '10110': 32, '10101': 12,
-                           '01100': 8, '01010': 7, '10011': 15, '11010': 26,
-                           '11011': 8, '11110': 4, '01110': 14, '11001': 6,
-                           '11000': 1, '11101': 2, '00101': 2}
-        # TODO It's ugly, I know. But we are getting different results from Python 3.5
-        # and Python 3.6. So let's trick this until we fix all testing
-        if expected_result != res:
-            expected_result = {'00001': 31, '01111': 23, '10010': 24, '01001': 29,
-                               '11000': 4, '10111': 74, '00101': 3, '11010': 21,
-                               '01100': 11, '11110': 2, '11101': 2, '11001': 18,
-                               '01011': 17, '00100': 45, '01010': 1, '11111': 13,
-                               '00011': 20, '00110': 35, '00000': 87, '10101': 12,
-                               '01110': 11, '00010': 122, '10100': 21, '10000': 88,
-                               '10110': 34, '01000': 108, '11011': 8, '10011': 14,
-                               '01101': 58, '00111': 48, '11100': 40}
-
-        self.assertEqual(res, expected_result)
+                                  coupling_map=coupling_map, shots=shots, seed=self.seed)
+        counts = result1.get_counts("rand")
+        expected_probs = {
+            '00000': 0.079239867254200971,
+            '00001': 0.032859032998526903,
+            '00010': 0.10752610993531816,
+            '00011': 0.018818532050952699,
+            '00100': 0.054830807251011054,
+            '00101': 0.0034141983951965164,
+            '00110': 0.041649309748902276,
+            '00111': 0.039967731207338125,
+            '01000': 0.10516937819949743,
+            '01001': 0.026635620063700002,
+            '01010': 0.0053475143548793866,
+            '01011': 0.01940513314416064,
+            '01100': 0.0044028405481225047,
+            '01101': 0.057524760052126644,
+            '01110': 0.010795354134597078,
+            '01111': 0.026491296821535528,
+            '10000': 0.094827455395274859,
+            '10001': 0.0008373965072688836,
+            '10010': 0.029082297894094441,
+            '10011': 0.012386622870598416,
+            '10100': 0.018739140061148799,
+            '10101': 0.01367656456536896,
+            '10110': 0.039184170706009248,
+            '10111': 0.062339335178438288,
+            '11000': 0.00293674365989009,
+            '11001': 0.012848433960739968,
+            '11010': 0.018472497159499782,
+            '11011': 0.0088903691234912003,
+            '11100': 0.031305389080034329,
+            '11101': 0.0004788556283690458,
+            '11110': 0.002232419390471667,
+            '11111': 0.017684822659235985
+        }
+        target = {key: shots * val for key, val in expected_probs.items()}
+        threshold = 0.025 * shots
+        self.assertTrue(compare_dicts(counts, target, threshold))
 
     def test_symbolic_unary(self):
         """Test symbolic math in DAGBackend and optimizer with a prefix.

--- a/test/python/test_projectq_cpp_simulator.py
+++ b/test/python/test_projectq_cpp_simulator.py
@@ -106,7 +106,7 @@ class TestProjectQCppSimulator(QiskitTestCase):
         for circuit in self.rqg.get_circuits(format_='QuantumCircuit'):
             self.log.info(circuit.qasm())
             compiled_circuit = openquantumcompiler.compile(circuit)
-            shots = 100
+            shots = 1000
             min_cnts = int(shots / 10)
             job_pq = QuantumJob(compiled_circuit,
                                 backend='local_projectq_simulator',
@@ -125,7 +125,8 @@ class TestProjectQCppSimulator(QiskitTestCase):
                          if cnt > min_cnts}
             self.log.info('local_projectq_simulator: %s', str(counts_pq))
             self.log.info('local_qasm_simulator: %s', str(counts_py))
-            self.assertTrue(counts_pq.keys() == counts_py.keys())
+            threshold = 0.05 * shots
+            self.assertDictAlmostEqual(counts_pq, counts_py, threshold)
             states = counts_py.keys()
             # contingency table
             ctable = numpy.array([[counts_pq[key] for key in states],

--- a/test/python/test_qasm_python_simulator.py
+++ b/test/python/test_qasm_python_simulator.py
@@ -30,7 +30,7 @@ from qiskit import qasm, unroll, QuantumProgram, QuantumJob
 from qiskit.backends._qasmsimulator import QasmSimulator
 
 from ._random_qasm_generator import RandomQasmGenerator
-from .common import QiskitTestCase
+from .common import QiskitTestCase, compare_dicts
 
 
 class LocalQasmSimulatorTest(QiskitTestCase):
@@ -96,9 +96,14 @@ class LocalQasmSimulatorTest(QiskitTestCase):
     def test_qasm_simulator(self):
         """Test data counts output for single circuit run against reference."""
         result = QasmSimulator().run(self.q_job)
-        expected = {'100 100': 137, '011 011': 131, '101 101': 117, '111 111': 127,
-                    '000 000': 131, '010 010': 141, '110 110': 116, '001 001': 124}
-        self.assertEqual(result.get_counts('test'), expected)
+        shots = 1024
+        threshold = 0.025 * shots
+        counts = result.get_counts('test')
+        target = {'100 100': shots / 8, '011 011': shots / 8,
+                  '101 101': shots / 8, '111 111': shots / 8,
+                  '000 000': shots / 8, '010 010': shots / 8,
+                  '110 110': shots / 8, '001 001': shots / 8}
+        self.assertTrue(compare_dicts(counts, target, threshold))
 
     def test_if_statement(self):
         self.log.info('test_if_statement_x')

--- a/test/python/test_qasm_python_simulator.py
+++ b/test/python/test_qasm_python_simulator.py
@@ -30,7 +30,7 @@ from qiskit import qasm, unroll, QuantumProgram, QuantumJob
 from qiskit.backends._qasmsimulator import QasmSimulator
 
 from ._random_qasm_generator import RandomQasmGenerator
-from .common import QiskitTestCase, compare_dicts
+from .common import QiskitTestCase
 
 
 class LocalQasmSimulatorTest(QiskitTestCase):
@@ -103,7 +103,7 @@ class LocalQasmSimulatorTest(QiskitTestCase):
                   '101 101': shots / 8, '111 111': shots / 8,
                   '000 000': shots / 8, '010 010': shots / 8,
                   '110 110': shots / 8, '001 001': shots / 8}
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_if_statement(self):
         self.log.info('test_if_statement_x')

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -31,7 +31,7 @@ from qiskit import (ClassicalRegister, QISKitError, QuantumCircuit,
                     RegisterSizeError)
 from qiskit.tools import file_io
 import qiskit.backends
-from .common import requires_qe_access, QiskitTestCase, Path, compare_dicts
+from .common import requires_qe_access, QiskitTestCase, Path
 
 
 class TestQuantumProgram(QiskitTestCase):
@@ -839,7 +839,7 @@ class TestQuantumProgram(QiskitTestCase):
         counts = result.get_counts("circuitName")
         target = {'000': shots / 2, '111': shots / 2}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_compile_coupling_map_as_dict(self):
         """Test compile_coupling_map in dict format (to be deprecated).
@@ -873,7 +873,7 @@ class TestQuantumProgram(QiskitTestCase):
         counts = result.get_counts("circuitName")
         target = {'000': shots / 2, '111': shots / 2}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_change_circuit_qobj_after_compile(self):
         q_program = QuantumProgram(specs=self.QPS_SPECS)
@@ -995,8 +995,8 @@ class TestQuantumProgram(QiskitTestCase):
                    '011': shots / 8, '100': shots / 8, '101': shots / 8,
                    '110': shots / 8, '111': shots / 8}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts2, target2, threshold))
-        self.assertTrue(compare_dicts(counts3, target3, threshold))
+        self.assertDictAlmostEqual(counts2, target2, threshold)
+        self.assertDictAlmostEqual(counts3, target3, threshold)
 
     def test_run_async_program(self):
         """Test run_async.
@@ -1013,8 +1013,8 @@ class TestQuantumProgram(QiskitTestCase):
                            '011': shots / 8, '100': shots / 8, '101': shots / 8,
                            '110': shots / 8, '111': shots / 8}
                 threshold = 0.025 * shots
-                self.assertTrue(compare_dicts(counts2, target2, threshold))
-                self.assertTrue(compare_dicts(counts3, target3, threshold))
+                self.assertDictAlmostEqual(counts2, target2, threshold)
+                self.assertDictAlmostEqual(counts3, target3, threshold)
             except Exception as e:
                 self.qp_program_exception = e
             finally:
@@ -1069,8 +1069,8 @@ class TestQuantumProgram(QiskitTestCase):
                            '011': shots / 8, '100': shots / 8, '101': shots / 8,
                            '110': shots / 8, '111': shots / 8}
                 threshold = 0.025 * shots
-                self.assertTrue(compare_dicts(counts2, target2, threshold))
-                self.assertTrue(compare_dicts(counts3, target3, threshold))
+                self.assertDictAlmostEqual(counts2, target2, threshold)
+                self.assertDictAlmostEqual(counts3, target3, threshold)
             except Exception as e:
                 with lock:
                     qp_programs_exception.append(e)
@@ -1141,8 +1141,8 @@ class TestQuantumProgram(QiskitTestCase):
                        '011': shots / 8, '100': shots / 8, '101': shots / 8,
                        '110': shots / 8, '111': shots / 8}
             threshold = 0.025 * shots
-            self.assertTrue(compare_dicts(counts2, target2, threshold))
-            self.assertTrue(compare_dicts(counts3, target3, threshold))
+            self.assertDictAlmostEqual(counts2, target2, threshold)
+            self.assertDictAlmostEqual(counts3, target3, threshold)
 
     def test_run_batch_async(self):
         """Test run_batch_async
@@ -1160,8 +1160,8 @@ class TestQuantumProgram(QiskitTestCase):
                                '011': shots / 8, '100': shots / 8, '101': shots / 8,
                                '110': shots / 8, '111': shots / 8}
                     threshold = 0.025 * shots
-                    self.assertTrue(compare_dicts(counts2, target2, threshold))
-                    self.assertTrue(compare_dicts(counts3, target3, threshold))
+                    self.assertDictAlmostEqual(counts2, target2, threshold)
+                    self.assertDictAlmostEqual(counts3, target3, threshold)
             except Exception as e:
                 self.qp_program_exception = e
             finally:
@@ -1253,8 +1253,8 @@ class TestQuantumProgram(QiskitTestCase):
                    '011': shots / 8, '100': shots / 8, '101': shots / 8,
                    '110': shots / 8, '111': shots / 8}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts2, target2, threshold))
-        self.assertTrue(compare_dicts(counts3, target3, threshold))
+        self.assertDictAlmostEqual(counts2, target2, threshold)
+        self.assertDictAlmostEqual(counts3, target3, threshold)
 
     def test_local_qasm_simulator_one_shot(self):
         """Test single shot of local simulator .
@@ -1410,7 +1410,7 @@ class TestQuantumProgram(QiskitTestCase):
         counts = result.get_counts('qc')
         target = {'0': shots / 2, '1': shots / 2}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
     @requires_qe_access
     def test_simulator_online_size(self, QE_TOKEN, QE_URL):
@@ -1466,8 +1466,8 @@ class TestQuantumProgram(QiskitTestCase):
                    '10': shots / 4, '11': shots / 4}
         target2 = {'00': shots / 2, '11': shots / 2}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts1, target1, threshold))
-        self.assertTrue(compare_dicts(counts2, target2, threshold))
+        self.assertDictAlmostEqual(counts1, target1, threshold)
+        self.assertDictAlmostEqual(counts2, target2, threshold)
 
     @requires_qe_access
     def test_execute_one_circuit_real_online(self, QE_TOKEN, QE_URL):
@@ -1593,7 +1593,7 @@ class TestQuantumProgram(QiskitTestCase):
         counts = result.get_counts('new_circuit')
         target = {'00': shots / 2, '01': shots / 2}
         threshold = 0.025 * shots
-        self.assertTrue(compare_dicts(counts, target, threshold))
+        self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_add_circuit_fail(self):
         """Test add two circuits fail.
@@ -1680,11 +1680,11 @@ class TestQuantumProgram(QiskitTestCase):
         threshold = 0.025 * shots
         counts_bell = bellresult.get_counts('bell')
         target_bell = {'00000': shots / 2, '00011': shots / 2}
-        self.assertTrue(compare_dicts(counts_bell, target_bell, threshold))
+        self.assertDictAlmostEqual(counts_bell, target_bell, threshold)
 
         counts_ghz = ghzresult.get_counts('ghz')
         target_ghz = {'00000': shots / 2, '11111': shots / 2}
-        self.assertTrue(compare_dicts(counts_ghz, target_ghz, threshold))
+        self.assertDictAlmostEqual(counts_ghz, target_ghz, threshold)
 
     def test_example_swap_bits(self):
         """Test a toy example swapping a set bit around.


### PR DESCRIPTION
## Description
- Added a `assertDictAlmostEqual` function to `QiskitTestCase` for assessing if two numerical dictionaries are approximately equal. Function was based on `assertAlmostEqual` function from unittest.TestCase`.
- Updated tests which relied on a fixed seed when comparing the outcome of circuits with random measurement outcomes to use this function so that the tests shouldn't fail if any changes are made to RNG implementation.

## Motivation and Context
Tests that compare a counts dictionary which includes measurement sampling error to a target using a fixed seed are not portable to different test systems. This PR allows for approximate comparison of two counts dictionaries within an allowed threshold to account for sampling statistics.

## How Has This Been Tested?
Updated tests to use new function, all current tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.