### PR TITLE
Adapting to new online simulator names.

### DIFF
--- a/qiskit/_compiler.py
+++ b/qiskit/_compiler.py
@@ -86,25 +86,9 @@ def compile(circuits, backend,
                       'shots': shots,
                       'backend_name': backend_name}
 
-    # TODO This backend needs HPC parameters to be passed in order to work
-    if 'hpc' in backend_name:
-        if hpc is None:
-            logger.info('ibmq_qasm_simulator_hpc backend needs HPC '
-                        'parameter. Setting defaults to hpc.multi_shot_optimization '
-                        '= true and hpc.omp_num_threads = 16')
-            hpc = {'multi_shot_optimization': True, 'omp_num_threads': 16}
-
-        if not all(key in hpc for key in
-                   ('multi_shot_optimization', 'omp_num_threads')):
-            raise QISKitError('Unknown HPC parameter format!')
-
-        qobj['config']['hpc'] = hpc
-    elif hpc is not None:
-        logger.info('HPC parameter is only available for '
-                    'ibmq_qasm_simulator_hpc. You are passing an HPC parameter '
-                    'but you are not using ibmq_qasm_simulator_hpc, so we will '
-                    'ignore it.')
-        hpc = None
+    if hpc is not None and \
+            not all(key in hpc for key in ('multi_shot_optimization', 'omp_num_threads')):
+        raise QISKitError('Unknown HPC parameter format!')
 
     qobj['circuits'] = []
     if not basis_gates:

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1195,7 +1195,7 @@ class QuantumProgram(object):
             max_credits (int): the max credits to use 3, or 5
             seed (int): the initial seed the simulators use
             hpc (dict): This will setup some parameter for
-                        ibmq_qasm_simulator_hpc, using a JSON-like format like::
+                        ibmq_qasm_simulator, using a JSON-like format like::
 
                             {
                                 'multi_shot_optimization': Boolean,
@@ -1203,7 +1203,7 @@ class QuantumProgram(object):
                             }
 
                         This parameter MUST be used only with
-                        ibmq_qasm_simulator_hpc, otherwise the SDK will warn
+                        ibmq_qasm_simulator, otherwise the SDK will warn
                         the user via logging, and set the value to None.
             skip_translation (bool): If True, bypass most of the compilation process and
                 creates a qobj with minimal check nor translation

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1202,9 +1202,6 @@ class QuantumProgram(object):
                                 'omp_num_threads': Numeric
                             }
 
-                        This parameter MUST be used only with
-                        ibmq_qasm_simulator, otherwise the SDK will warn
-                        the user via logging, and set the value to None.
             skip_translation (bool): If True, bypass most of the compilation process and
                 creates a qobj with minimal check nor translation
         Returns:

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -79,11 +79,7 @@ class IBMQBackend(BaseBackend):
             calibrations = self._api.backend_calibration(backend_name)
             # FIXME a hack to remove calibration data that is none.
             # Needs to be fixed in api
