### PR TITLE
Stop JobProcessor from modifying input qobj

### DIFF
--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -103,7 +103,6 @@ class JobProcessor:
                             future.qobj)
         with self.lock:
             logger.debug("Have a Result: %s", pprint.pformat(result))
-            self.futures[future]['result'] = result
             self.jobs_results.append(result)
             if self.num_jobs != 0:
                 self.num_jobs -= 1


### PR DESCRIPTION
Fixes #391 

## Description

Stops `JobProcessor` from modifying input qobj to `QuantumProgram.run`.

## Motivation and Context
See issue #391 

## How Has This Been Tested?
All tests pass

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.