### PR TITLE
pip release: 0.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
-project (QISKit VERSION 0.5.0 LANGUAGES CXX)
+project (QISKit VERSION 0.5.1 LANGUAGES CXX)
 
 # Verbose!!
 set(CMAKE_VERBOSE_MAKEFILE True)

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -46,4 +46,4 @@ from .wrapper._wrapper import available_backends, execute, register, get_backend
 # Import the wrapper, to make it available when doing "import qiskit".
 from . import wrapper
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'


### PR DESCRIPTION
* No code changes this time. There was problem with the MacOS Wheel
  package. We cannot overwrite a Wheel package on PyPi without
  bumping up software version number.
