### PR TITLE
Fix dictAlmostEqual comparisons, online travis tests, misc

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -396,10 +396,7 @@ class QuantumProgram(object):
             else:
                 name = self._create_id('qc', self.__quantum_program.keys())
                 quantum_circuit.name = name
-        for qname, qreg in quantum_circuit.get_qregs().items():
-            self.create_quantum_register(qname, len(qreg))
-        for cname, creg in quantum_circuit.get_cregs().items():
-            self.create_classical_register(cname, len(creg))
+
         self.__quantum_program[name] = quantum_circuit
 
     def load_qasm_file(self, qasm_file, name=None,

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -95,14 +95,15 @@ class QiskitTestCase(unittest.TestCase):
         comparing that the difference between values with the same key are
         not greater than delta (default 1e-8), or that difference rounded
         to the given number of decimal places is not zero. If a key in one
-        dictionary is not in the other the default_value keyword arugment
+        dictionary is not in the other the default_value keyword argument
         will be used for the missing value (default 0). If the two objects
         compare equal then they will automatically compare almost equal.
 
         Args:
             dict1 (dict): a dictionary.
             dict2 (dict): a dictionary.
-            delta (number): threshold for comparison (defaults to 1e-8).
+            delta (number): threshold for comparison (defaults to 0.040 *
+                sum of values in dict1).
             msg (str): return a custom message on failure.
             places (int): number of decimal places for comparison.
             default_value (number): default value for missing keys.
@@ -117,8 +118,8 @@ class QiskitTestCase(unittest.TestCase):
         if delta is not None and places is not None:
             raise TypeError("specify delta or places not both")
 
+        success = True
         if places is not None:
-            success = True
             standard_msg = ''
             # check value for keys in target
             keys1 = set(dict1.keys())
@@ -140,14 +141,14 @@ class QiskitTestCase(unittest.TestCase):
                     standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
                                                           safe_repr(val1),
                                                           safe_repr(val2))
-            if success is True:
+            if success:
                 return
             standard_msg = standard_msg[:-2] + ' within %s places' % places
 
         else:
             if delta is None:
-                delta = 1e-8  # default delta value
-            success = True
+                delta = 0.04 * sum(dict1.values())  # default delta value
+
             standard_msg = ''
             # check value for keys in target
             keys1 = set(dict1.keys())
@@ -169,7 +170,7 @@ class QiskitTestCase(unittest.TestCase):
                     standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
                                                           safe_repr(val1),
                                                           safe_repr(val2))
-            if success is True:
+            if success:
                 return
             standard_msg = standard_msg[:-2] + ' within %s delta' % delta
 

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -257,8 +257,7 @@ def _is_ci_fork_pull_request():
     """
     if os.getenv('TRAVIS'):
         # Using Travis CI.
-        if (os.getenv('TRAVIS_REPO_SLUG') !=
-                os.getenv('TRAVIS_PULL_REQUEST_SLUG')):
+        if os.getenv('TRAVIS_PULL_REQUEST_BRANCH'):
             return True
     elif os.getenv('APPVEYOR'):
         # Using AppVeyor CI.

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -85,7 +85,6 @@ class QiskitTestCase(unittest.TestCase):
         # pylint: disable=invalid-name
         return _AssertNoLogsContext(self, logger, level)
 
-    # pylint: disable=invalid-name
     def assertDictAlmostEqual(self, dict1, dict2, delta=None, msg=None,
                               places=None, default_value=0):
         """
