### PR TITLE
Resyncing master stable

### DIFF
--- a/qiskit/_compiler.py
+++ b/qiskit/_compiler.py
@@ -168,21 +168,6 @@ def compile(list_of_circuits, backend, compile_config=None):
             coupling_map = None
         if coupling_map == 'all-to-all':
             coupling_map = None
-        # if the backend is a real chip, insert barrier before measurements
-        if not backend_conf['simulator']:
-            measured_qubits = []
-            qasm_idx = []
-            for i, instruction in enumerate(circuit.data):
-                if isinstance(instruction, Measure):
-                    measured_qubits.append(instruction.arg[0])
-                    qasm_idx.append(i)
-                elif isinstance(instruction, Gate) and bool(set(instruction.arg) &
-                                                            set(measured_qubits)):
-                    raise QISKitError('backend "{0}" rejects gate after '
-                                      'measurement in circuit "{1}"'.format(backend_name,
-                                                                            circuit.name))
-            for i, qubit in zip(qasm_idx, measured_qubits):
-                circuit.data.insert(i, Barrier([qubit], circuit))
         dag_circuit, final_layout = compile_circuit(
             circuit,
             basis_gates=basis_gates,

--- a/qiskit/_compiler.py
+++ b/qiskit/_compiler.py
@@ -25,8 +25,6 @@ import copy
 
 # Stable Modules
 from ._qiskiterror import QISKitError
-from ._measure import Measure
-from ._gate import Gate
 from ._quantumcircuit import QuantumCircuit
 from .qasm import Qasm
 
@@ -34,7 +32,6 @@ from .qasm import Qasm
 # Beta Modules
 from .dagcircuit import DAGCircuit
 from .unroll import DagUnroller, DAGBackend, JsonBackend, Unroller, CircuitBackend
-from .extensions.standard.barrier import Barrier
 from .mapper import (Coupling, optimize_1q_gates, coupling_list2dict, swap_mapper,
                      cx_cancellation, direction_mapper)
 from ._quantumjob import QuantumJob

--- a/qiskit/_openquantumcompiler.py
+++ b/qiskit/_openquantumcompiler.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-builtin
+
+# Copyright 2017 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+"""Tools for compiling Quantum Programs."""
+from qiskit.unroll import DagUnroller, JsonBackend
+
+
+# TODO: This is here for backward compatibility with QISKit Developer Challenge
+# Once the challenge is finished, we have to remove this entire module.
+def dag2json(dag_circuit, basis_gates='u1,u2,u3,cx,id'):
+    """Make a Json representation of the circuit.
+    Takes a circuit dag and returns json circuit obj. This is an internal
+    function.
+    Args:
+        dag_circuit (QuantumCircuit): a dag representation of the circuit.
+        basis_gates (str): a comma seperated string and are the base gates,
+                               which by default are: u1,u2,u3,cx,id
+    Returns:
+        json: the json version of the dag
+    """
+    return DagUnroller(dag_circuit, JsonBackend(basis_gates)).execute()

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -903,56 +903,6 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertTrue(qobj2['circuits'][1]['config']['xvals'] == [
             'only for qobj2', 2, 3, 4])
 
-    @requires_qe_access
-    def test_gate_after_measure(self, QE_TOKEN, QE_URL):
-        """Test that no gate is inserted after measure when compiling
-        for real backends. NEED internet connection for this.
-
-        See: https://github.com/QISKit/qiskit-sdk-py/issues/342
-
-        TODO: (JAY) THIS IS VERY SYSTEM DEPENDENT AND NOT A GOOD TEST. I WOULD LIKE
-        TO DELETE THIS
-        """
-        q_program = QuantumProgram()
-        qr = q_program.create_quantum_register('qr', 16)
-        cr = q_program.create_classical_register('cr', 16)
-        qc = q_program.create_circuit('emoticon', [qr], [cr])
-        qc.x(qr[0])
-        qc.x(qr[3])
-        qc.x(qr[5])
-        qc.h(qr[9])
-        qc.cx(qr[9], qr[8])
-        qc.x(qr[11])
-        qc.x(qr[12])
-        qc.x(qr[13])
-        for j in range(16):
-            qc.measure(qr[j], cr[j])
-        q_program.set_api(QE_TOKEN, QE_URL)
-        backend = 'ibmqx5'
-        coupling_map = [[1, 0], [1, 2], [2, 3], [3, 4], [3, 14], [5, 4],
-                        [6, 5], [6, 7], [6, 11], [7, 10], [8, 7], [9, 8],
-                        [9, 10], [11, 10], [12, 5], [12, 11], [12, 13],
-                        [13, 4], [13, 14], [15, 0], [15, 2], [15, 14]]
-
-        initial_layout = {('qr', 0): ('q', 1), ('qr', 1): ('q', 0),
-                          ('qr', 2): ('q', 2), ('qr', 3): ('q', 3),
-                          ('qr', 4): ('q', 4), ('qr', 5): ('q', 14),
-                          ('qr', 6): ('q', 5), ('qr', 7): ('q', 6),
-                          ('qr', 8): ('q', 7), ('qr', 9): ('q', 11),
-                          ('qr', 10): ('q', 10), ('qr', 11): ('q', 8),
-                          ('qr', 12): ('q', 9), ('qr', 13): ('q', 12),
-                          ('qr', 14): ('q', 13), ('qr', 15): ('q', 15)}
-        qobj = q_program.compile(["emoticon"], backend=backend,
-                                 initial_layout=initial_layout, coupling_map=coupling_map)
-        measured_qubits = set()
-        has_gate_after_measure = False
-        for x in qobj["circuits"][0]["compiled_circuit"]["operations"]:
-            if x["name"] == "measure":
-                measured_qubits.add(x["qubits"][0])
-            elif set(x["qubits"]) & measured_qubits:
-                has_gate_after_measure = True
-        self.assertFalse(has_gate_after_measure)
-
     ###############################################################
     # Test for running programs
     ###############################################################


### PR DESCRIPTION
So we have to fix some stuff on `stable` to release a new version, we couldn't make it through `master` because it has strongly changed these days, so we pushed against `stable` and released a new pypi package version (0.4.13).
Now we are merging back these changes into `master`.
Some of these changes don't apply to `master` so I cherry-picked the significant ones and made some changes to adapt them.

@ajavadia Your changes were introduced in the old `QuantumProgram.compile()` method, that has strongly changed in current `master`. I guess that we need to fix this in our `_compiler.compile()` , right?