### PR TITLE
Fix test_localjob.py and slowtests

### DIFF
--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -31,6 +31,14 @@ from qiskit.backends.basejob import JobStatus
 from .common import requires_qe_access, QiskitTestCase, slow_test
 
 
+def lowest_pending_jobs(backends):
+    """Returns the backend with lowest pending jobs."""
+    backends = filter(lambda x: x.status.get('available', False), backends)
+    by_pending_jobs = sorted(backends,
+                             key=lambda x: x.status['pending_jobs'])
+    return by_pending_jobs[0]
+
+
 class TestIBMQJob(QiskitTestCase):
     """
     Test ibmqjob module.
@@ -72,7 +80,8 @@ class TestIBMQJob(QiskitTestCase):
 
     @slow_test
     def test_run_device(self):
-        backend = self._provider.available_backends({'simulator': False})[0]
+        backends = self._provider.available_backends({'simulator': False})
+        backend = lowest_pending_jobs(backends)
         self.log.info(backend.name)
         qobj = qiskit._compiler.compile(self._qc, backend)
         shots = qobj['config']['shots']
@@ -143,7 +152,8 @@ class TestIBMQJob(QiskitTestCase):
 
     @slow_test
     def test_run_async_device(self):
-        backend = self._provider.available_backends({'simulator': False})[0]
+        backends = self._provider.available_backends({'simulator': False})
+        backend = lowest_pending_jobs(backends)
         self.log.info('submitting to backend %s', backend.name)
         num_qubits = 5
         qr = QuantumRegister(num_qubits, 'qr')

--- a/test/python/test_localjob.py
+++ b/test/python/test_localjob.py
@@ -93,11 +93,11 @@ class TestLocalJob(QiskitTestCase):
         """Test the cancelation of jobs.
 
         Since only Jobs that are still in the executor queue pending to be
-        executed can be cancelled, this tests launches a lot of jobs, passing
+        executed can be cancelled, this test launches a lot of jobs, passing
         if some of them can be cancelled.
         """
         # Force the number of workers to 1, as only Jobs that are still in
-        # the executor queue can be queue.
+        # the executor queue can be canceled.
         if sys.platform == 'darwin':
             LocalJob._executor = futures.ThreadPoolExecutor(max_workers=1)
         else:
@@ -116,7 +116,7 @@ class TestLocalJob(QiskitTestCase):
         num_jobs = 50
         job_array = [backend.run(quantum_job) for _ in range(num_jobs)]
 
-        # Try to cancel them in the reversed order they were launched: the
+        # Try to cancel them in the reverse order they were launched: the
         # most recent job is the one with more chances of still being in the
         # queue.
         for job in reversed(job_array):

--- a/test/python/test_localjob.py
+++ b/test/python/test_localjob.py
@@ -18,15 +18,17 @@
 
 """LocalJob Test."""
 
+import sys
 import unittest
-import time
+from concurrent import futures
+
 import numpy
 from scipy.stats import chi2_contingency
 
+import qiskit._compiler
 from qiskit import (ClassicalRegister, QuantumCircuit, QuantumRegister,
                     QuantumJob)
-import qiskit._compiler
-from qiskit.backends.local import LocalProvider
+from qiskit.backends.local import LocalProvider, LocalJob
 from .common import requires_qe_access, QiskitTestCase
 
 
@@ -79,10 +81,28 @@ class TestLocalJob(QiskitTestCase):
         quantum_job = QuantumJob(qobj, backend, shots=1e5, preformatted=True)
         num_jobs = 5
         job_array = [backend.run(quantum_job) for _ in range(num_jobs)]
-        time.sleep(0.1)  # give time for jobs to start (better way?)
-        self.assertTrue(all([job.running for job in job_array]))
+
+        # Wait for all the results.
+        result_array = [job.result() for job in job_array]
+
+        # Ensure all jobs have finished.
+        self.assertTrue(all([job.done for job in job_array]))
+        self.assertTrue(all([result.get_status() == 'COMPLETED' for result in result_array]))
 
     def test_cancel(self):
+        """Test the cancelation of jobs.
+
+        Since only Jobs that are still in the executor queue pending to be
+        executed can be cancelled, this tests launches a lot of jobs, passing
+        if some of them can be cancelled.
+        """
+        # Force the number of workers to 1, as only Jobs that are still in
+        # the executor queue can be queue.
+        if sys.platform == 'darwin':
+            LocalJob._executor = futures.ThreadPoolExecutor(max_workers=1)
+        else:
+            LocalJob._executor = futures.ProcessPoolExecutor(max_workers=1)
+
         backend = self._provider.get_backend('local_qasm_simulator_py')
         num_qubits = 5
         qr = QuantumRegister(num_qubits, 'q')
@@ -95,8 +115,11 @@ class TestLocalJob(QiskitTestCase):
         quantum_job = QuantumJob(qobj, backend, shots=1e5, preformatted=True)
         num_jobs = 50
         job_array = [backend.run(quantum_job) for _ in range(num_jobs)]
-        time.sleep(0.1)
-        for job in job_array:
+
+        # Try to cancel them in the reversed order they were launched: the
+        # most recent job is the one with more chances of still being in the
+        # queue.
+        for job in reversed(job_array):
             job.cancel()
         num_cancelled = sum([job.cancelled for job in job_array])
         self.log.info('number of successfully cancelled jobs: %d/%d',

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -25,9 +25,11 @@ from .common import requires_qe_access, QiskitTestCase, slow_test
 
 def lowest_pending_jobs(list_of_backends):
     """Returns the backend with lowest pending jobs."""
-    by_pending_jobs = sorted(list_of_backends,
-                             key=lambda x: get_backend(x).status['pending_jobs'])
-    return by_pending_jobs[0]
+    backends = [get_backend(name) for name in list_of_backends]
+    backends = filter(lambda x: x.status.get('available', False), backends)
+    by_pending_jobs = sorted(backends,
+                             key=lambda x: x.status['pending_jobs'])
+    return by_pending_jobs[0].name
 
 
 class TestBitReordering(QiskitTestCase):
@@ -41,7 +43,8 @@ class TestBitReordering(QiskitTestCase):
     def test_basic_reordering(self, QE_TOKEN, QE_URL):
         """a simple reordering within a 2-qubit register"""
         sim, real = self._get_backends(QE_TOKEN, QE_URL)
-        unittest.skipIf(not real, 'no remote device available.')
+        if not sim or not real:
+            raise unittest.SkipTest('no remote device available')
 
         q = qiskit.QuantumRegister(2)
         c = qiskit.ClassicalRegister(2)
@@ -63,7 +66,8 @@ class TestBitReordering(QiskitTestCase):
     def test_multi_register_reordering(self, QE_TOKEN, QE_URL):
         """a more complicated reordering across 3 registers of different sizes"""
         sim, real = self._get_backends(QE_TOKEN, QE_URL)
-        unittest.skipIf(not real, 'no remote device available.')
+        if not sim or not real:
+            raise unittest.SkipTest('no remote device available')
 
         q0 = qiskit.QuantumRegister(2)
         q1 = qiskit.QuantumRegister(2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fix `test_cancel()` issue, as in some environments the Jobs might have
been to fast and not be able to be cancelled, causing the test to fail.
Fix `test_run_async()`, waiting for the jobs to finish and checking for
the results, as a similar situation might apply (the jobs being run
too fast and being completed by the time the assertion was reached,
which was only checking for `RUNNING`).

* Adjust tests to avoid unavailable backends (such as "ibmqx2") be used
during the tests by making sure that the device picked up by the tests
is `available`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.