@@ -111,7 +110,7 @@ class QiskitTestCase(unittest.TestCase):
         Raises:
             TypeError: raises TestCase failureException if the test fails.
         """
-
+        # pylint: disable=invalid-name
         if dict1 == dict2:
             # Shortcut
             return

--- a/test/python/test_api_ibmq.py
+++ b/test/python/test_api_ibmq.py
@@ -32,7 +32,6 @@ HAS_GROUP_VARS = False
 try:
     import Qconfig
     QE_TOKEN = Qconfig.APItoken
-    print(Qconfig.config)
     QE_URL = Qconfig.config['url']
     QE_HUB = Qconfig.config['hub']
     QE_GROUP = Qconfig.config['group']

--- a/test/python/test_extensions_simulator.py
+++ b/test/python/test_extensions_simulator.py
@@ -18,7 +18,7 @@
 """Tests for verifying the correctness of simulator extension instructions."""
 
 import unittest
-import qiskit as qk
+import qiskit
 import qiskit.extensions.simulator
 from qiskit.tools.qi.qi import state_fidelity
 from qiskit.wrapper import execute
@@ -44,9 +44,9 @@ class TestExtensionsSimulator(QiskitTestCase):
 
     def test_save_load(self):
         """save |+>|0>, do some stuff, then load"""
-        q = qk.QuantumRegister(2)
-        c = qk.ClassicalRegister(2)
-        circ = qk.QuantumCircuit(q, c)
+        q = qiskit.QuantumRegister(2)
+        c = qiskit.ClassicalRegister(2)
+        circ = qiskit.QuantumCircuit(q, c)
         circ.h(q[0])
         circ.save(1)
         circ.cx(q[0], q[1])
@@ -65,9 +65,9 @@ class TestExtensionsSimulator(QiskitTestCase):
 
     def test_snapshot(self):
         """snapshot a bell state in the middle of circuit"""
-        q = qk.QuantumRegister(2)
-        c = qk.ClassicalRegister(2)
-        circ = qk.QuantumCircuit(q, c)
+        q = qiskit.QuantumRegister(2)
+        c = qiskit.ClassicalRegister(2)
+        circ = qiskit.QuantumCircuit(q, c)
         circ.h(q[0])
         circ.cx(q[0], q[1])
         circ.snapshot(3)
@@ -85,9 +85,9 @@ class TestExtensionsSimulator(QiskitTestCase):
 
     def test_noise(self):
         """turn on a pauli x noise for qubits 0 and 2"""
-        q = qk.QuantumRegister(3)
-        c = qk.ClassicalRegister(3)
-        circ = qk.QuantumCircuit(q, c)
+        q = qiskit.QuantumRegister(3)
+        c = qiskit.ClassicalRegister(3)
+        circ = qiskit.QuantumCircuit(q, c)
         circ.iden(q[0])
         circ.noise(0)
         circ.iden(q[1])

--- a/test/python/test_identifiers.py
+++ b/test/python/test_identifiers.py
@@ -301,8 +301,7 @@ class TestAnonymousIds(QiskitTestCase):
         result = q_program.execute(backend=backend, shots=shots, seed=78)
         counts = result.get_counts(new_circuit.name)
         target = {'00': shots / 2, '01': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
         self.assertRaises(QISKitError, result.get_counts)
 
 
@@ -650,8 +649,7 @@ class TestZeroIds(QiskitTestCase):
         result = q_program.execute(circuits, backend=backend, shots=shots, seed=78)
         counts = result.get_counts(1001)
         target = {'00': shots / 2, '01': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
 
 class TestIntegerIds(QiskitTestCase):
@@ -999,8 +997,7 @@ class TestIntegerIds(QiskitTestCase):
                                    seed=78)
         counts = result.get_counts(1001)
         target = {'00': shots / 2, '01': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
 
 class TestTupleIds(QiskitTestCase):
@@ -1344,8 +1341,7 @@ class TestTupleIds(QiskitTestCase):
                                    seed=78)
         counts = result.get_counts((1001.1, 1001j))
         target = {'00': shots / 2, '01': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
 
 class TestAnonymousIdsNoQuantumProgram(QiskitTestCase):

--- a/test/python/test_initializer.py
+++ b/test/python/test_initializer.py
@@ -39,7 +39,7 @@ class TestInitialize(QiskitTestCase):
     def test_uniform_superposition(self):
         desired_vector = [0.5, 0.5, 0.5, 0.5]
         qp = QuantumProgram()
-        qr = QuantumRegister("qr", 2)
+        qr = QuantumRegister(2, "qr")
         qc = QuantumCircuit(qr)
         qc.initialize(desired_vector, [qr[0], qr[1]])
         qp.add_circuit("qc", qc)
@@ -53,7 +53,7 @@ class TestInitialize(QiskitTestCase):
     def test_deterministic_state(self):
         desired_vector = [0, 1, 0, 0]
         qp = QuantumProgram()
-        qr = QuantumRegister("qr", 2)
+        qr = QuantumRegister(2, "qr")
         qc = QuantumCircuit(qr)
         qc.initialize(desired_vector, [qr[0], qr[1]])
         qp.add_circuit("qc", qc)
@@ -67,7 +67,7 @@ class TestInitialize(QiskitTestCase):
     def test_bell_state(self):
         desired_vector = [1/math.sqrt(2), 0, 0, 1/math.sqrt(2)]
         qp = QuantumProgram()
-        qr = QuantumRegister("qr", 2)
+        qr = QuantumRegister(2, "qr")
         qc = QuantumCircuit(qr)
         qc = qp.create_circuit("qc", [qr])
         qc.initialize(desired_vector, [qr[0], qr[1]])
@@ -82,7 +82,7 @@ class TestInitialize(QiskitTestCase):
     def test_ghz_state(self):
         desired_vector = [1/math.sqrt(2), 0, 0, 0, 0, 0, 0, 1/math.sqrt(2)]
         qp = QuantumProgram()
-        qr = QuantumRegister("qr", 3)
+        qr = QuantumRegister(3, "qr")
         qc = QuantumCircuit(qr)
         qc = qp.create_circuit("qc", [qr])
         qc.initialize(desired_vector, [qr[0], qr[1], qr[2]])
@@ -97,7 +97,7 @@ class TestInitialize(QiskitTestCase):
     def test_single_qubit(self):
         desired_vector = [1/math.sqrt(3), math.sqrt(2)/math.sqrt(3)]
         qp = QuantumProgram()
-        qr = QuantumRegister("qr", 1)
+        qr = QuantumRegister(1, "qr")
         qc = QuantumCircuit(qr)
         qc.initialize(desired_vector, [qr[0]])
         qp.add_circuit("qc", qc)
@@ -119,7 +119,7 @@ class TestInitialize(QiskitTestCase):
             1 / math.sqrt(16) * complex(1, 0),
             0]
         qp = QuantumProgram()
-        qr = QuantumRegister("qr", 3)
+        qr = QuantumRegister(3, "qr")
         qc = QuantumCircuit(qr)
         qc.initialize(desired_vector, [qr[0], qr[1], qr[2]])
         qp.add_circuit("qc", qc)
@@ -149,7 +149,7 @@ class TestInitialize(QiskitTestCase):
             1 / math.sqrt(4) * complex(1, 0),
             1 / math.sqrt(8) * complex(1, 0)]
         qp = QuantumProgram()
-        qr = QuantumRegister("qr", 4)
+        qr = QuantumRegister(4, "qr")
         qc = QuantumCircuit(qr)
         qc.initialize(desired_vector, [qr[0], qr[1], qr[2], qr[3]])
         qp.add_circuit("qc", qc)
@@ -162,7 +162,7 @@ class TestInitialize(QiskitTestCase):
 
     def test_malformed_amplitudes(self):
         desired_vector = [1/math.sqrt(3), math.sqrt(2)/math.sqrt(3), 0]
-        qr = QuantumRegister("qr", 2)
+        qr = QuantumRegister(2, "qr")
         qc = QuantumCircuit(qr)
         self.assertRaises(
             QISKitError,
@@ -170,7 +170,7 @@ class TestInitialize(QiskitTestCase):
 
     def test_non_unit_probability(self):
         desired_vector = [1, 1]
-        qr = QuantumRegister("qr", 2)
+        qr = QuantumRegister(2, "qr")
         qc = QuantumCircuit(qr)
         self.assertRaises(
             QISKitError,
@@ -179,8 +179,8 @@ class TestInitialize(QiskitTestCase):
     def test_initialize_middle_circuit(self):
         desired_vector = [0.5, 0.5, 0.5, 0.5]
         qp = QuantumProgram()
-        qr = QuantumRegister("qr", 2)
-        cr = ClassicalRegister("cr", 2)
+        qr = QuantumRegister(2, "qr")
+        cr = ClassicalRegister(2, "cr")
         qc = QuantumCircuit(qr, cr)
         qc.h(qr[0])
         qc.cx(qr[0], qr[1])
@@ -216,7 +216,7 @@ class TestInitialize(QiskitTestCase):
             1 / math.sqrt(4),
             1 / math.sqrt(4) * complex(0, 1)]
         qp = QuantumProgram()
-        qr = QuantumRegister("qr", 4)
+        qr = QuantumRegister(4, "qr")
         qc = QuantumCircuit(qr)
         qc.initialize(desired_vector, [qr[0], qr[1], qr[2], qr[3]])
         qp.add_circuit("qc", qc)

--- a/test/python/test_initializer.py
+++ b/test/python/test_initializer.py
@@ -191,11 +191,10 @@ class TestInitialize(QiskitTestCase):
         qp.add_circuit("qc", qc)
         # statevector simulator does not support reset
         shots = 2000
-        threshold = 0.025 * shots
         result = qp.execute("qc", backend='local_qasm_simulator', shots=shots)
         counts = result.get_counts()
         target = {'00': shots / 4, '01': shots / 4, '10': shots / 4, '11': shots / 4}
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     def test_sympy(self):
         desired_vector = [

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -58,8 +58,7 @@ class MapperTest(QiskitTestCase):
                                  seed=self.seed, shots=shots)
         counts = result.get_counts("test")
         target = {'0001': shots / 2, '0101':  shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     def test_optimize_1q_gates_issue159(self):
         """Test change in behavior for optimize_1q_gates that removes u1(2*pi) rotations.
