### PR TITLE
dummy provider filter

### DIFF
--- a/test/python/_dummybackend.py
+++ b/test/python/_dummybackend.py
@@ -37,8 +37,14 @@ class DummyProvider(BaseProvider):
     def get_backend(self, name):
         return DummySimulator()
 
-    def available_backends(self, *args, **kwargs):
-        return [DummySimulator()]
+    def available_backends(self, filters=None):
+        backends = {DummySimulator.name: DummySimulator()}
+
+        filters = filters or {}
+        for key, value in filters.items():
+            backends = {name: instance for name, instance in backends.items()
+                        if instance.configuration.get(key) == value}
+        return list(backends.values())
 
 
 class DummySimulator(BaseBackend):

--- a/test/python/_dummybackend.py
+++ b/test/python/_dummybackend.py
@@ -38,6 +38,7 @@ class DummyProvider(BaseProvider):
         return DummySimulator()
 
     def available_backends(self, filters=None):
+        # pylint: disable=arguments-differ
         backends = {DummySimulator.name: DummySimulator()}
 
         filters = filters or {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The test suite on the master branch is currently failing, due to a small issue with filtering.
The failing test is `test_reordering`, and the underlying cause is that `available_backends({'simulator': False})` is returning `ibmqx2, ibmqx4, ibmqx5, local_dummy_simulator`. Clearly, the last one should not be there, since it is a simulator. The reason it shows up is that `filter` is not implemented for the dummy provider. This PR addresses that.

(The above test does not fail when run individually. Only when run with other tests, the local_dummy_backend persists in the `wrapper.available_backends()`).

This is a temporary fix until #410 properly addresses the filtering mechanism.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.