### PR TITLE
Fix deprecation warnings

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -687,7 +687,7 @@ class QuantumProgram(object):
 
         warnings.warn(
             "set_api() will be deprecated in upcoming versions (>0.5.0). "
-            "Using the API object instead is recommended.", DeprecationWarning)
+            "Use register(token, url) instead.", DeprecationWarning)
         qiskit.wrapper.register(token, url,
                                 hub, group, project, proxies, verify,
                                 provider_name='qiskit')
@@ -724,7 +724,7 @@ class QuantumProgram(object):
         """
         warnings.warn(
             "set_api_hubs_config() will be deprecated in upcoming versions (>0.5.0). "
-            "Using the API object instead is recommended.", DeprecationWarning)
+            "Use register(token, url, hub, group, project).", DeprecationWarning)
         config_dict = {
             'hub': hub,
             'group': group,
@@ -769,9 +769,8 @@ class QuantumProgram(object):
             qiskit.backends family of functions instead is recommended.
         """
         warnings.warn(
-            "available_backends() will be deprecated in upcoming versions (>0.5.0). "
-            "Using qiskit.backends.local_backends() and "
-            "qiskit.backends.remote_backends() instead is recommended.",
+            "QuantumProgram.available_backends() will be deprecated in upcoming versions (>0.5.0)."
+            "Using available_backends() with optional filter arguments is recommended instead.",
             DeprecationWarning)
 
         return qiskit.wrapper.available_backends(compact=compact)
@@ -794,7 +793,7 @@ class QuantumProgram(object):
         """
         warnings.warn(
             "online_backends() will be deprecated in upcoming versions (>0.5.0). "
-            "Using qiskit.backends.remote_backends() object instead is recommended.",
+            "Using available_backends({'local': False}) is recommended instead.",
             DeprecationWarning)
 
         return qiskit.wrapper.remote_backends()
@@ -814,7 +813,7 @@ class QuantumProgram(object):
         """
         warnings.warn(
             "online_simulators() will be deprecated in upcoming versions (>0.5.0). "
-            "Using qiskit.backends.remote_backends() instead is recommended.",
+            "Using available_backends({'local': False, 'simulator': True}) is recommended.",
             DeprecationWarning)
 
         return qiskit.wrapper.available_backends({'local': False,
@@ -835,7 +834,7 @@ class QuantumProgram(object):
         """
         warnings.warn(
             "online_devices() will be deprecated in upcoming versions (>0.5.0). "
-            "Using qiskit.backends.remote_backends() instead is recommended.",
+            "Using available_backends({'local': False, 'simulator': False}) is recommended.",
             DeprecationWarning)
 
         return qiskit.wrapper.available_backends({'local': False,
@@ -863,8 +862,7 @@ class QuantumProgram(object):
         """
         warnings.warn(
             "get_backend_status() will be deprecated in upcoming versions (>0.5.0). "
-            "Using qiskit.backends.get_backend_instance('name').status "
-            "instead is recommended.", DeprecationWarning)
+            "Using get_backend('name').status is recommended instead.", DeprecationWarning)
 
         my_backend = qiskit.wrapper.get_backend(backend)
         return my_backend.status
@@ -891,8 +889,7 @@ class QuantumProgram(object):
         """
         warnings.warn(
             "get_backend_configuration() will be deprecated in upcoming versions (>0.5.0). "
-            "Using qiskit.backends.get_backend_instance('name').configuration "
-            "instead is recommended.", DeprecationWarning)
+            "Using get_backend('name').configuration is recommended instead.", DeprecationWarning)
 
         my_backend = qiskit.wrapper.get_backend(backend)
         return my_backend.configuration
@@ -919,8 +916,7 @@ class QuantumProgram(object):
         """
         warnings.warn(
             "get_backend_calibration() will be deprecated in upcoming versions (>0.5.0). "
-            "Using qiskit.backends.get_backend_instance('name').calibration "
-            "instead is recommended.", DeprecationWarning)
+            "Using get_backend('name').calibration is recommended instead.", DeprecationWarning)
 
         my_backend = qiskit.wrapper.get_backend(backend)
         return my_backend.calibration