@@ -127,8 +126,7 @@ class MapperTest(QiskitTestCase):
             '11111': 0.017684822659235985
         }
         target = {key: shots * val for key, val in expected_probs.items()}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     def test_symbolic_unary(self):
         """Test symbolic math in DAGBackend and optimizer with a prefix.

--- a/test/python/test_qasm_simulator_cpp.py
+++ b/test/python/test_qasm_simulator_cpp.py
@@ -130,13 +130,12 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
     def test_run_qobj(self):
         result = self.backend.run(self.q_job)
         shots = self.qobj['config']['shots']
-        threshold = 0.025 * shots
         counts = result.get_counts('test_circuit2')
         target = {'100 100': shots / 8, '011 011': shots / 8,
                   '101 101': shots / 8, '111 111': shots / 8,
                   '000 000': shots / 8, '010 010': shots / 8,
                   '110 110': shots / 8, '001 001': shots / 8}
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     def test_qobj_measure_opt(self):
         filename = self._get_resource_path('qobj/cpp_measure_opt.json')
@@ -202,9 +201,8 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
                 self.assertEqual(counts, expected_counts,
                                  msg=name + ' counts')
             else:
-                threshold = 0.025 * shots
                 self.assertDictAlmostEqual(counts, expected_counts,
-                                           threshold, msg=name + 'counts')
+                                           msg=name + 'counts')
             # Check snapshot
             snapshots = result.get_snapshots(name)
             self.assertEqual(set(snapshots), {'0'},

--- a/test/python/test_qasm_simulator_cpp.py
+++ b/test/python/test_qasm_simulator_cpp.py
@@ -19,7 +19,6 @@
 
 import json
 import unittest
-import logging
 import numpy as np
 from numpy.linalg import norm
 
@@ -33,9 +32,6 @@ from qiskit.backends.local.qasm_simulator_cpp import (QasmSimulatorCpp,
                                                       cx_error_matrix,
                                                       x90_error_matrix)
 from .common import QiskitTestCase
-
-logger = logging.getLogger('qiskit.backends.local.qasm_simulator_cpp')
-logger.setLevel(logging.ERROR)
 
 
 class TestLocalQasmSimulatorCpp(QiskitTestCase):

--- a/test/python/test_qasm_simulator_projectq.py
+++ b/test/python/test_qasm_simulator_projectq.py
@@ -122,8 +122,7 @@ class TestQasmSimulatorProjectQ(QiskitTestCase):
                          if cnt > min_cnts}
             self.log.info('local_qasm_simulator_projectq: %s', str(counts_pq))
             self.log.info('local_qasm_simulator: %s', str(counts_qk))
-            threshold = 0.05 * shots
-            self.assertDictAlmostEqual(counts_pq, counts_qk, threshold)
+            self.assertDictAlmostEqual(counts_pq, counts_qk)
             states = counts_qk.keys()
             # contingency table
             ctable = numpy.array([[counts_pq[key] for key in states],

--- a/test/python/test_qasm_simulator_py.py
+++ b/test/python/test_qasm_simulator_py.py
@@ -102,13 +102,12 @@ class TestLocalQasmSimulatorPyPy(QiskitTestCase):
         """Test data counts output for single circuit run against reference."""
         result = QasmSimulatorPy().run(self.q_job)
         shots = 1024
-        threshold = 0.025 * shots
         counts = result.get_counts('test')
         target = {'100 100': shots / 8, '011 011': shots / 8,
                   '101 101': shots / 8, '111 111': shots / 8,
                   '000 000': shots / 8, '010 010': shots / 8,
                   '110 110': shots / 8, '001 001': shots / 8}
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     def test_if_statement(self):
         self.log.info('test_if_statement_x')

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1530,8 +1530,8 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should return the data
         """
 
