### PR TITLE
remove extra barriers temporarily from compile

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1179,8 +1179,8 @@ class QuantumProgram(object):
                                                                 set(measured_qubits)):
                         raise QISKitError('backend "{0}" rejects gate after '
                                           'measurement in circuit "{1}"'.format(backend, name))
-                for i, qubit in zip(qasm_idx, measured_qubits):
-                    circuit.data.insert(i, Barrier([qubit], circuit))
+                #for i, qubit in zip(qasm_idx, measured_qubits):
+                #    circuit.data.insert(i, Barrier([qubit], circuit))
             dag_circuit, final_layout = openquantumcompiler.compile(
                 circuit,
                 basis_gates=basis_gates,

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -43,9 +43,6 @@ from . import QuantumCircuit
 from . import QISKitError
 from . import JobProcessor
 from . import QuantumJob
-from . import Measure
-from . import Gate
-from .extensions.standard.barrier import Barrier
 from ._logging import set_qiskit_logger, unset_qiskit_logger
 
 # Beta Modules

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1167,20 +1167,6 @@ class QuantumProgram(object):
                 coupling_map = None
             if coupling_map == 'all-to-all':
                 coupling_map = None
-            # if the backend is a real chip, insert barrier before measurements
-            if not backend_conf['simulator']:
-                measured_qubits = []
-                qasm_idx = []
-                for i, instruction in enumerate(circuit.data):
-                    if isinstance(instruction, Measure):
-                        measured_qubits.append(instruction.arg[0])
-                        qasm_idx.append(i)
-                    elif isinstance(instruction, Gate) and bool(set(instruction.arg) &
-                                                                set(measured_qubits)):
-                        raise QISKitError('backend "{0}" rejects gate after '
-                                          'measurement in circuit "{1}"'.format(backend, name))
-                #for i, qubit in zip(qasm_idx, measured_qubits):
-                #    circuit.data.insert(i, Barrier([qubit], circuit))
             dag_circuit, final_layout = openquantumcompiler.compile(
                 circuit,
                 basis_gates=basis_gates,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In PR #347 we introduced an automatic compiler barrier insertion to avoid measurement reordering. The backends do not handle redundant barriers well, however, and some experiments were throwing errors. This is a temporary fix of the issue, until we:
1- fix barriers in the backends
2- use the dag information to insert barriers once and once only

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.