### PR TITLE
Allow combining circuits with different unique registers

### DIFF
--- a/qiskit/_quantumcircuit.py
+++ b/qiskit/_quantumcircuit.py
@@ -129,10 +129,11 @@ class QuantumCircuit(object):
         """
         # Check compatibility and add new registers
         for name, register in rhs.regs.items():
-            if name in self.regs and register != self.regs[name]:
-                raise QISKitError("circuits are not compatible")
-            else:
+            if name not in self.regs:
                 self.add(register)
+            elif name in self.regs and register != self.regs[name]:
+                raise QISKitError("circuits are not compatible")
+
         # Add new gates
         for gate in rhs.data:
             gate.reapply(self)

--- a/qiskit/_quantumcircuit.py
+++ b/qiskit/_quantumcircuit.py
@@ -90,32 +90,50 @@ class QuantumCircuit(object):
 
     def combine(self, rhs):
         """
-        Append rhs to self if self contains rhs's registers.
+        Append rhs to self if self contains compatible registers.
+
+        Two circuits are compatible if they contain the same registers
+        or if they contain different registers with unique names. The
+        returned circuit will contain all unique registers between both
+        circuits.
 
         Return self + rhs as a new object.
         """
-        if self.name is not None and rhs.name is not None:
-            circuit_name = "c%sN%s" % (self.name, rhs.name)
-        else:
-            circuit_name = None
-        for register in rhs.regs.values():
-            if not self.has_register(register):
+        combined_registers = []
+        # Check registers in LHS are compatible with RHS
+        for name, register in self.regs.items():
+            if name in rhs.regs and register != rhs.regs[name]:
                 raise QISKitError("circuits are not compatible")
-        circuit = QuantumCircuit(
-            *[register for register in self.regs.values()], name=circuit_name)
+            else:
+                combined_registers.append(register)
+        # Add registers in RHS not in LHS
+        complement_registers = set(rhs.regs) - set(self.regs)
+        for name in complement_registers:
+            combined_registers.append(rhs.regs[name])
+        # Make new circuit with combined registers
+        circuit = QuantumCircuit(*combined_registers)
         for gate in itertools.chain(self.data, rhs.data):
             gate.reapply(circuit)
         return circuit
 
     def extend(self, rhs):
         """
-        Append rhs to self if self contains rhs's registers.
+        Append rhs to self if self if it contains compatible registers.
+
+        Two circuits are compatible if they contain the same registers
+        or if they contain different registers with unique names. The
+        returned circuit will contain all unique registers between both
+        circuits.
 
         Modify and return self.
         """
-        for register in rhs.regs.values():
-            if not self.has_register(register):
+        # Check compatibility and add new registers
+        for name, register in rhs.regs.items():
+            if name in self.regs and register != self.regs[name]:
                 raise QISKitError("circuits are not compatible")
+            else:
+                self.add(register)
+        # Add new gates
         for gate in rhs.data:
             gate.reapply(self)
         return self

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1595,23 +1595,45 @@ class TestQuantumProgram(QiskitTestCase):
         threshold = 0.025 * shots
         self.assertDictAlmostEqual(counts, target, threshold)
 
+    def test_add_circuit_different_registers(self):
+        """Test add two circuits.
+
+        If all correct should return the data
+        """
+
+        qr = QuantumRegister("qr", 2)
+        cr = ClassicalRegister("cr", 2)
+        qc1 = QuantumCircuit(qr)
+        qc1.x(qr)
+        qc2 = QuantumCircuit(qr, cr)
+        qc2.measure(qr, cr)
+
+        qp = QuantumProgram()
+        name = 'test'
+        qp.add_circuit(name, qc1 + qc2)
+        backend = 'local_qasm_simulator'  # the backend to run on
+        shots = 1024  # the number of shots in the experiment.
+        result = qp.execute(name, backend=backend, shots=shots, seed=78)
+        counts = result.get_counts(name)
+        target = {'11': shots}
+        threshold = 0.0
+        self.assertDictAlmostEqual(counts, target, threshold)
+
     def test_add_circuit_fail(self):
         """Test add two circuits fail.
 
