### PR TITLE
Backporting changes from stable-0.4.14 to master, manually.

### DIFF
--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -604,7 +604,6 @@ class TestQuantumProgram(QiskitTestCase):
         qp = QuantumProgram(specs=self.QPS_SPECS)
         qp.set_api(QE_TOKEN, QE_URL)
         online_simulators = qp.online_simulators()
-        # print(online_simulators)
         self.log.info(online_simulators)
         self.assertTrue(isinstance(online_simulators, list))
 
@@ -617,7 +616,6 @@ class TestQuantumProgram(QiskitTestCase):
         qp = QuantumProgram(specs=self.QPS_SPECS)
         qp.set_api(QE_TOKEN, QE_URL)
         online_devices = qp.online_devices()
-        # print(online_devices)
         self.log.info(online_devices)
         self.assertTrue(isinstance(online_devices, list))
 
@@ -628,7 +626,6 @@ class TestQuantumProgram(QiskitTestCase):
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
         out = q_program.get_backend_status("local_qasm_simulator")
-        # print(out)
         self.assertIn(out['available'], [True])
 
     def test_backend_status_fail(self):
@@ -649,7 +646,6 @@ class TestQuantumProgram(QiskitTestCase):
         config_keys = {'name', 'simulator', 'local', 'description',
                        'coupling_map', 'basis_gates'}
         backend_config = qp.get_backend_configuration("local_qasm_simulator")
-        # print(backend_config)
         self.assertTrue(config_keys < backend_config.keys())
 
     @requires_qe_access
@@ -664,10 +660,11 @@ class TestQuantumProgram(QiskitTestCase):
                        'coupling_map', 'basis_gates'}
         qp.set_api(QE_TOKEN, QE_URL)
         backend_list = qp.available_backends()
+        backend_list.remove('ibmqx_hpc_qasm_simulator')
+        backend_list.remove('ibmqx_qasm_simulator')
         if backend_list:
             backend = backend_list[0]
         backend_config = qp.get_backend_configuration(backend)
-        # print(backend_config)
         self.log.info(backend_config)
         self.assertTrue(config_keys < backend_config.keys())
 
@@ -692,7 +689,6 @@ class TestQuantumProgram(QiskitTestCase):
         if backend_list:
             backend = backend_list[0]
         result = q_program.get_backend_calibration(backend)
-        # print(result)
         self.log.info(result)
         self.assertEqual(len(result), 4)
 
@@ -708,7 +704,6 @@ class TestQuantumProgram(QiskitTestCase):
         if backend_list:
             backend = backend_list[0]
         result = q_program.get_backend_parameters(backend)
-        # print(result)
         self.log.info(result)
         self.assertEqual(len(result), 4)
 


### PR DESCRIPTION
This will remove IBM online simulators from the tests related to configuration checking.