-        qr = QuantumRegister("qr", 2)
-        cr = ClassicalRegister("cr", 2)
+        qr = QuantumRegister(2, "qr")
+        cr = ClassicalRegister(2, "cr")
         qc1 = QuantumCircuit(qr)
         qc1.x(qr)
         qc2 = QuantumCircuit(qr, cr)
@@ -1554,9 +1554,9 @@ class TestQuantumProgram(QiskitTestCase):
         If two circuits have samed name register of different size or type
         it should raise a QISKitError.
         """
-        q1 = QuantumRegister("q", 1)
-        q2 = QuantumRegister("q", 2)
-        c1 = QuantumRegister("q", 1)
+        q1 = QuantumRegister(1, "q")
+        q2 = QuantumRegister(2, "q")
+        c1 = QuantumRegister(1, "q")
         qc1 = QuantumCircuit(q1)
         qc2 = QuantumCircuit(q2)
         qc3 = QuantumCircuit(c1)
@@ -1595,8 +1595,8 @@ class TestQuantumProgram(QiskitTestCase):
         If all correct should return the data
         """
 
-        qr = QuantumRegister("qr", 2)
-        cr = ClassicalRegister("cr", 2)
+        qr = QuantumRegister(2, "qr")
+        cr = ClassicalRegister(2, "cr")
         qc1 = QuantumCircuit(qr)
         qc1.x(qr)
         qc2 = QuantumCircuit(qr, cr)
@@ -1619,9 +1619,9 @@ class TestQuantumProgram(QiskitTestCase):
         If two circuits have samed name register of different size or type
         it should raise a QISKitError.
         """
-        q1 = QuantumRegister("q", 1)
-        q2 = QuantumRegister("q", 2)
-        c1 = QuantumRegister("q", 1)
+        q1 = QuantumRegister(1, "q")
+        q2 = QuantumRegister(2, "q")
+        c1 = QuantumRegister(1, "q")
         qc1 = QuantumCircuit(q1)
         qc2 = QuantumCircuit(q2)
         qc3 = QuantumCircuit(c1)

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -825,8 +825,7 @@ class TestQuantumProgram(QiskitTestCase):
 
         counts = result.get_counts("circuitName")
         target = {'000': shots / 2, '111': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     def test_compile_coupling_map_as_dict(self):
         """Test compile_coupling_map in dict format (to be deprecated).
@@ -859,8 +858,7 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertEqual(len(to_check), 160)
         counts = result.get_counts("circuitName")
         target = {'000': shots / 2, '111': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     def test_change_circuit_qobj_after_compile(self):
         q_program = QuantumProgram(specs=self.QPS_SPECS)
@@ -930,9 +928,8 @@ class TestQuantumProgram(QiskitTestCase):
         target3 = {'000': shots / 8, '001': shots / 8, '010': shots / 8,
                    '011': shots / 8, '100': shots / 8, '101': shots / 8,
                    '110': shots / 8, '111': shots / 8}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts2, target2, threshold)
-        self.assertDictAlmostEqual(counts3, target3, threshold)
+        self.assertDictAlmostEqual(counts2, target2)
+        self.assertDictAlmostEqual(counts3, target3)
 
     def test_run_async_program(self):
         """Test run_async.
@@ -948,9 +945,8 @@ class TestQuantumProgram(QiskitTestCase):
                 target3 = {'000': shots / 8, '001': shots / 8, '010': shots / 8,
                            '011': shots / 8, '100': shots / 8, '101': shots / 8,
                            '110': shots / 8, '111': shots / 8}
-                threshold = 0.025 * shots
-                self.assertDictAlmostEqual(counts2, target2, threshold)
-                self.assertDictAlmostEqual(counts3, target3, threshold)
+                self.assertDictAlmostEqual(counts2, target2)
+                self.assertDictAlmostEqual(counts3, target3)
             except Exception as e:
                 self.qp_program_exception = e
             finally:
@@ -1004,9 +1000,8 @@ class TestQuantumProgram(QiskitTestCase):
                 target3 = {'000': shots / 8, '001': shots / 8, '010': shots / 8,
                            '011': shots / 8, '100': shots / 8, '101': shots / 8,
                            '110': shots / 8, '111': shots / 8}
-                threshold = 0.025 * shots
-                self.assertDictAlmostEqual(counts2, target2, threshold)
-                self.assertDictAlmostEqual(counts3, target3, threshold)
+                self.assertDictAlmostEqual(counts2, target2)
+                self.assertDictAlmostEqual(counts3, target3)
             except Exception as e:
                 with lock:
                     qp_programs_exception.append(e)
@@ -1076,9 +1071,8 @@ class TestQuantumProgram(QiskitTestCase):
             target3 = {'000': shots / 8, '001': shots / 8, '010': shots / 8,
                        '011': shots / 8, '100': shots / 8, '101': shots / 8,
                        '110': shots / 8, '111': shots / 8}
-            threshold = 0.025 * shots
-            self.assertDictAlmostEqual(counts2, target2, threshold)
-            self.assertDictAlmostEqual(counts3, target3, threshold)
+            self.assertDictAlmostEqual(counts2, target2)
+            self.assertDictAlmostEqual(counts3, target3)
 
     def test_run_batch_async(self):
         """Test run_batch_async
