### PR TITLE
use assertDictAlmostEqual in test_mapper

### DIFF
--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -52,12 +52,13 @@ class MapperTest(QiskitTestCase):
         """
         self.qp.load_qasm_file(self._get_resource_path('qasm/math_domain_error.qasm'), name='test')
         coupling_map = [[0, 2], [1, 2], [2, 3]]
+        shots = 2000
         result = self.qp.execute("test", backend="local_qasm_simulator",
                                  coupling_map=coupling_map,
-                                 seed=self.seed, shots=1024)
+                                 seed=self.seed, shots=shots)
         counts = result.get_counts("test")
-        target = {'0001': 480, '0101': 544}
-        threshold = 0.025 * 1024
+        target = {'0001': shots / 2, '0101':  shots / 2}
+        threshold = 0.025 * shots
         self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_optimize_1q_gates_issue159(self):

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -52,10 +52,13 @@ class MapperTest(QiskitTestCase):
         """
         self.qp.load_qasm_file(self._get_resource_path('qasm/math_domain_error.qasm'), name='test')
         coupling_map = [[0, 2], [1, 2], [2, 3]]
-        result1 = self.qp.execute(["test"], backend="local_qasm_simulator",
-                                  coupling_map=coupling_map, seed=self.seed)
-
-        self.assertEqual(result1.get_counts("test"), {'0001': 480, '0101': 544})
+        result = self.qp.execute("test", backend="local_qasm_simulator",
+                                 coupling_map=coupling_map,
+                                 seed=self.seed, shots=1024)
+        counts = result.get_counts("test")
+        target = {'0001': 480, '0101': 544}
+        threshold = 0.025 * 1024
+        self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_optimize_1q_gates_issue159(self):
         """Test change in behavior for optimize_1q_gates that removes u1(2*pi) rotations.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Seems like one test case was missed in #380 when we updated tests to allow tolerance intervals instead of exact comparisons.
This PR covers that.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.