@@ -947,8 +943,7 @@ class QuantumProgram(object):
         """
         warnings.warn(
             "get_backend_parameters() will be deprecated in upcoming versions (>0.5.0). "
-            "Using qiskit.backends.get_backend_instance('name').parameters"
-            "instead is recommended.", DeprecationWarning)
+            "Using get_backend('name').parameters is recommended instead.", DeprecationWarning)
 
         my_backend = qiskit.wrapper.get_backend(backend)
         return my_backend.parameters
@@ -972,7 +967,7 @@ class QuantumProgram(object):
             coupling_map = coupling_dict2list(coupling_map)
             warnings.warn(
                 "coupling_map as a dictionary will be deprecated in upcoming versions (>0.5.0). "
-                "Using the coupling_map as a list recommended.", DeprecationWarning)
+                "Using the coupling_map as a list is recommended.", DeprecationWarning)
 
         list_of_circuits = []
         if not name_of_circuits:

--- a/qiskit/backends/local/qasm_simulator_cpp.py
+++ b/qiskit/backends/local/qasm_simulator_cpp.py
@@ -94,7 +94,8 @@ class QasmSimulatorCpp(BaseBackend):
         if qobj['config']['shots'] == 1:
             warnings.warn('The behavior of getting statevector from simulators '
                           'by setting shots=1 is deprecated and will be removed. '
-                          'Use the local_statevector_simulator instead.',
+                          'Use the local_statevector_simulator instead, or place '
+                          'explicit snapshot instructions.',
                           DeprecationWarning)
         for circ in qobj['circuits']:
             if 'measure' not in [op['name'] for

--- a/test/python/qobj/cpp_conditionals.json
+++ b/test/python/qobj/cpp_conditionals.json
@@ -33,7 +33,12 @@
                     	"qubits": [1], 
                     	"conditional": {"type": "equals", "mask": "0x1", "val": "0x1"}
                     },
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -100,7 +105,12 @@
                     	"qubits": [1], 
                     	"conditional": {"type": "equals", "mask": "0x2", "val": "0x1"}
                     },
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },

--- a/test/python/qobj/cpp_measure_opt_flag.json
+++ b/test/python/qobj/cpp_measure_opt_flag.json
@@ -32,7 +32,12 @@
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },

--- a/test/python/qobj/cpp_reset.json
+++ b/test/python/qobj/cpp_reset.json
@@ -10,14 +10,19 @@
             "name": "reset",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "reset", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure",
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -25,15 +30,20 @@
             "name": "x reset",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "x", "qubits": [0]},
                     {"name": "reset", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure",
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -41,15 +51,20 @@
             "name": "y reset",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "y", "qubits": [0]},
                     {"name": "reset", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure",
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -57,15 +72,20 @@
             "name": "h reset",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "reset", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure",
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         }

--- a/test/python/qobj/cpp_save_load.json
+++ b/test/python/qobj/cpp_save_load.json
@@ -10,8 +10,8 @@
             "name": "save_command",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
@@ -24,7 +24,12 @@
                     {"name": "load", "params": [0]},
                     {"name": "snapshot", "params": [1]},
                     {"name": "load", "params": [1]},
-                    {"name": "snapshot", "params": [11]}
+                    {"name": "snapshot", "params": [11]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         }

--- a/test/python/qobj/cpp_single_qubit_gates.json
+++ b/test/python/qobj/cpp_single_qubit_gates.json
@@ -10,13 +10,18 @@
             "name": "snapshot",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -24,14 +29,19 @@
             "name": "id(U)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "U", "params": [0.0, 0.0, 0.0], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -39,14 +49,19 @@
             "name": "id(u3)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "u3", "params": [0.0, 0.0, 0.0], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -54,14 +69,19 @@
             "name": "id(u1)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "u1", "params": [0.0], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -69,14 +89,19 @@
             "name": "id(direct)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "id", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -84,14 +109,19 @@
             "name": "x(U)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "U", "params": [3.14159265358979, 0.0, 3.14159265358979], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -99,14 +129,19 @@
             "name": "x(u3)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "u3", "params": [3.14159265358979, 0.0, 3.14159265358979], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -114,14 +149,19 @@
             "name": "x(direct)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "x", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -129,14 +169,19 @@
             "name": "y(U)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "U", "params": [3.14159265358979, 1.5707963267948966, 1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -144,14 +189,19 @@
             "name": "y(u3)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "u3", "params": [3.14159265358979, 1.5707963267948966, 1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -159,14 +209,19 @@
             "name": "y(direct)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "y", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -174,14 +229,19 @@
             "name": "h(U)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "U", "params": [1.5707963267948966, 0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -189,14 +249,19 @@
             "name": "h(u3)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "u3", "params": [1.5707963267948966, 0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -204,14 +269,19 @@
             "name": "h(u2)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "u2", "params": [0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -219,14 +289,19 @@
             "name": "h(direct)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -234,15 +309,20 @@
             "name": "h(direct) z(U)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "U", "params": [0.0, 0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -250,15 +330,20 @@
             "name": "h(direct) z(u3)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u3", "params": [0.0, 0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -266,15 +351,20 @@
             "name": "h(direct) z(u1)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u1", "params": [3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -282,15 +372,20 @@
             "name": "h(direct) z(direct)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "z", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -298,15 +393,20 @@
             "name": "h(direct) s(U)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "U", "params": [0.0, 0.0, 1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -314,15 +414,20 @@
             "name": "h(direct) s(u3)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u3", "params": [0.0, 0.0, 1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -330,15 +435,20 @@
             "name": "h(direct) s(u1)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u1", "params": [1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -346,15 +456,20 @@
             "name": "h(direct) s(direct)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "s", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -362,15 +477,20 @@
             "name": "h(direct) sdg(U)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "U", "params": [0.0, 0.0, -1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -378,15 +498,20 @@
             "name": "h(direct) sdg(u3)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u3", "params": [0.0, 0.0, -1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -394,15 +519,20 @@
             "name": "h(direct) sdg(u1)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u1", "params": [-1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -410,15 +540,20 @@
             "name": "h(direct) sdg(direct)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "sdg", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -426,15 +561,20 @@
             "name": "h(direct) t(U)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "U", "params": [0.0, 0.0, 0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -442,15 +582,20 @@
             "name": "h(direct) t(u3)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u3", "params": [0.0, 0.0, 0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -458,15 +603,20 @@
             "name": "h(direct) t(u1)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u1", "params": [0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -474,15 +624,20 @@
             "name": "h(direct) t(direct)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "t", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -490,15 +645,20 @@
             "name": "h(direct) tdg(U)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "U", "params": [0.0, 0.0, -0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -506,15 +666,20 @@
             "name": "h(direct) tdg(u3)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u3", "params": [0.0, 0.0, -0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -522,15 +687,20 @@
             "name": "h(direct) tdg(u1)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "u1", "params": [-0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -538,15 +708,20 @@
             "name": "h(direct) tdg(direct)",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 1,
                     "qubit_labels": [["q", 0]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "tdg", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]}
+                    {"name": "#snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         }

--- a/test/python/qobj/cpp_two_qubit_gates.json
+++ b/test/python/qobj/cpp_two_qubit_gates.json
@@ -10,15 +10,20 @@
             "name": "h0 CX01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "CX", "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -26,15 +31,20 @@
             "name": "h0 CX10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "CX", "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -42,15 +52,20 @@
             "name": "h1 CX01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [1]},
                     {"name": "CX", "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -58,15 +73,20 @@
             "name": "h1 CX10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [1]},
                     {"name": "CX", "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -74,15 +94,20 @@
             "name": "h0 cx01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "cx", "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -90,15 +115,20 @@
             "name": "h0 cx10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "cx", "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -106,15 +136,20 @@
             "name": "h1 cx01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [1]},
                     {"name": "cx", "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -122,15 +157,20 @@
             "name": "h1 cx10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [1]},
                     {"name": "cx", "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -138,15 +178,20 @@
             "name": "h0 cz01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "cz", "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -154,15 +199,20 @@
             "name": "h0 cz10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "cz", "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -170,15 +220,20 @@
             "name": "h1 cz01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [1]},
                     {"name": "cz", "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -186,15 +241,20 @@
             "name": "h1 cz10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [1]},
                     {"name": "cz", "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -202,8 +262,8 @@
             "name": "h0 h1 cz01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
@@ -211,7 +271,12 @@
                     {"name": "h", "qubits": [0]},
                     {"name": "h", "qubits": [1]},
                     {"name": "cz", "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -219,8 +284,8 @@
             "name": "h0 h1 cz10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
@@ -228,7 +293,12 @@
                     {"name": "h", "qubits": [0]},
                     {"name": "h", "qubits": [1]},
                     {"name": "cz", "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -236,15 +306,20 @@
             "name": "h0 rzz01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -252,15 +327,20 @@
             "name": "h0 rzz10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [0]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -268,15 +348,20 @@
             "name": "h1 rzz01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [1]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -284,15 +369,20 @@
             "name": "h1 rzz10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "operations": [
                     {"name": "h", "qubits": [1]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -300,8 +390,8 @@
             "name": "h0 h1 rzz01",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
@@ -309,7 +399,12 @@
                     {"name": "h", "qubits": [0]},
                     {"name": "h", "qubits": [1]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         },
@@ -317,8 +412,8 @@
             "name": "h0 h1 rzz10",
             "compiled_circuit": {
                 "header": {
-                    "clbit_labels": [],
-                    "number_of_clbits": 0,
+                    "clbit_labels": [["c0", 1]],
+                    "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
@@ -326,7 +421,12 @@
                     {"name": "h", "qubits": [0]},
                     {"name": "h", "qubits": [1]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [1, 0]},
-                    {"name": "snapshot", "params": [0]}
+                    {"name": "snapshot", "params": [0]},
+                    {
+                    	"name": "measure", 
+                    	"qubits": [0],
+                    	"clbits": [0]
+                    }
                 ]
             }
         }

--- a/test/python/test_qasm_simulator_py.py
+++ b/test/python/test_qasm_simulator_py.py
@@ -36,7 +36,7 @@ from .common import QiskitTestCase
 do_profiling = False
 
 
-class TestLocalQasmSimulatorPyPy(QiskitTestCase):
+class TestLocalQasmSimulatorPy(QiskitTestCase):
     """Test local_qasm_simulator_py."""
 
     @classmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
1. Updates tests and  fixes #441, by ensuring tests do not output a lot of DeprecationWarnings
2. Updates the DeprecationWarning messages in quantumprogram.py to the latest SDK usage convention.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.