@@ -1095,9 +1089,8 @@ class TestQuantumProgram(QiskitTestCase):
                     target3 = {'000': shots / 8, '001': shots / 8, '010': shots / 8,
                                '011': shots / 8, '100': shots / 8, '101': shots / 8,
                                '110': shots / 8, '111': shots / 8}
-                    threshold = 0.025 * shots
-                    self.assertDictAlmostEqual(counts2, target2, threshold)
-                    self.assertDictAlmostEqual(counts3, target3, threshold)
+                    self.assertDictAlmostEqual(counts2, target2)
+                    self.assertDictAlmostEqual(counts3, target3)
             except Exception as e:
                 self.qp_program_exception = e
             finally:
@@ -1188,9 +1181,8 @@ class TestQuantumProgram(QiskitTestCase):
         target3 = {'000': shots / 8, '001': shots / 8, '010': shots / 8,
                    '011': shots / 8, '100': shots / 8, '101': shots / 8,
                    '110': shots / 8, '111': shots / 8}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts2, target2, threshold)
-        self.assertDictAlmostEqual(counts3, target3, threshold)
+        self.assertDictAlmostEqual(counts2, target2)
+        self.assertDictAlmostEqual(counts3, target3)
 
     def test_local_qasm_simulator_one_shot(self):
         """Test single shot of local simulator .
@@ -1344,8 +1336,7 @@ class TestQuantumProgram(QiskitTestCase):
                                    seed=73846087)
         counts = result.get_counts('qc')
         target = {'0': shots / 2, '1': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     @requires_qe_access
     def test_simulator_online_size(self, QE_TOKEN, QE_URL):
@@ -1398,9 +1389,8 @@ class TestQuantumProgram(QiskitTestCase):
         target1 = {'00': shots / 4, '01': shots / 4,
                    '10': shots / 4, '11': shots / 4}
         target2 = {'00': shots / 2, '11': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts1, target1, threshold)
-        self.assertDictAlmostEqual(counts2, target2, threshold)
+        self.assertDictAlmostEqual(counts1, target1)
+        self.assertDictAlmostEqual(counts2, target2)
 
     @requires_qe_access
     def test_execute_one_circuit_real_online(self, QE_TOKEN, QE_URL):
@@ -1521,15 +1511,13 @@ class TestQuantumProgram(QiskitTestCase):
                                    seed=78)
         counts = result.get_counts(name)
         target = {'00': shots / 2, '01': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     def test_combine_circuit_different(self):
-        """Test combinging two circuits with different registers.
+        """Test combining two circuits with different registers.
 
         If all correct should return the data
         """
-
         qr = QuantumRegister(2, "qr")
         cr = ClassicalRegister(2, "cr")
         qc1 = QuantumCircuit(qr)
@@ -1545,8 +1533,7 @@ class TestQuantumProgram(QiskitTestCase):
         result = qp.execute(name, backend=backend, shots=shots, seed=78)
         counts = result.get_counts(name)
         target = {'11': shots}
-        threshold = 0.0
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertEqual(counts, target)
 
     def test_combine_circuit_fail(self):
         """Test combining two circuits fails if registers incompatible.
@@ -1586,15 +1573,13 @@ class TestQuantumProgram(QiskitTestCase):
                                    seed=78)
         counts = result.get_counts(name)
         target = {'00': shots / 2, '01': shots / 2}
-        threshold = 0.025 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertDictAlmostEqual(counts, target)
 
     def test_extend_circuit_different_registers(self):
         """Test extending a circuit with different registers.
 
         If all correct should return the data
         """
-
         qr = QuantumRegister(2, "qr")
         cr = ClassicalRegister(2, "cr")
         qc1 = QuantumCircuit(qr)
@@ -1610,8 +1595,7 @@ class TestQuantumProgram(QiskitTestCase):
         result = qp.execute(name, backend=backend, shots=shots, seed=78)
         counts = result.get_counts(name)
         target = {'11': shots}
-        threshold = 0.0
-        self.assertDictAlmostEqual(counts, target, threshold)
+        self.assertEqual(counts, target)
 
     def test_extend_circuit_fail(self):
         """Test extending a circuits fails if registers incompatible.
@@ -1693,14 +1677,13 @@ class TestQuantumProgram(QiskitTestCase):
         self.log.info(bellresult.get_counts("bell"))
         self.log.info(ghzresult.get_counts("ghz"))
 
-        threshold = 0.025 * shots
         counts_bell = bellresult.get_counts('bell')
         target_bell = {'00000': shots / 2, '00011': shots / 2}
-        self.assertDictAlmostEqual(counts_bell, target_bell, threshold)
+        self.assertDictAlmostEqual(counts_bell, target_bell)
 
         counts_ghz = ghzresult.get_counts('ghz')
         target_ghz = {'00000': shots / 2, '11111': shots / 2}
