### PR TITLE
Fix mapping error for multiple qregs raised in #492

### DIFF
--- a/qiskit/_compiler.py
+++ b/qiskit/_compiler.py
@@ -135,13 +135,13 @@ def compile(circuits, backend,
             # Pick good initial layout if None is given and not simulator
             if initial_layout is None and not backend.configuration['simulator']:
                 best_sub = best_subset(backend, num_qubits)
-                qreg_list = []
+                initial_layout = {}
+                map_iter = 0
                 for key, value in circuit.get_qregs().items():
-                    qreg_list += [key]*len(value)
+                    for i in range(value.size):
+                        initial_layout[(key, i)] = ('q', best_sub[map_iter])
+                        map_iter += 1
 
-                initial_layout = {(rr, kk): ('q', best_sub[kk])
-                                  for rr in qreg_list
-                                  for kk in range(len(qreg_list))}
             dag_circuit, final_layout = compile_circuit(
                 circuit,
                 basis_gates=basis_gates,

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -346,6 +346,27 @@ class TestCompiler(QiskitTestCase):
             qobj = None
         self.assertIsInstance(qobj, dict)
 
+    @requires_qe_access
+    def test_mapping_multi_qreg(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+        """Test mapping works for multiple qregs.
+        """
+        provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        backend = provider.get_backend('ibmqx5')
+
+        q = qiskit.QuantumRegister(2, name='qr')
+        q2 = qiskit.QuantumRegister(2, name='qr2')
+        c = qiskit.ClassicalRegister(2, name='cr')
+        qc = qiskit.QuantumCircuit(q, q2, c)
+        qc.h(q[0])
+        qc.cx(q[0], q2[1])
+        qc.measure(q, c)
+
+        try:
+            qobj = qiskit._compiler.compile(qc, backend)
+        except QISKitError:
+            qobj = None
+        self.assertIsInstance(qobj, dict)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -353,12 +353,14 @@ class TestCompiler(QiskitTestCase):
         provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
         backend = provider.get_backend('ibmqx5')
 
-        q = qiskit.QuantumRegister(2, name='qr')
-        q2 = qiskit.QuantumRegister(2, name='qr2')
-        c = qiskit.ClassicalRegister(2, name='cr')
-        qc = qiskit.QuantumCircuit(q, q2, c)
+        q = qiskit.QuantumRegister(3, name='qr')
+        q2 = qiskit.QuantumRegister(1, name='qr2')
+        q3 = qiskit.QuantumRegister(4, name='qr3')
+        c = qiskit.ClassicalRegister(3, name='cr')
+        qc = qiskit.QuantumCircuit(q, q2, q3, c)
         qc.h(q[0])
-        qc.cx(q[0], q2[1])
+        qc.cx(q[0], q2[0])
+        qc.cx(q[1], q3[2])
         qc.measure(q, c)
 
         try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was an indexing error in the case when multiple qregs where in a circuit.

## Motivation and Context
Fixes Issue #492.

## How Has This Been Tested?
Tested on original code where error showed up, and added unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.