### PR TITLE
Reintroduce remote discovery during qp.set_api() and openquantumcompiler.dag2json()

### DIFF
--- a/qiskit/_openquantumcompiler.py
+++ b/qiskit/_openquantumcompiler.py
@@ -133,6 +133,20 @@ def load_unroll_qasm_file(filename, basis_gates='u1,u2,u3,cx,id'):
     return circuit_unrolled
 
 
+def dag2json(dag_circuit, basis_gates='u1,u2,u3,cx,id'):
+    """Make a Json representation of the circuit.
+    Takes a circuit dag and returns json circuit obj. This is an internal
+    function.
+    Args:
+        dag_circuit (QuantumCircuit): a dag representation of the circuit.
+        basis_gates (str): a comma seperated string and are the base gates,
+                               which by default are: u1,u2,u3,cx,id
+    Returns:
+        json: the json version of the dag
+    """
+    return DagUnroller(dag_circuit, JsonBackend(basis_gates)).execute()
+
+
 class QISKitCompilerError(QISKitError):
     """Exceptions raised during compilation"""
     pass

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -722,6 +722,7 @@ class QuantumProgram(object):
             if proxies:
                 config_dict['proxies'] = proxies
             self.__api = IBMQuantumExperience(token, config_dict, verify)
+            qiskit.backends.discover_remote_backends(self.__api)
         except Exception as ex:
             root_exception = ex
             if 'License required' in str(ex):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Reintroduce the discovery of remote backends during `QuantumProgram.set_api()`, as noted in https://github.com/QISKit/qiskit-tutorial/issues/136, as it seems it has been removed inadvertently, and without it the user would need to manually call `available_backends()` to populate the list before being able to use a remote backend.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.