-        If the circuits have different registers it should return a QISKitError
+        If two circuits have samed name register of different size or type
+        it should raise a QISKitError.
         """
-        q_program = QuantumProgram()
-        qr = q_program.create_quantum_register("qr", 1)
-        cr = q_program.create_classical_register("cr", 1)
-        q = q_program.create_quantum_register("q", 1)
-        c = q_program.create_classical_register("c", 1)
-        qc1 = q_program.create_circuit("qc1", [qr], [cr])
-        qc2 = q_program.create_circuit("qc2", [q], [c])
-        qc1.h(qr[0])
-        qc1.measure(qr[0], cr[0])
-        qc2.measure(q[0], c[0])
-        # new_circuit = qc1 + qc2
+        q1 = QuantumRegister("q", 1)
+        q2 = QuantumRegister("q", 2)
+        c1 = QuantumRegister("q", 1)
+        qc1 = QuantumCircuit(q1)
+        qc2 = QuantumCircuit(q2)
+        qc3 = QuantumCircuit(c1)
+
         self.assertRaises(QISKitError, qc1.__add__, qc2)
+        self.assertRaises(QISKitError, qc1.__add__, qc3)
 
     def test_example_multiple_compile(self):
         """Test a toy example compiling multiple circuits.

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1569,8 +1569,8 @@ class TestQuantumProgram(QiskitTestCase):
     # More test cases for interesting examples
     ###############################################################
 
-    def test_add_circuit(self):
-        """Test add two circuits.
+    def test_combine_circuit_common(self):
+        """Test combining two circuits with same registers.
 
         If all correct should return the data
         """
@@ -1583,20 +1583,19 @@ class TestQuantumProgram(QiskitTestCase):
         qc1.measure(qr[0], cr[0])
         qc2.measure(qr[1], cr[1])
         new_circuit = qc1 + qc2
-        q_program.add_circuit('new_circuit', new_circuit)
-        # new_circuit.measure(qr[0], cr[0])
-        circuits = ['new_circuit']
+        name = 'test_circuit'
+        q_program.add_circuit(name, new_circuit)
         backend = 'local_qasm_simulator'  # the backend to run on
         shots = 1024  # the number of shots in the experiment.
-        result = q_program.execute(circuits, backend=backend, shots=shots,
+        result = q_program.execute(name, backend=backend, shots=shots,
                                    seed=78)
-        counts = result.get_counts('new_circuit')
+        counts = result.get_counts(name)
         target = {'00': shots / 2, '01': shots / 2}
         threshold = 0.025 * shots
         self.assertDictAlmostEqual(counts, target, threshold)
 
-    def test_add_circuit_different_registers(self):
-        """Test add two circuits.
+    def test_combine_circuit_different(self):
+        """Test combinging two circuits with different registers.
 
         If all correct should return the data
         """
@@ -1619,8 +1618,8 @@ class TestQuantumProgram(QiskitTestCase):
         threshold = 0.0
         self.assertDictAlmostEqual(counts, target, threshold)
 
-    def test_add_circuit_fail(self):
-        """Test add two circuits fail.
+    def test_combine_circuit_fail(self):
+        """Test combining two circuits fails if registers incompatible.
 
         If two circuits have samed name register of different size or type
         it should raise a QISKitError.
@@ -1634,6 +1633,72 @@ class TestQuantumProgram(QiskitTestCase):
 
         self.assertRaises(QISKitError, qc1.__add__, qc2)
         self.assertRaises(QISKitError, qc1.__add__, qc3)
