### PR TITLE
Fix #475 update state_tomography.py to use local_statevector_simulator

### DIFF
--- a/test/performance/state_tomography.py
+++ b/test/performance/state_tomography.py
@@ -98,7 +98,7 @@ def state_tomography(state, n_qubits, shots):
 
     # Prepared target state and assess quality
     qp = target_prep(qp, state, target)
-    prep_result = qp.execute(['prep'], backend=backend, shots=1)
+    prep_result = qp.execute(['prep'], backend='local_statevector_simulator')
     prep_state = prep_result.get_data('prep')['statevector']
     F_prep = state_fidelity(prep_state, target)
     print('Prepared state fidelity =', F_prep)


### PR DESCRIPTION
## Description

Fixes #475 
Updates compiler performance test `state_tomography.py` to use `local_statevector_simulator` backend to get the state vector of the prep circuit.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.