-        self.assertDictAlmostEqual(counts_ghz, target_ghz, threshold)
+        self.assertDictAlmostEqual(counts_ghz, target_ghz)
 
     def test_example_swap_bits(self):
         """Test a toy example swapping a set bit around.

--- a/test/python/test_simulator_interfaces.py
+++ b/test/python/test_simulator_interfaces.py
@@ -18,19 +18,13 @@
 """Tests for checking qiskit interfaces to simulators."""
 
 import unittest
-import logging
-import qiskit as qk
+import qiskit
 import qiskit.extensions.simulator
 from qiskit.tools.qi.qi import state_fidelity
 from qiskit.wrapper import available_backends, register, execute, get_backend
 from qiskit.backends.local import QasmSimulatorPy, QasmSimulatorCpp
 from .common import requires_qe_access, QiskitTestCase
 
-
-logger_cpp = logging.getLogger('qiskit.backends.local.qasm_simulator_cpp')
-logger_py = logging.getLogger('qiskit.backends.local.qasm_simulator_py')
-logger_cpp.setLevel(logging.ERROR)
-logger_py.setLevel(logging.ERROR)
 
 # Cpp backend required
 try:
@@ -49,8 +43,8 @@ class TestCrossSimulation(QiskitTestCase):
 
     def test_statevector(self):
         """statevector from a bell state"""
-        q = qk.QuantumRegister(2)
-        circ = qk.QuantumCircuit(q)
+        q = qiskit.QuantumRegister(2)
+        circ = qiskit.QuantumCircuit(q)
         circ.h(q[0])
         circ.cx(q[0], q[1])
 
@@ -69,9 +63,9 @@ class TestCrossSimulation(QiskitTestCase):
     def test_qasm(self, QE_TOKEN, QE_URL):
         """counts from a GHZ state"""
         register(QE_TOKEN, QE_URL)
-        q = qk.QuantumRegister(3)
-        c = qk.ClassicalRegister(3)
-        circ = qk.QuantumCircuit(q, c)
+        q = qiskit.QuantumRegister(3)
+        c = qiskit.ClassicalRegister(3)
+        circ = qiskit.QuantumCircuit(q, c)
         circ.h(q[0])
         circ.cx(q[0], q[1])
         circ.cx(q[1], q[2])
@@ -96,9 +90,9 @@ class TestCrossSimulation(QiskitTestCase):
 
     def test_qasm_snapshot(self):
         """snapshot a circuit at multiple places"""
-        q = qk.QuantumRegister(3)
-        c = qk.ClassicalRegister(3)
-        circ = qk.QuantumCircuit(q, c)
+        q = qiskit.QuantumRegister(3)
+        c = qiskit.ClassicalRegister(3)
+        circ = qiskit.QuantumCircuit(q, c)
         circ.h(q[0])
         circ.cx(q[0], q[1])
         circ.snapshot(1)
@@ -124,9 +118,9 @@ class TestCrossSimulation(QiskitTestCase):
     def test_qasm_reset_measure(self, QE_TOKEN, QE_URL):
         """counts from a qasm program with measure and reset in the middle"""
         register(QE_TOKEN, QE_URL)
-        q = qk.QuantumRegister(3)
-        c = qk.ClassicalRegister(3)
-        circ = qk.QuantumCircuit(q, c)
+        q = qiskit.QuantumRegister(3)
+        c = qiskit.ClassicalRegister(3)
+        circ = qiskit.QuantumCircuit(q, c)
         circ.h(q[0])
         circ.cx(q[0], q[1])
         circ.reset(q[0])

--- a/test/python/test_simulator_interfaces.py
+++ b/test/python/test_simulator_interfaces.py
@@ -90,9 +90,9 @@ class TestCrossSimulation(QiskitTestCase):
         counts_py = result_py.get_counts()
         counts_ibmq = result_ibmq.get_counts()
         counts_hpc = result_hpc.get_counts()
-        self.assertDictAlmostEqual(counts_cpp, counts_py, shots*0.025)
-        self.assertDictAlmostEqual(counts_py, counts_ibmq, shots*0.025)
-        self.assertDictAlmostEqual(counts_ibmq, counts_hpc, shots*0.025)
+        self.assertDictAlmostEqual(counts_cpp, counts_py)
+        self.assertDictAlmostEqual(counts_py, counts_ibmq)
+        self.assertDictAlmostEqual(counts_ibmq, counts_hpc)
 
     def test_qasm_snapshot(self):
         """snapshot a circuit at multiple places"""
@@ -151,9 +151,9 @@ class TestCrossSimulation(QiskitTestCase):
         counts_py = result_py.get_counts()
         # counts_ibmq = result_ibmq.get_counts()
         # counts_hpc = result_hpc.get_counts()
-        self.assertDictAlmostEqual(counts_cpp, counts_py, shots*0.025)
-        # self.assertDictAlmostEqual(counts_py, counts_ibmq, shots*0.025)
-        # self.assertDictAlmostEqual(counts_ibmq, counts_hpc, shots*0.025)
+        self.assertDictAlmostEqual(counts_cpp, counts_py)
+        # self.assertDictAlmostEqual(counts_py, counts_ibmq)
+        # self.assertDictAlmostEqual(counts_ibmq, counts_hpc)
 
 
 class TestSimulatorNames(QiskitTestCase):

--- a/test/python/test_skip_translation.py
+++ b/test/python/test_skip_translation.py
@@ -27,11 +27,10 @@ class CompileSkipTranslationTest(QiskitTestCase):
     """Test compilaton with skip translation."""
 
     def test_simple_compile(self):
-        '''
+        """
         Compares with and without skip_translation
