### PR TITLE
Serializable Qobj + Pass cpp/projectq simulator tests

### DIFF
--- a/qiskit/_compiler.py
+++ b/qiskit/_compiler.py
@@ -127,8 +127,7 @@ def compile(list_of_circuits, backend, compile_config=None):
     qobj['id'] = qobj_id
     qobj['config'] = {'max_credits': max_credits,
                       'shots': shots,
-                      'backend_name': backend_name
-                     }
+                      'backend_name': backend_name}
 
     # TODO This backend needs HPC parameters to be passed in order to work
     if backend_name == 'ibmqx_hpc_qasm_simulator':

--- a/qiskit/_compiler.py
+++ b/qiskit/_compiler.py
@@ -76,7 +76,7 @@ def execute(list_of_circuits, backend, compile_config=None,
     qobj = compile(list_of_circuits, backend, compile_config)
 
     # XXX When qobj is done this should replace q_job
-    q_job = QuantumJob(qobj, preformatted=True, resources={
+    q_job = QuantumJob(qobj, backend=backend, preformatted=True, resources={
         'max_credits': qobj['config']['max_credits'], 'wait': wait, 'timeout': timeout})
     result = backend.run(q_job)
     return result
@@ -125,8 +125,10 @@ def compile(list_of_circuits, backend, compile_config=None):
         qobj_id = "".join([random.choice(string.ascii_letters + string.digits)
                            for n in range(30)])
     qobj['id'] = qobj_id
-    qobj["config"] = {"max_credits": max_credits, 'backend': backend,
-                      "shots": shots}
+    qobj['config'] = {'max_credits': max_credits,
+                      'shots': shots,
+                      'backend_name': backend_name
+                     }
 
     # TODO This backend needs HPC parameters to be passed in order to work
     if backend_name == 'ibmqx_hpc_qasm_simulator':

--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -21,6 +21,7 @@ import pprint
 from concurrent import futures
 from threading import Lock
 
+from ._qiskiterror import QISKitError
 from ._compiler import compile_circuit
 from ._result import Result
 
@@ -38,6 +39,12 @@ def run_backend(q_job):
     """
     backend = q_job.backend
     qobj = q_job.qobj
+    backend_name = qobj['config']['backend_name']
+    if not backend:
+        raise QISKitError("No backend instance to run on.")
+    if backend_name != backend.configuration['name']:
+        raise QISKitError('non-matching backends specified in Qobj '
+                          'object and json')
     if backend.configuration.get('local'):  # remove condition when api gets qobj
         for circuit in qobj['circuits']:
             if circuit['compiled_circuit'] is None:

--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -36,6 +36,9 @@ def run_backend(q_job):
 
     Returns:
         Result: Result object.
+
+    Raises:
+        QISKitError: if the backend is malformed
     """
     backend = q_job.backend
     qobj = q_job.qobj

--- a/qiskit/_quantumjob.py
+++ b/qiskit/_quantumjob.py
@@ -21,7 +21,6 @@ import random
 import string
 
 # stable modules
-from qiskit import QISKitError
 from ._quantumcircuit import QuantumCircuit
 from .qasm import Qasm
 
@@ -35,7 +34,7 @@ class QuantumJob():
 
     # TODO We need to create more tests for checking all possible inputs.
     # TODO Make this interface clearer -- circuits could be many things!
-    def __init__(self, circuits, backend=None,
+    def __init__(self, circuits, backend,
                  circuit_config=None, seed=None,
                  resources=None,
                  shots=1024, names=None,
@@ -45,8 +44,7 @@ class QuantumJob():
             circuits (QuantumCircuit|DagCircuit | list(QuantumCircuit|DagCircuit)):
                 QuantumCircuit|DagCircuit or list of QuantumCircuit|DagCircuit.
                 If preformatted=True, this is a raw qobj.
-            backend (BaseBackend): The backend to run the circuit on, required
-                if preformatted=False.
+            backend (BaseBackend): The backend to run the circuit on, required.
             circuit_config (dict): Circuit configuration.
             seed (int): The intial seed the simulatros use.
             resources (dict): Resource requirements of job.
@@ -82,12 +80,10 @@ class QuantumJob():
             # circuits is actually a qobj...validate (not ideal but convenient)
             self.qobj = circuits
         else:
-            if not backend:
-                raise QISKitError('backend needs to be specified if '
-                                  'preformatted==True.')
             self.qobj = self._create_qobj(circuits, circuit_config, backend,
                                           seed, resources, shots, do_compile)
-        self.backend = self.qobj['config']['backend']
+        self.backend_name = self.qobj['config']['backend_name']
+        self.backend = backend
         self.resources = resources
         self.seed = seed
         self.result = None
@@ -146,7 +142,7 @@ class QuantumJob():
                 'config': {
                     'max_credits': resources['max_credits'],
                     'shots': shots,
-                    'backend': backend
+                    'backend_name': backend.configuration['name']
                 },
                 'circuits': circuit_records}
 

--- a/qiskit/_quantumjob.py
+++ b/qiskit/_quantumjob.py
@@ -82,7 +82,6 @@ class QuantumJob():
         else:
             self.qobj = self._create_qobj(circuits, circuit_config, backend,
                                           seed, resources, shots, do_compile)
-        self.backend_name = self.qobj['config']['backend_name']
         self.backend = backend
         self.resources = resources
         self.seed = seed

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1047,7 +1047,7 @@ class QuantumProgram(object):
         execution_list = []
 
         print_func("id: %s" % qobj['id'])
-        print_func("backend: %s" % qobj['config']['backend'])
+        print_func("backend: %s" % qobj['config']['backend_name'])
         print_func("qobj config:")
         for key in qobj['config']:
             if key != 'backend':
@@ -1229,7 +1229,8 @@ class QuantumProgram(object):
     def _run_internal(self, qobj_list, wait=5, timeout=60, callback=None):
         q_job_list = []
         for qobj in qobj_list:
-            q_job = QuantumJob(qobj, preformatted=True, resources={
+            backend = qiskit.wrapper.get_backend(qobj['config']['backend_name'])
+            q_job = QuantumJob(qobj, backend=backend, preformatted=True, resources={
                 'max_credits': qobj['config']['max_credits'], 'wait': wait,
                 'timeout': timeout})
             q_job_list.append(q_job)

--- a/qiskit/_result.py
+++ b/qiskit/_result.py
@@ -86,8 +86,8 @@ class Result(object):
         # sessions)
         my_config = copy.deepcopy(self._qobj['config'])
         other_config = copy.deepcopy(other._qobj['config'])
-        my_backend = my_config.pop('backend').configuration['name']
-        other_backend = other_config.pop('backend').configuration['name']
+        my_backend = my_config.pop('backend_name')
+        other_backend = other_config.pop('backend_name')
 
         if my_config == other_config and my_backend == other_backend:
             if isinstance(self._qobj['id'], str):

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -88,7 +88,7 @@ class IBMQBackend(BaseBackend):
 
         seed0 = qobj['circuits'][0]['config']['seed']
         hpc = None
-        if (qobj['config']['backend'] == 'ibmqx_hpc_qasm_simulator' and
+        if (qobj['config']['backend_name'] == 'ibmqx_hpc_qasm_simulator' and
                 'hpc' in qobj['config']):
             try:
                 # Use CamelCase when passing the hpc parameters to the API.
@@ -103,7 +103,8 @@ class IBMQBackend(BaseBackend):
 
         # TODO: this should be self._configuration['name'] - need to check that
         # it is always the case.
-        backend_name = qobj['config']['backend'].configuration['name']
+        #backend_name = qobj['config']['backend_name'].configuration['name']
+        backend_name = qobj['config']['backend_name']
         output = self._api.run_job(api_jobs, backend_name,
                                    shots=qobj['config']['shots'],
                                    max_credits=qobj['config']['max_credits'],
@@ -113,13 +114,13 @@ class IBMQBackend(BaseBackend):
             raise ResultError(output['error'])
 
         logger.info('Running qobj: %s on remote backend %s with job id: %s',
-                    qobj["id"], qobj['config']['backend'], output['id'])
+                    qobj["id"], qobj['config']['backend_name'], output['id'])
         job_result = _wait_for_job(output['id'], self._api, wait=wait,
                                    timeout=timeout)
         logger.info('Got a result for qobj: %s from remote backend %s with job id: %s',
-                    qobj["id"], qobj['config']['backend'], output['id'])
+                    qobj["id"], qobj['config']['backend_name'], output['id'])
         job_result['name'] = qobj['id']
-        job_result['backend'] = qobj['config']['backend']
+        job_result['backend'] = qobj['config']['backend_name']
         this_result = Result(job_result, qobj)
         return this_result
 

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -103,7 +103,6 @@ class IBMQBackend(BaseBackend):
 
         # TODO: this should be self._configuration['name'] - need to check that
         # it is always the case.
-        #backend_name = qobj['config']['backend_name'].configuration['name']
         backend_name = qobj['config']['backend_name']
         output = self._api.run_job(api_jobs, backend_name,
                                    shots=qobj['config']['shots'],

--- a/test/performance/vqe.py
+++ b/test/performance/vqe.py
@@ -83,7 +83,7 @@ def vqe(molecule='H2', depth=6, max_trials=200, shots=1):
     if shots != 1:
         H = group_paulis(pauli_list)
 
-    entangler_map = qp.configuration(device)['coupling_map']
+    entangler_map = qp.get_backend_configuration(device)['coupling_map']
 
     if entangler_map == 'all-to-all':
         entangler_map = {i: [j for j in range(n_qubits) if j != i] for i in range(n_qubits)}

--- a/test/python/qobj/cpp_conditionals.json
+++ b/test/python/qobj/cpp_conditionals.json
@@ -3,7 +3,7 @@
     "config": {
         "shots": 1,
         "seed": 1,
-        "backend": "local_qasm_simulator_cpp"
+        "backend_name": "local_qiskit_simulator"
     },
     "circuits": [
         {

--- a/test/python/qobj/cpp_measure_opt.json
+++ b/test/python/qobj/cpp_measure_opt.json
@@ -3,7 +3,7 @@
     "config": {
         "shots": 2000,
         "seed": 1,
-        "backend": "local_qasm_simulator_cpp"
+        "backend_name": "local_qiskit_simulator"
     },
     "circuits": [
         {

--- a/test/python/qobj/cpp_reset.json
+++ b/test/python/qobj/cpp_reset.json
@@ -3,7 +3,7 @@
     "config": {
         "shots": 1,
         "seed": 1,
-        "backend": "local_qasm_simulator_cpp"
+        "backend_name": "local_qiskit_simulator"
     },
     "circuits": [
         {

--- a/test/python/qobj/cpp_save_load.json
+++ b/test/python/qobj/cpp_save_load.json
@@ -3,7 +3,7 @@
     "config": {
         "shots": 1,
         "seed": 1,
-        "backend": "local_qasm_simulator_cpp"
+        "backend_name": "local_qiskit_simulator"
     },
     "circuits": [
         {

--- a/test/python/qobj/cpp_single_qubit_gates.json
+++ b/test/python/qobj/cpp_single_qubit_gates.json
@@ -3,7 +3,7 @@
     "config": {
         "shots": 1,
         "seed": 1,
-        "backend": "local_qasm_simulator_cpp"
+        "backend_name": "local_qiskit_simulator"
     },
     "circuits": [
         {

--- a/test/python/qobj/cpp_two_qubit_gates.json
+++ b/test/python/qobj/cpp_two_qubit_gates.json
@@ -3,7 +3,7 @@
     "config": {
         "shots": 1,
         "seed": 1,
-        "backend": "local_qasm_simulator_cpp"
+        "backend_name": "local_qiskit_simulator"
     },
     "circuits": [
         {

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -43,7 +43,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        my_backend = QasmSimulator()
+        backend = QasmSimulator()
 
         qubit_reg = qiskit.QuantumRegister(2, name='q')
         clbit_reg = qiskit.ClassicalRegister(2, name='c')
@@ -52,7 +52,7 @@ class TestCompiler(QiskitTestCase):
         qc.cx(qubit_reg[0], qubit_reg[1])
         qc.measure(qubit_reg, clbit_reg)
 
-        qobj = qiskit._compiler.compile(qc, my_backend)
+        qobj = qiskit._compiler.compile(qc, backend)
 
         # FIXME should test against the qobj when defined
         self.assertEqual(len(qobj), 3)
@@ -62,7 +62,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        my_backend = QasmSimulator()
+        backend = QasmSimulator()
 
         qubit_reg = qiskit.QuantumRegister(2, name='q')
         clbit_reg = qiskit.ClassicalRegister(2, name='c')
@@ -72,7 +72,7 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qubit_reg, clbit_reg)
         qc_extra = qiskit.QuantumCircuit(qubit_reg, clbit_reg, name="extra")
         qc_extra.measure(qubit_reg, clbit_reg)
-        qobj = qiskit._compiler.compile([qc, qc_extra], my_backend)
+        qobj = qiskit._compiler.compile([qc, qc_extra], backend)
 
         # FIXME should test against the qobj when defined
         self.assertEqual(len(qobj), 3)
@@ -82,7 +82,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        my_backend = QasmSimulator()
+        backend = QasmSimulator()
 
         qubit_reg = qiskit.QuantumRegister(2, name='q')
         clbit_reg = qiskit.ClassicalRegister(2, name='c')
@@ -91,8 +91,8 @@ class TestCompiler(QiskitTestCase):
         qc.cx(qubit_reg[0], qubit_reg[1])
         qc.measure(qubit_reg, clbit_reg)
 
-        qobj = qiskit._compiler.compile(qc, my_backend)
-        result = my_backend.run(qiskit.QuantumJob(qobj, preformatted=True))
+        qobj = qiskit._compiler.compile(qc, backend)
+        result = backend.run(qiskit.QuantumJob(qobj, backend=backend, preformatted=True))
         self.assertIsInstance(result, Result)
 
     def test_compile_two_run(self):
@@ -100,7 +100,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        my_backend = QasmSimulator()
+        backend = QasmSimulator()
 
         qubit_reg = qiskit.QuantumRegister(2, name='q')
         clbit_reg = qiskit.ClassicalRegister(2, name='c')
@@ -110,8 +110,8 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qubit_reg, clbit_reg)
         qc_extra = qiskit.QuantumCircuit(qubit_reg, clbit_reg, name="extra")
         qc_extra.measure(qubit_reg, clbit_reg)
-        qobj = qiskit._compiler.compile([qc, qc_extra], my_backend)
-        result = my_backend.run(qiskit.QuantumJob(qobj, preformatted=True))
+        qobj = qiskit._compiler.compile([qc, qc_extra], backend)
+        result = backend.run(qiskit.QuantumJob(qobj, backend=backend, preformatted=True))
         self.assertIsInstance(result, Result)
 
     def test_execute(self):
@@ -119,7 +119,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        my_backend = QasmSimulator()
+        backend = QasmSimulator()
 
         qubit_reg = qiskit.QuantumRegister(2)
         clbit_reg = qiskit.ClassicalRegister(2)
@@ -128,7 +128,7 @@ class TestCompiler(QiskitTestCase):
         qc.cx(qubit_reg[0], qubit_reg[1])
         qc.measure(qubit_reg, clbit_reg)
 
-        results = qiskit._compiler.execute(qc, my_backend)
+        results = qiskit._compiler.execute(qc, backend)
 
         self.assertIsInstance(results, Result)
 
@@ -137,7 +137,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        my_backend = QasmSimulator()
+        backend = QasmSimulator()
 
         qubit_reg = qiskit.QuantumRegister(2)
         clbit_reg = qiskit.ClassicalRegister(2)
@@ -147,7 +147,7 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qubit_reg, clbit_reg)
         qc_extra = qiskit.QuantumCircuit(qubit_reg, clbit_reg)
         qc_extra.measure(qubit_reg, clbit_reg)
-        results = qiskit._compiler.execute([qc, qc_extra], my_backend)
+        results = qiskit._compiler.execute([qc, qc_extra], backend)
 
         self.assertIsInstance(results, Result)
 
@@ -158,7 +158,7 @@ class TestCompiler(QiskitTestCase):
         If all correct some should exists.
         """
         provider = IBMQProvider(QE_TOKEN, QE_URL)
-        my_backend = lowest_pending_jobs(
+        backend = lowest_pending_jobs(
             provider.available_backends({'local': False, 'simulator': False}))
 
         qubit_reg = qiskit.QuantumRegister(2, name='q')
@@ -168,7 +168,7 @@ class TestCompiler(QiskitTestCase):
         qc.cx(qubit_reg[0], qubit_reg[1])
         qc.measure(qubit_reg, clbit_reg)
 
-        qobj = qiskit._compiler.compile(qc, my_backend)
+        qobj = qiskit._compiler.compile(qc, backend)
 
         # FIXME should test against the qobj when defined
         self.assertEqual(len(qobj), 3)
@@ -180,7 +180,7 @@ class TestCompiler(QiskitTestCase):
         If all correct some should exists.
         """
         provider = IBMQProvider(QE_TOKEN, QE_URL)
-        my_backend = lowest_pending_jobs(
+        backend = lowest_pending_jobs(
             provider.available_backends({'local': False, 'simulator': False}))
 
         qubit_reg = qiskit.QuantumRegister(2, name='q')
@@ -191,7 +191,7 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qubit_reg, clbit_reg)
         qc_extra = qiskit.QuantumCircuit(qubit_reg, clbit_reg, name="extra")
         qc_extra.measure(qubit_reg, clbit_reg)
-        qobj = qiskit._compiler.compile([qc, qc_extra], my_backend)
+        qobj = qiskit._compiler.compile([qc, qc_extra], backend)
 
         # FIXME should test against the qobj when defined
         self.assertEqual(len(qobj), 3)
@@ -203,7 +203,7 @@ class TestCompiler(QiskitTestCase):
         If all correct some should exists.
         """
         provider = IBMQProvider(QE_TOKEN, QE_URL)
-        my_backend = provider.get_backend('ibmqx_qasm_simulator')
+        backend = provider.get_backend('ibmqx_qasm_simulator')
         qubit_reg = qiskit.QuantumRegister(2, name='q')
         clbit_reg = qiskit.ClassicalRegister(2, name='c')
         qc = qiskit.QuantumCircuit(qubit_reg, clbit_reg, name="bell")
@@ -211,8 +211,8 @@ class TestCompiler(QiskitTestCase):
         qc.cx(qubit_reg[0], qubit_reg[1])
         qc.measure(qubit_reg, clbit_reg)
 
-        qobj = qiskit._compiler.compile(qc, my_backend)
-        result = my_backend.run(qiskit.QuantumJob(qobj, preformatted=True))
+        qobj = qiskit._compiler.compile(qc, backend)
+        result = backend.run(qiskit.QuantumJob(qobj, backend=backend, preformatted=True))
         self.assertIsInstance(result, Result)
 
     @requires_qe_access
@@ -222,7 +222,7 @@ class TestCompiler(QiskitTestCase):
         If all correct some should exists.
         """
         provider = IBMQProvider(QE_TOKEN, QE_URL)
-        my_backend = provider.get_backend('ibmqx_qasm_simulator')
+        backend = provider.get_backend('ibmqx_qasm_simulator')
         qubit_reg = qiskit.QuantumRegister(2, name='q')
         clbit_reg = qiskit.ClassicalRegister(2, name='c')
         qc = qiskit.QuantumCircuit(qubit_reg, clbit_reg, name="bell")
@@ -231,8 +231,8 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qubit_reg, clbit_reg)
         qc_extra = qiskit.QuantumCircuit(qubit_reg, clbit_reg, name="extra")
         qc_extra.measure(qubit_reg, clbit_reg)
-        qobj = qiskit._compiler.compile([qc, qc_extra], my_backend)
-        result = my_backend.run(qiskit.QuantumJob(qobj, preformatted=True))
+        qobj = qiskit._compiler.compile([qc, qc_extra], backend)
+        result = backend.run(qiskit.QuantumJob(qobj, backend=backend, preformatted=True))
         self.assertIsInstance(result, Result)
 
     @requires_qe_access
@@ -242,7 +242,7 @@ class TestCompiler(QiskitTestCase):
         If all correct some should exists.
         """
         provider = IBMQProvider(QE_TOKEN, QE_URL)
-        my_backend = provider.get_backend('ibmqx_qasm_simulator')
+        backend = provider.get_backend('ibmqx_qasm_simulator')
 
         qubit_reg = qiskit.QuantumRegister(2)
         clbit_reg = qiskit.ClassicalRegister(2)
@@ -251,7 +251,7 @@ class TestCompiler(QiskitTestCase):
         qc.cx(qubit_reg[0], qubit_reg[1])
         qc.measure(qubit_reg, clbit_reg)
 
-        results = qiskit._compiler.execute(qc, my_backend)
+        results = qiskit._compiler.execute(qc, backend)
         self.assertIsInstance(results, Result)
 
     @requires_qe_access
@@ -261,7 +261,7 @@ class TestCompiler(QiskitTestCase):
         If all correct some should exists.
         """
         provider = IBMQProvider(QE_TOKEN, QE_URL)
-        my_backend = provider.get_backend('ibmqx_qasm_simulator')
+        backend = provider.get_backend('ibmqx_qasm_simulator')
 
         qubit_reg = qiskit.QuantumRegister(2)
         clbit_reg = qiskit.ClassicalRegister(2)
@@ -271,7 +271,7 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qubit_reg, clbit_reg)
         qc_extra = qiskit.QuantumCircuit(qubit_reg, clbit_reg)
         qc_extra.measure(qubit_reg, clbit_reg)
-        results = qiskit._compiler.execute([qc, qc_extra], my_backend)
+        results = qiskit._compiler.execute([qc, qc_extra], backend)
 
         self.assertIsInstance(results, Result)
 

--- a/test/python/test_job_processor.py
+++ b/test/python/test_job_processor.py
@@ -116,14 +116,14 @@ class TestJobProcessor(QiskitTestCase):
                     'max_credits': 3,
                     'shots': 1024,
                     'seed': None,
-                    'backend': backend},
+                    'backend_name': backend.configuration['name']},
                 'circuits': [
                     {'name': 'example',
                      'compiled_circuit': formatted_circuit,
                      'layout': None,
                      'seed': None}
                 ]}
-        _ = QuantumJob(qobj, preformatted=True)
+        _ = QuantumJob(qobj, backend=backend, preformatted=True)
 
     def test_init_job_processor(self):
         njobs = 5

--- a/test/python/test_local_qasm_simulator_cpp.py
+++ b/test/python/test_local_qasm_simulator_cpp.py
@@ -61,7 +61,7 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
                      'config': {
                          'max_credits': 3,
                          'shots': 2000,
-                         'backend': 'local_qiskit_simulator',
+                         'backend_name': 'local_qiskit_simulator',
                          'seed': 1111
                      },
                      'circuits': [
@@ -78,15 +78,16 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
                              'layout': None,
                          }
                      ]}
-        self.q_job = QuantumJob(self.qobj,
-                                backend='local_qiskit_simulator',
-                                preformatted=True)
         # Simulator backend
         try:
             self.backend = QasmSimulatorCpp()
         except FileNotFoundError as fnferr:
             raise unittest.SkipTest(
                 'cannot find {} in path'.format(fnferr))
+
+        self.q_job = QuantumJob(self.qobj,
+                                backend=self.backend,
+                                preformatted=True)
 
     def test_x90_coherent_error_matrix(self):
         X90 = np.array([[1, -1j], [-1j, 1]]) / np.sqrt(2)
@@ -138,7 +139,7 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
         filename = self._get_resource_path('qobj/cpp_measure_opt.json')
         with open(filename, 'r') as file:
             q_job = QuantumJob(json.load(file),
-                               backend='local_qasm_simulator_cpp',
+                               backend=self.backend,
                                preformatted=True)
         result = self.backend.run(q_job)
         shots = q_job.qobj['config']['shots']
@@ -217,7 +218,7 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
         filename = self._get_resource_path('qobj/cpp_reset.json')
         with open(filename, 'r') as file:
             q_job = QuantumJob(json.load(file),
-                               backend='local_qasm_simulator_cpp',
+                               backend=self.backend,
                                preformatted=True)
         result = self.backend.run(q_job)
         expected_data = {
@@ -243,7 +244,7 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
         filename = self._get_resource_path('qobj/cpp_save_load.json')
         with open(filename, 'r') as file:
             q_job = QuantumJob(json.load(file),
-                               backend='local_qasm_simulator_cpp',
+                               backend=self.backend,
                                preformatted=True)
         result = self.backend.run(q_job)
 
@@ -271,7 +272,7 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
         filename = self._get_resource_path('qobj/cpp_single_qubit_gates.json')
         with open(filename, 'r') as file:
             q_job = QuantumJob(json.load(file),
-                               backend='local_qasm_simulator_cpp',
+                               backend=self.backend,
                                preformatted=True)
         result = self.backend.run(q_job)
         expected_data = {
@@ -364,7 +365,7 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
         filename = self._get_resource_path('qobj/cpp_two_qubit_gates.json')
         with open(filename, 'r') as file:
             q_job = QuantumJob(json.load(file),
-                               backend='local_qasm_simulator_cpp',
+                               backend=self.backend,
                                preformatted=True)
         result = self.backend.run(q_job)
         expected_data = {
@@ -423,7 +424,7 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
         filename = self._get_resource_path('qobj/cpp_conditionals.json')
         with open(filename, 'r') as file:
             q_job = QuantumJob(json.load(file),
-                               backend='local_qasm_simulator_cpp',
+                               backend=self.backend,
                                preformatted=True)
         result = self.backend.run(q_job)
         expected_data = {

--- a/test/python/test_qasm_python_simulator.py
+++ b/test/python/test_qasm_python_simulator.py
@@ -66,7 +66,7 @@ class LocalQasmSimulatorTest(QiskitTestCase):
                      'config': {
                          'max_credits': resources['max_credits'],
                          'shots': 1024,
-                         'backend': 'local_qasm_simulator',
+                         'backend_name': 'local_qasm_simulator',
                      },
                      'circuits': [
                          {
@@ -77,7 +77,7 @@ class LocalQasmSimulatorTest(QiskitTestCase):
                          }
                      ]}
         self.q_job = QuantumJob(self.qobj,
-                                backend='local_qasm_simulator',
+                                backend=QasmSimulator(),
                                 circuit_config=circuit_config,
                                 seed=self.seed,
                                 resources=resources,
@@ -143,7 +143,7 @@ class LocalQasmSimulatorTest(QiskitTestCase):
             'config': {
                 'max_credits': 3,
                 'shots': shots,
-                'backend': 'local_qasm_simulator',
+                'backend_name': 'local_qasm_simulator',
             },
             'circuits': [
                 {
@@ -170,7 +170,7 @@ class LocalQasmSimulatorTest(QiskitTestCase):
                 }
             ]
         }
-        q_job = QuantumJob(qobj, preformatted=True)
+        q_job = QuantumJob(qobj, backend=QasmSimulator(), preformatted=True)
         result = QasmSimulator().run(q_job)
         result_if_true = result.get_data('test_if_true')
         self.log.info('result_if_true circuit:')

--- a/test/python/test_qasm_sympy_simulator.py
+++ b/test/python/test_qasm_sympy_simulator.py
@@ -50,7 +50,7 @@ class LocalQasmSimulatorTest(QiskitTestCase):
                      'config': {
                          'max_credits': resources['max_credits'],
                          'shots': 1024,
-                         'backend': 'local_sympy_qasm_simulator',
+                         'backend_name': 'local_sympy_qasm_simulator',
                      },
                      'circuits': [
                          {
@@ -61,7 +61,7 @@ class LocalQasmSimulatorTest(QiskitTestCase):
                          }
                      ]}
         self.q_job = QuantumJob(self.qobj,
-                                backend='local_sympy_qasm_simulator',
+                                backend=SympyQasmSimulator,
                                 circuit_config=circuit_config,
                                 seed=self.seed,
                                 resources=resources,

--- a/test/python/test_qasm_sympy_simulator.py
+++ b/test/python/test_qasm_sympy_simulator.py
@@ -61,7 +61,7 @@ class LocalQasmSimulatorTest(QiskitTestCase):
                          }
                      ]}
         self.q_job = QuantumJob(self.qobj,
-                                backend=SympyQasmSimulator,
+                                backend=SympyQasmSimulator(),
                                 circuit_config=circuit_config,
                                 seed=self.seed,
                                 resources=resources,

--- a/test/python/test_unitary_python_simulator.py
+++ b/test/python/test_unitary_python_simulator.py
@@ -60,7 +60,7 @@ class LocalUnitarySimulatorTest(QiskitTestCase):
             'config': {
                 'max_credits': None,
                 'shots': 1,
-                'backend': 'local_unitary_simulator'
+                'backend_name': 'local_unitary_simulator'
             },
             'circuits': [
                 {
@@ -84,7 +84,7 @@ class LocalUnitarySimulatorTest(QiskitTestCase):
         expected = np.loadtxt(self._get_resource_path('example_unitary_matrix.dat'),
                               dtype='complex', delimiter=',')
         q_job = QuantumJob(qobj,
-                           backend='local_unitary_simulator',
+                           backend=UnitarySimulator(),
                            preformatted=True)
 
         result = UnitarySimulator().run(q_job)
@@ -142,7 +142,7 @@ class LocalUnitarySimulatorTest(QiskitTestCase):
         self.qp = random_circuits.get_program()
         pr.enable()
         self.qp.execute(self.qp.get_circuit_names(),
-                        backend='local_unitary_simulator')
+                        backend=UnitarySimulator())
         pr.disable()
         sout = io.StringIO()
         ps = pstats.Stats(pr, stream=sout).sort_stats('cumulative')

--- a/test/python/test_unitary_sympy_simulator.py
+++ b/test/python/test_unitary_sympy_simulator.py
@@ -52,7 +52,7 @@ class LocalUnitarySimulatorTest(QiskitTestCase):
             'config': {
                 'max_credits': None,
                 'shots': 1,
-                'backend': 'local_sympy_unitary_simulator'
+                'backend_name': 'local_sympy_unitary_simulator'
             },
             'circuits': [
                 {
@@ -70,7 +70,7 @@ class LocalUnitarySimulatorTest(QiskitTestCase):
         }
 
         q_job = QuantumJob(qobj,
-                           backend='local_sympy_unitary_simulator',
+                           backend=SympyUnitarySimulator(),
                            preformatted=True)
 
         result = SympyUnitarySimulator().run(q_job)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I realized that the previous PR merge broke our c++ simulator and Project Q simulators. It was because our c++ simulator tests were flawed (they were actually using the Python backend!), and the ProjectQ simulator was not installed on Travis.

The problem was with the Qobj dictionary created. The value for the`backend` field was a `Backend` instance, but this is not valid JSON and those simulators that expect and decode JSON will throw errors. I made this point to the backend string, but included a copy of the instance in the QuantumJob wrapper. Going forward, this will be part of the Qobj object.


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.