-            if backend_name == 'ibmqx_hpc_qasm_simulator':
-                calibrations = {}
-            # FIXME a hack to remove calibration data that is none.
-            # Needs to be fixed in api
-            if backend_name == 'ibmqx_qasm_simulator':
+            if backend_name == 'ibmq_qasm_simulator':
                 calibrations = {}
         except Exception as ex:
             raise LookupError(
@@ -111,11 +107,7 @@ class IBMQBackend(BaseBackend):
             parameters = self._api.backend_parameters(backend_name)
             # FIXME a hack to remove parameters data that is none.
             # Needs to be fixed in api
-            if backend_name == 'ibmqx_hpc_qasm_simulator':
-                parameters = {}
-            # FIXME a hack to remove parameters data that is none.
-            # Needs to be fixed in api
-            if backend_name == 'ibmqx_qasm_simulator':
+            if backend_name == 'ibmq_qasm_simulator':
                 parameters = {}
         except Exception as ex:
             raise LookupError(

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -249,8 +249,7 @@ class IBMQJob(BaseJob):
 
         seed0 = qobj['circuits'][0]['config']['seed']
         hpc = None
-        if (qobj['config']['backend_name'] == 'ibmq_qasm_simulator_hpc' and
-                'hpc' in qobj['config']):
+        if 'hpc' in qobj['config']:
             try:
                 # Use CamelCase when passing the hpc parameters to the API.
                 hpc = {

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -51,6 +51,7 @@ class IBMQProvider(BaseProvider):
 
     def aliased_backend_names(self):
         return {
+            # TODO: Review the comment below. Is still true?
             # FIXME: uncomment after API fix: online simulator names should change
             # 'ibmq_qasm_simulator': ['ibmq_qasm_simulator',
             #                         'ibmq_qasm_simulator_hpc']
@@ -58,9 +59,8 @@ class IBMQProvider(BaseProvider):
 
     def deprecated_backend_names(self):
         return {
-            # FIXME: uncomment after API fix: online simulator names should change
-            # 'ibmq_qasm_simulator': 'ibmq_qasm_simulator',
-            # 'ibmq_qasm_simulator_hpc': 'ibmq_qasm_simulator_hpc',
+            'ibmqx_qasm_simulator': 'ibmq_qasm_simulator',
+            'ibmqx_qasm_simulator_hpc': 'ibmq_qasm_simulator',
             'real': 'ibmqx1'
             }
 

--- a/qiskit/wrapper/defaultqiskitprovider.py
+++ b/qiskit/wrapper/defaultqiskitprovider.py
@@ -130,12 +130,6 @@ class DefaultQISKitProvider(BaseProvider):
             resolved_name = deprecated[name]
             logger.warning('WARNING: %s is deprecated. Use %s.', name, resolved_name)
 
-        # FIXME: remove after API fix: online simulator names should change
-        if name == 'ibmq_qasm_simulator':
-            resolved_name = 'ibmqx_qasm_simulator'
-        if name == 'ibmq_qasm_simulator_hpc':
-            resolved_name = 'ibmqx_hpc_qasm_simulator'
-
         if resolved_name not in available:
             raise LookupError('backend "{}" not found.'.format(name))
 

--- a/test/python/test_api_ibmq.py
+++ b/test/python/test_api_ibmq.py
@@ -59,6 +59,7 @@ class TestApiHub(QiskitTestCase):
         super().setUp()
         qiskit.register(QE_TOKEN, QE_URL, hub=QE_HUB, group=QE_GROUP,
                         project=QE_PROJECT)
+        # TODO: FIXME: Change this backend name when changed in IBM-Q
         self.backend = 'ibmqx_qasm_simulator'
 
     @staticmethod

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -31,7 +31,7 @@ from .common import requires_qe_access, QiskitTestCase, Path
 
 def remove_backends_from_list(backends):
     """Helper and temporary function for removing specific backends from a list"""
-    backends_to_remove = ['ibmqx_hpc_qasm_simulator', 'ibmqx_qasm_simulator']
+    backends_to_remove = ['ibmq_qasm_simulator']
     return [backend for backend in backends if str(backend) not in backends_to_remove]
 
 

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -61,7 +61,7 @@ class TestIBMQJob(QiskitTestCase):
         cls._provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
 
     def test_run_simulator(self):
-        backend = self._provider.get_backend('ibmqx_qasm_simulator')
+        backend = self._provider.get_backend('ibmq_qasm_simulator')
         qobj = qiskit._compiler.compile(self._qc, backend)
         shots = qobj['config']['shots']
         quantum_job = QuantumJob(qobj, backend, preformatted=True)
@@ -111,7 +111,7 @@ class TestIBMQJob(QiskitTestCase):
     @slow_test
     def test_run_async_simulator(self):
         IBMQJob._executor = futures.ThreadPoolExecutor(max_workers=2)
-        backend = self._provider.get_backend('ibmqx_qasm_simulator')
+        backend = self._provider.get_backend('ibmq_qasm_simulator')
         self.log.info('submitting to backend %s', backend.name)
         num_qubits = 16
         qr = QuantumRegister(num_qubits, 'qr')
@@ -212,7 +212,7 @@ class TestIBMQJob(QiskitTestCase):
         self.assertTrue(job.cancelled)
 
     def test_job_id(self):
-        backend = self._provider.get_backend('ibmqx_qasm_simulator')
+        backend = self._provider.get_backend('ibmq_qasm_simulator')
         qobj = qiskit._compiler.compile(self._qc, backend)
         quantum_job = QuantumJob(qobj, backend, preformatted=True)
         job = backend.run(quantum_job)
@@ -222,7 +222,7 @@ class TestIBMQJob(QiskitTestCase):
         self.assertTrue(job.job_id is not None)
 
     def test_get_backend_name(self):
-        backend_name = 'ibmqx_qasm_simulator'
+        backend_name = 'ibmq_qasm_simulator'
         backend = self._provider.get_backend(backend_name)
         qobj = qiskit._compiler.compile(self._qc, backend)
         quantum_job = QuantumJob(qobj, backend, preformatted=True)

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -663,8 +663,7 @@ class TestQuantumProgram(QiskitTestCase):
                        'coupling_map', 'basis_gates'}
         qp.set_api(QE_TOKEN, QE_URL, hub, group, project)
         backend_list = qp.available_backends()
-        backend_list.remove('ibmqx_hpc_qasm_simulator')
-        backend_list.remove('ibmqx_qasm_simulator')
+        backend_list.remove('ibmq_qasm_simulator')
         if backend_list:
             backend = backend_list[0]
         backend_config = qp.get_backend_configuration(backend)
@@ -1757,9 +1756,9 @@ class TestQuantumProgram(QiskitTestCase):
     def test_hpc_parameter_is_correct(self, QE_TOKEN, QE_URL,
                                       hub=None, group=None, project=None):
         """Test for checking HPC parameter in compile() method.
-        It must be only used when the backend is ibmq_qasm_simulator_hpc.
+        It must be only used when the backend is ibmq_qasm_simulator (HPC).
         It will warn the user if the parameter is passed correctly but the
-        backend is not ibmq_qasm_simulator_hpc.
+        backend is not ibmq_qasm_simulator (HPC).
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
         qr = q_program.get_quantum_register("q_name")
@@ -1771,7 +1770,7 @@ class TestQuantumProgram(QiskitTestCase):
         qc2.measure(qr, cr)
         circuits = ['qc2']
         shots = 1
-        backend = 'ibmq_qasm_simulator_hpc'
+        backend = 'ibmq_qasm_simulator'
         q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
         qobj = q_program.compile(circuits, backend=backend, shots=shots,
                                  seed=88,
@@ -1783,7 +1782,7 @@ class TestQuantumProgram(QiskitTestCase):
     def test_hpc_parameter_is_incorrect(self, QE_TOKEN, QE_URL,
                                         hub=None, group=None, project=None):
         """Test for checking HPC parameter in compile() method.
-        It must be only used when the backend is ibmq_qasm_simulator_hpc.
+        It must be only used when the backend is ibmq_qasm_simulator (HPC).
         If the parameter format is incorrect, it will raise a QISKitError.
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
@@ -1796,7 +1795,7 @@ class TestQuantumProgram(QiskitTestCase):
         qc2.measure(qr, cr)
         circuits = ['qc2']
         shots = 1
-        backend = 'ibmq_qasm_simulator_hpc'
+        backend = 'ibmq_qasm_simulator'
         q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
         self.assertRaises(QISKitError, q_program.compile, circuits,
                           backend=backend, shots=shots, seed=88,

--- a/test/python/test_simulator_interfaces.py
+++ b/test/python/test_simulator_interfaces.py
@@ -74,19 +74,15 @@ class TestCrossSimulation(QiskitTestCase):
         sim_cpp = 'local_qasm_simulator_cpp'
         sim_py = 'local_qasm_simulator_py'
         sim_ibmq = 'ibmq_qasm_simulator'
-        sim_hpc = 'ibmq_qasm_simulator_hpc'
         shots = 2000
         result_cpp = execute(circ, sim_cpp, shots=shots).result()
         result_py = execute(circ, sim_py, shots=shots).result()
         result_ibmq = execute(circ, sim_ibmq, shots=shots).result()
-        result_hpc = execute(circ, sim_hpc, shots=shots).result()
         counts_cpp = result_cpp.get_counts()
         counts_py = result_py.get_counts()
         counts_ibmq = result_ibmq.get_counts()
-        counts_hpc = result_hpc.get_counts()
         self.assertDictAlmostEqual(counts_cpp, counts_py, shots*0.05)
         self.assertDictAlmostEqual(counts_py, counts_ibmq, shots*0.05)
-        self.assertDictAlmostEqual(counts_ibmq, counts_hpc, shots*0.05)
 
     def test_qasm_snapshot(self):
         """snapshot a circuit at multiple places"""
@@ -135,19 +131,15 @@ class TestCrossSimulation(QiskitTestCase):
         sim_cpp = 'local_qasm_simulator_cpp'
         sim_py = 'local_qasm_simulator_py'
         # sim_ibmq = 'ibmq_qasm_simulator'
-        # sim_hpc = 'ibmq_qasm_simulator_hpc'
         shots = 1000
         result_cpp = execute(circ, sim_cpp, shots=shots, seed=1).result()
         result_py = execute(circ, sim_py, shots=shots, seed=1).result()
         # result_ibmq = execute(circ, sim_ibmq, {'shots': shots}).result()
-        # result_hpc = execute(circ, sim_hpc, {'shots': shots}).result()
         counts_cpp = result_cpp.get_counts()
         counts_py = result_py.get_counts()
         # counts_ibmq = result_ibmq.get_counts()
-        # counts_hpc = result_hpc.get_counts()
         self.assertDictAlmostEqual(counts_cpp, counts_py, shots * 0.04)
         # self.assertDictAlmostEqual(counts_py, counts_ibmq, shots*0.04)
-        # self.assertDictAlmostEqual(counts_ibmq, counts_hpc, shots*0.04)
 
 
 class TestSimulatorNames(QiskitTestCase):


### PR DESCRIPTION
* ibmqx_qasm_simulator and ibmqx_hpc_qasm_simulator have been merged
  into ibmq_qasm_simulator, so we have to updates tests and code.
* hpc parameter is not enforced anymore, as there are no 'hpc'
  specific backends, and the rest of the backends ignore this param
  in case someone sends it to them by mistake.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.