+
+    def test_extend_circuit(self):
+        """Test extending a circuit with same registers.
+
+        If all correct should return the data
+        """
+        q_program = QuantumProgram()
+        qr = q_program.create_quantum_register("qr", 2)
+        cr = q_program.create_classical_register("cr", 2)
+        qc1 = q_program.create_circuit("qc1", [qr], [cr])
+        qc2 = q_program.create_circuit("qc2", [qr], [cr])
+        qc1.h(qr[0])
+        qc1.measure(qr[0], cr[0])
+        qc2.measure(qr[1], cr[1])
+        qc1 += qc2
+        name = 'test_circuit'
+        q_program.add_circuit(name, qc1)
+        # new_circuit.measure(qr[0], cr[0])
+        backend = 'local_qasm_simulator'  # the backend to run on
+        shots = 1024  # the number of shots in the experiment.
+        result = q_program.execute(name, backend=backend, shots=shots,
+                                   seed=78)
+        counts = result.get_counts(name)
+        target = {'00': shots / 2, '01': shots / 2}
+        threshold = 0.025 * shots
+        self.assertDictAlmostEqual(counts, target, threshold)
+
+    def test_extend_circuit_different_registers(self):
+        """Test extending a circuit with different registers.
+
+        If all correct should return the data
+        """
+
+        qr = QuantumRegister("qr", 2)
+        cr = ClassicalRegister("cr", 2)
+        qc1 = QuantumCircuit(qr)
+        qc1.x(qr)
+        qc2 = QuantumCircuit(qr, cr)
+        qc2.measure(qr, cr)
+        qc1 += qc2
+        qp = QuantumProgram()
+        name = 'test_circuit'
+        qp.add_circuit(name, qc1)
+        backend = 'local_qasm_simulator'  # the backend to run on
+        shots = 1024  # the number of shots in the experiment.
+        result = qp.execute(name, backend=backend, shots=shots, seed=78)
+        counts = result.get_counts(name)
+        target = {'11': shots}
+        threshold = 0.0
+        self.assertDictAlmostEqual(counts, target, threshold)
+
+    def test_extend_circuit_fail(self):
+        """Test extending a circuits fails if registers incompatible.
+
+        If two circuits have samed name register of different size or type
+        it should raise a QISKitError.
+        """
+        q1 = QuantumRegister("q", 1)
+        q2 = QuantumRegister("q", 2)
+        c1 = QuantumRegister("q", 1)
+        qc1 = QuantumCircuit(q1)
+        qc2 = QuantumCircuit(q2)
+        qc3 = QuantumCircuit(c1)
+
+        self.assertRaises(QISKitError, qc1.__iadd__, qc2)
+        self.assertRaises(QISKitError, qc1.__iadd__, qc3)
 
     def test_example_multiple_compile(self):
         """Test a toy example compiling multiple circuits.


### PR DESCRIPTION
## Description

This patch modifies the `QuantumCircuit.combine` and `QuantumCircuit.extend` functions (and hence `+`, and `+=` operators) to allow combing circuits with common and/or distinct quantum and classical registers.

#### Example 1 (distinct registers)
```python
from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit

qr1 = QuantumRegister('q1', 2)
cr1 = ClassicalRegister('c1', 2)
qr2 = QuantumRegister('q2', 2)
cr2 = ClassicalRegister('c2', 2)

# Circ 1
qc1 = QuantumCircuit(qr1, cr1)
qc1.h(qr1)

# Circ 2
qc2 = QuantumCircuit(qr2, cr2)
qc2.x(qr2)

# Combine and add additional gates
circ = qc1 + qc2
circ.cx(qr1, qr2)
circ.measure(qr1, cr1)
circ.measure(qr2, cr2)
```
In this case the resulting qasm equivalents will be

```
# qc1
OPENQASM 2.0;
include "qelib1.inc";
qreg q1[2];
creg c1[2];
h q1[0];
h q1[1];

# qc2
OPENQASM 2.0;
include "qelib1.inc";
qreg q2[2];
creg c2[2];
x q2[0];
x q2[1];

# circ
OPENQASM 2.0;
include "qelib1.inc";
qreg q1[2];
creg c1[2];
creg c2[2];
qreg q2[2];
h q1[0];
h q1[1];
x q2[0];
x q2[1];
cx q1[0],q2[0];
cx q1[1],q2[1];
measure q1[0] -> c1[0];
measure q1[1] -> c1[1];
measure q2[0] -> c2[0];
measure q2[1] -> c2[1];
```

#### Example 2 (common register)
```python
from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit

qr1 = QuantumRegister('q1', 1)
qr2 = QuantumRegister('q2', 1)
cr = ClassicalRegister('c', 2)

# Circ 1
qc1 = QuantumCircuit(qr1, cr)
qc1.h(qr1)

# Circ 2
qc2 = QuantumCircuit(qr2, cr)
qc2.x(qr2)

# Combine and add additional gates
circ = qc1 + qc2
circ.cx(qr1, qr2)
circ.measure(qr1[0], cr[0])
circ.measure(qr2[0], cr[1])
```
In this case the resulting qasm equivalents will be
```
# qc1
OPENQASM 2.0;
include "qelib1.inc";
qreg q1[1];
creg c[2];
h q1[0];

# qc2
OPENQASM 2.0;
include "qelib1.inc";
qreg q2[1];
creg c[2];
x q2[0];

# circ
OPENQASM 2.0;
include "qelib1.inc";
qreg q1[1];
creg c[2];
qreg q2[1];
h q1[0];
x q2[0];
cx q1[0],q2[0];
measure q1[0] -> c[0];
measure q2[0] -> c[1];
```

#### Example 3 (raise an error)
```python
from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit

qr1 = QuantumRegister('reg', 1)
qr2 = QuantumRegister('reg', 2)
cr1 = ClassicalRegister('reg', 2)

qc1 = QuantumCircuit(qr1)
qc2 = QuantumCircuit(qr2)
qc3 = QuantumCircuit(cr1)

qc1 + qc2 # raises QISKitError due to registers having same name but different size
qc2 + qc3 # raises QISKitError due to registers having same name but different type
```

## Motivation and Context
When working with `QuantumCircuit` objects directly you should be able to combine circuits which are defined on different quantum and/or classical registers. In the case where two circuits have registers with common names these should be the same register or an error is raised.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.