-        '''
+        """
         name = 'test_simple'
-        self.log.info(name)
         qp = QuantumProgram()
         qr = qp.create_quantum_register('qr', 2)
         cr = qp.create_classical_register('cr', 2)
@@ -50,7 +49,6 @@ class CompileSkipTranslationTest(QiskitTestCase):
     def test_simple_execute(self):
         name = 'test_simple'
         seed = 42
-        self.log.info(name)
         qp = QuantumProgram()
         qr = qp.create_quantum_register('qr', 2)
         cr = qp.create_classical_register('cr', 2)

--- a/test/python/test_tomography.py
+++ b/test/python/test_tomography.py
@@ -112,7 +112,7 @@ class TestTomography(QiskitTestCase):
         qp, qr, cr = _test_circuits_2qubit()
         # Test simulation and fitting
         shots = 1000
-        threshold = 1e-2
+        threshold = 0.015
         ref_X1Id0 = np.array(
             [0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0]) / 2
         choi = _tomography_test_data(qp, 'X1Id0', qr, cr, tomo_set, shots)

--- a/test/python/test_unroller.py
+++ b/test/python/test_unroller.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name,missing-docstring,no-member,bad-continuation
+# pylint: disable=invalid-name,missing-docstring
 #
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #
@@ -133,7 +133,7 @@ measure r[2] -> d[2];
         ast = qasm.Qasm(filename=self._get_resource_path('qasm/example.qasm')).parse()
         dag_circuit = Unroller(ast, DAGBackend(["cx", "u1", "u2", "u3"])).execute()
         dag_unroller = DagUnroller(dag_circuit, DAGBackend())
-        expanded_dag_circuit = dag_unroller.expand_gates(["cx", "u1", "u2", "u3"])
+        expanded_dag_circuit = dag_unroller.expand_gates(basis=["cx", "u1", "u2", "u3"])
         expected_result = """\
 OPENQASM 2.0;
 qreg q[3];
@@ -173,30 +173,33 @@ measure r[2] -> d[2];
         dag_circuit = Unroller(ast, DAGBackend()).execute()
         dag_unroller = DagUnroller(dag_circuit, JsonBackend())
         json_circuit = dag_unroller.execute()
-        expected_result = \
-            {'operations':
-                [{'qubits': [5], 'texparams': ['0.5 \\pi', '0', '\\pi'],
-                  'name': 'U', 'params': [1.5707963267948966, 0.0, 3.141592653589793]},
-                 {'name': 'CX', 'qubits': [5, 2]},
-                 {'clbits': [2], 'name': 'measure', 'qubits': [2]},
-                 {'qubits': [4], 'texparams': ['0.5 \\pi', '0', '\\pi'], 'name': 'U',
-                  'params': [1.5707963267948966, 0.0, 3.141592653589793]},
-                 {'name': 'CX', 'qubits': [4, 1]},
-                 {'clbits': [1], 'name': 'measure', 'qubits': [1]},
-                 {'qubits': [3], 'texparams': ['0.5 \\pi', '0', '\\pi'], 'name': 'U',
-                  'params': [1.5707963267948966, 0.0, 3.141592653589793]},
-                 {'name': 'CX', 'qubits': [3, 0]},
-                 {'name': 'barrier', 'qubits': [3, 4, 5]},
-                 {'clbits': [5], 'name': 'measure', 'qubits': [5]},
-                 {'clbits': [4], 'name': 'measure', 'qubits': [4]},
-                 {'clbits': [3], 'name': 'measure', 'qubits': [3]},
-                 {'clbits': [0], 'name': 'measure', 'qubits': [0]}],
-             'header':
-                 {'number_of_clbits': 6,
-                  'qubit_labels': [['r', 0], ['r', 1], ['r', 2], ['q', 0], ['q', 1], ['q', 2]],
-                  'number_of_qubits': 6, 'clbit_labels': [['d', 3], ['c', 3]]
-                  }
-             }
+        expected_result = {
+            'operations':
+                [
+                    {'qubits': [5], 'texparams': ['0.5 \\pi', '0', '\\pi'],
+                     'name': 'U', 'params': [1.5707963267948966, 0.0, 3.141592653589793]},
+                    {'name': 'CX', 'qubits': [5, 2]},
+                    {'clbits': [2], 'name': 'measure', 'qubits': [2]},
+                    {'qubits': [4], 'texparams': ['0.5 \\pi', '0', '\\pi'], 'name': 'U',
+                     'params': [1.5707963267948966, 0.0, 3.141592653589793]},
+                    {'name': 'CX', 'qubits': [4, 1]},
+                    {'clbits': [1], 'name': 'measure', 'qubits': [1]},
+                    {'qubits': [3], 'texparams': ['0.5 \\pi', '0', '\\pi'], 'name': 'U',
+                     'params': [1.5707963267948966, 0.0, 3.141592653589793]},
+                    {'name': 'CX', 'qubits': [3, 0]},
+                    {'name': 'barrier', 'qubits': [3, 4, 5]},
+                    {'clbits': [5], 'name': 'measure', 'qubits': [5]},
+                    {'clbits': [4], 'name': 'measure', 'qubits': [4]},
+                    {'clbits': [3], 'name': 'measure', 'qubits': [3]},
+                    {'clbits': [0], 'name': 'measure', 'qubits': [0]}
+                ],
+            'header':
+                {
+                    'number_of_clbits': 6,
+                    'qubit_labels': [['r', 0], ['r', 1], ['r', 2], ['q', 0], ['q', 1], ['q', 2]],
+                    'number_of_qubits': 6, 'clbit_labels': [['d', 3], ['c', 3]]
+                }
+        }
 
         self.assertEqual(json_circuit, expected_result)
 
@@ -209,29 +212,32 @@ measure r[2] -> d[2];
         dag_circuit = Unroller(ast, DAGBackend(["cx", "u1", "u2", "u3"])).execute()
         dag_unroller = DagUnroller(dag_circuit, JsonBackend(["cx", "u1", "u2", "u3"]))
         json_circuit = dag_unroller.execute()
-        expected_result = \
-            {'operations':
-                [{'qubits': [5], 'texparams': ['0', '\\pi'], 'params': [0.0, 3.141592653589793],
-                  'name': 'u2'},
-                 {'qubits': [5, 2], 'texparams': [], 'params': [], 'name': 'cx'},
-                 {'qubits': [2], 'clbits': [2], 'name': 'measure'},
-                 {'qubits': [4], 'texparams': ['0', '\\pi'], 'params': [0.0, 3.141592653589793],
-                  'name': 'u2'},
-                 {'qubits': [4, 1], 'texparams': [], 'params': [], 'name': 'cx'},
-                 {'qubits': [1], 'clbits': [1], 'name': 'measure'},
-                 {'qubits': [3], 'texparams': ['0', '\\pi'], 'params': [0.0, 3.141592653589793],
-                  'name': 'u2'},
-                 {'qubits': [3, 0], 'texparams': [], 'params': [], 'name': 'cx'},
-                 {'qubits': [3, 4, 5], 'name': 'barrier'},
-                 {'qubits': [5], 'clbits': [5], 'name': 'measure'},
-                 {'qubits': [4], 'clbits': [4], 'name': 'measure'},
-                 {'qubits': [3], 'clbits': [3], 'name': 'measure'},
-                 {'qubits': [0], 'clbits': [0], 'name': 'measure'}],
-             'header':
-                 {'clbit_labels': [['d', 3], ['c', 3]],
-                  'number_of_qubits': 6,
-                  'qubit_labels': [['r', 0], ['r', 1], ['r', 2], ['q', 0], ['q', 1], ['q', 2]],
-                  'number_of_clbits': 6
-                  }
-             }
+        expected_result = {
+            'operations':
+                [
+                    {'qubits': [5], 'texparams': ['0', '\\pi'], 'params': [0.0, 3.141592653589793],
+                     'name': 'u2'},
+                    {'qubits': [5, 2], 'texparams': [], 'params': [], 'name': 'cx'},
+                    {'qubits': [2], 'clbits': [2], 'name': 'measure'},
+                    {'qubits': [4], 'texparams': ['0', '\\pi'], 'params': [0.0, 3.141592653589793],
+                     'name': 'u2'},
+                    {'qubits': [4, 1], 'texparams': [], 'params': [], 'name': 'cx'},
+                    {'qubits': [1], 'clbits': [1], 'name': 'measure'},
+                    {'qubits': [3], 'texparams': ['0', '\\pi'], 'params': [0.0, 3.141592653589793],
+                     'name': 'u2'},
+                    {'qubits': [3, 0], 'texparams': [], 'params': [], 'name': 'cx'},
+                    {'qubits': [3, 4, 5], 'name': 'barrier'},
+                    {'qubits': [5], 'clbits': [5], 'name': 'measure'},
+                    {'qubits': [4], 'clbits': [4], 'name': 'measure'},
+                    {'qubits': [3], 'clbits': [3], 'name': 'measure'},
+                    {'qubits': [0], 'clbits': [0], 'name': 'measure'}
+                ],
+            'header':
+                {
+                    'clbit_labels': [['d', 3], ['c', 3]],
+                    'number_of_qubits': 6,
+                    'qubit_labels': [['r', 0], ['r', 1], ['r', 2], ['q', 0], ['q', 1], ['q', 2]],
+                    'number_of_clbits': 6
+                }
+        }
         self.assertEqual(json_circuit, expected_result)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix a number of issues in the tests:
* the most important is the `assertDictAlmostEqual` comparisons, as some of them were failing which when using the C++ simulator under some environments (Linux/Python 3.5):
  ```
  TestQuantumProgram.test_combine_circuit_common
  TestQuantumProgram.test_extend_circuit
  TestQuantumProgram.test_local_qasm_simulator
  TestQuantumProgram.test_run_async_program
  TestQuantumProgram.test_run_async_stress
  TestQuantumProgram.test_run_batch
  TestQuantumProgram.test_run_batch_async
  TestQuantumProgram.test_run_program
  TestTomography.test_process_tomography_2qubit
  TestCrossSimulation.test_qasm_reset_measure
   ```
  Upon closer inspection, it seems the thresholds (usually `0.025*shots`) were a bit too restrictive. This PR sets the default threshold to `0.04*shots`, which seems to be enough. Manual tests were made to rule out the possibility of it being an issue with the simulator itself - for the failing tests, increasing the number of shots to `shots*10` (~10k) resulted in being able to reduce the threshold to 0.01 and pass sucessfully.
* reintroduce the execution of the tests that require online connection when pushing to `master` (ie. they will still be skipped during the CI for open pull requests, for quicker response time and avoid network overhead). It seems this facility was lost some weeks ago, related to travis enviroment variables.
* avoid copying registers during `QuantumProgram.add_circuit()`.
* small tweaks for style and for ensuring the output of the tests and the logging keeps closer to the standards.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.