### PR TITLE
Adding `wheel` package to dev dependencies.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ better-apidoc==0.1.2
 sphinxcontrib-fulltoc==1.2.0
 coverage>=4.4.0
 jsonschema>=2.6,<2.7
+wheel


### PR DESCRIPTION
Running `make pypi_package` fails with `error: invalid command 'bdist_wheel'` if the `wheel` package is not installed.