### PR TITLE
adding `load_qasm` and default `url` to wrapper

### DIFF
--- a/examples/python/load_qasm.py
+++ b/examples/python/load_qasm.py
@@ -1,0 +1,25 @@
+"""
+Example on how to use: load_qasm_file
+If you want to use your local cloned repository intead of the one installed via pypi,
+you have to run like this:
+    examples/python$ PYTHONPATH=$PYTHONPATH:../.. python load_qasm.py
+"""
+from qiskit.wrapper import load_qasm_file
+from qiskit import QISKitError, available_backends, execute
+try:
+    qc = load_qasm_file("../qasm/entangled_registers.qasm")
+
+    # See a list of available local simulators
+    print("Local backends: ", available_backends({'local': True}))
+
+    # Compile and run the Quantum circuit on a local simulator backend
+    job_sim = execute(qc, "local_qasm_simulator")
+    sim_result = job_sim.result()
+
+    # Show the results
+    print("simulation: ", sim_result)
+    print(sim_result.get_counts(qc))
+
+except QISKitError as ex:
+    print('There was an internal QISKit error. Error = {}'.format(ex))
+

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -41,7 +41,8 @@ import qiskit.extensions.quantum_initializer
 from ._quantumjob import QuantumJob
 from ._quantumprogram import QuantumProgram
 from ._result import Result
-from .wrapper._wrapper import available_backends, execute, register, get_backend, compile
+from .wrapper._wrapper import (available_backends, execute, register, get_backend, compile,
+                               load_qasm_text, load_qasm_file)
 
 # Import the wrapper, to make it available when doing "import qiskit".
 from . import wrapper

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -42,7 +42,7 @@ from ._quantumjob import QuantumJob
 from ._quantumprogram import QuantumProgram
 from ._result import Result
 from .wrapper._wrapper import (available_backends, execute, register, get_backend, compile,
-                               load_qasm_text, load_qasm_file)
+                               load_qasm_string, load_qasm_file)
 
 # Import the wrapper, to make it available when doing "import qiskit".
 from . import wrapper

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -422,17 +422,10 @@ class QuantumProgram(object):
         Raises:
             QISKitError: if the file cannot be read.
         """
-        if not os.path.exists(qasm_file):
-            raise QISKitError('qasm file "{0}" not found'.format(qasm_file))
-        if not name:
-            name = os.path.splitext(os.path.basename(qasm_file))[0]
-        node_circuit = Qasm(filename=qasm_file).parse()  # Node (AST)
-        logger.info("circuit name: %s", name)
-        logger.info("******************************")
-        logger.info(node_circuit.qasm())
-        # current method to turn it a DAG quantum circuit.
-        unrolled_circuit = Unroller(node_circuit, CircuitBackend(basis_gates.split(",")))
-        circuit_unrolled = unrolled_circuit.execute()
+        warnings.warn(
+            "QuantumProgram.load_qasm_file() will be deprecated in upcoming versions (>0.5.0). "
+            "Using qiskit.load_qasm_file() instead is recommended.", DeprecationWarning)
+        circuit_unrolled = qiskit.wrapper.load_qasm_file(qasm_file, name, basis_gates)        
         self.add_circuit(name, circuit_unrolled)
         return name
 
@@ -449,16 +442,10 @@ class QuantumProgram(object):
             str: Adds a quantum circuit with the gates given in the qasm string to
             the quantum program.
         """
-        node_circuit = Qasm(data=qasm_string).parse()  # Node (AST)
-        if not name:
-            # Get a random name if none is given
-            name = str(uuid.uuid4())
-        logger.info("circuit name: %s", name)
-        logger.info("******************************")
-        logger.info(node_circuit.qasm())
-        # current method to turn it a DAG quantum circuit.
-        unrolled_circuit = Unroller(node_circuit, CircuitBackend(basis_gates.split(",")))
-        circuit_unrolled = unrolled_circuit.execute()
+        warnings.warn(
+            "QuantumProgram.load_qasm_text() will be deprecated in upcoming versions (>0.5.0). "
+            "Using qiskit.load_qasm_text() instead is recommended.", DeprecationWarning)
+        circuit_unrolled = qiskit.wrapper.load_qasm_text(qasm_string, name, basis_gates)
         self.add_circuit(name, circuit_unrolled)
         return name
 

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -22,8 +22,6 @@ Qasm Program Class
 import itertools
 import json
 import logging
-import os
-import uuid
 import warnings
 
 import qiskit.wrapper
@@ -36,7 +34,6 @@ from ._quantumjob import QuantumJob
 from ._quantumregister import QuantumRegister
 from .mapper import coupling_dict2list
 from .qasm import Qasm
-from .unroll import CircuitBackend, Unroller
 
 logger = logging.getLogger(__name__)
 
@@ -425,7 +422,7 @@ class QuantumProgram(object):
         warnings.warn(
             "QuantumProgram.load_qasm_file() will be deprecated in upcoming versions (>0.5.0). "
             "Using qiskit.load_qasm_file() instead is recommended.", DeprecationWarning)
-        circuit_unrolled = qiskit.wrapper.load_qasm_file(qasm_file, name, basis_gates)        
+        circuit_unrolled = qiskit.wrapper.load_qasm_file(qasm_file, name, basis_gates)
         self.add_circuit(name, circuit_unrolled)
         return name
 
@@ -445,7 +442,7 @@ class QuantumProgram(object):
         warnings.warn(
             "QuantumProgram.load_qasm_text() will be deprecated in upcoming versions (>0.5.0). "
             "Using qiskit.load_qasm_text() instead is recommended.", DeprecationWarning)
-        circuit_unrolled = qiskit.wrapper.load_qasm_text(qasm_string, name, basis_gates)
+        circuit_unrolled = qiskit.wrapper.load_qasm_string(qasm_string, name, basis_gates)
         self.add_circuit(name, circuit_unrolled)
         return name
 

--- a/qiskit/wrapper/__init__.py
+++ b/qiskit/wrapper/__init__.py
@@ -25,4 +25,4 @@ refer to the documentation of each component and use them separately.
 
 from ._wrapper import (available_backends, local_backends, remote_backends,
                        get_backend, compile, execute, register,
-                       load_qasm_text, load_qasm_file)
+                       load_qasm_string, load_qasm_file)

--- a/qiskit/wrapper/__init__.py
+++ b/qiskit/wrapper/__init__.py
@@ -24,4 +24,5 @@ refer to the documentation of each component and use them separately.
 """
 
 from ._wrapper import (available_backends, local_backends, remote_backends,
-                       get_backend, compile, execute, register)
+                       get_backend, compile, execute, register,
+                       load_qasm_text, load_qasm_file)

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -223,6 +223,8 @@ def load_qasm_string(qasm_string, name=None,
             text into it. If no name given, assign automatically.
     Returns:
         QuantumCircuit: circuit constructed from qasm.
+    Raises:
+        QISKitError: if the string is not valid QASM
     """
     node_circuit = Qasm(data=qasm_string).parse()
     unrolled_circuit = Unroller(node_circuit, CircuitBackend(basis_gates.split(",")))
@@ -244,8 +246,7 @@ def load_qasm_file(qasm_file, name=None,
             the text file.
         basis_gates (str): basis gates for the quantum circuit.
     Returns:
-        str: Adds a quantum circuit with the gates given in the qasm file to the
-        quantum program and returns the name to be used to get this circuit
+         QuantumCircuit: circuit constructed from qasm.
     Raises:
         QISKitError: if the file cannot be read.
     """
@@ -253,9 +254,8 @@ def load_qasm_file(qasm_file, name=None,
         raise QISKitError('qasm file "{0}" not found'.format(qasm_file))
     if not name:
         name = os.path.splitext(os.path.basename(qasm_file))[0]
-    node_circuit = Qasm(filename=qasm_file).parse()
-    unrolled_circuit = Unroller(node_circuit, CircuitBackend(basis_gates.split(",")))
-    circuit_unrolled = unrolled_circuit.execute()
-    if name:
-        circuit_unrolled.name = name
-    return circuit_unrolled
+
+    with open(qasm_file) as file:
+        qasm_data = file.read()
+
+    return load_qasm_string(qasm_data, name=name, basis_gates=basis_gates)

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -227,6 +227,8 @@ def load_qasm_text(qasm_string, name=None,
     node_circuit = Qasm(data=qasm_string).parse()
     unrolled_circuit = Unroller(node_circuit, CircuitBackend(basis_gates.split(",")))
     circuit_unrolled = unrolled_circuit.execute()
+    if name:
+        circuit_unrolled.name = name
     return circuit_unrolled
 
 
@@ -254,4 +256,6 @@ def load_qasm_file(qasm_file, name=None,
     node_circuit = Qasm(filename=qasm_file).parse()
     unrolled_circuit = Unroller(node_circuit, CircuitBackend(basis_gates.split(",")))
     circuit_unrolled = unrolled_circuit.execute()
-    return name
+    if name:
+        circuit_unrolled.name = name
+    return circuit_unrolled

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -16,11 +16,15 @@
 # =============================================================================
 """Helper module for simplified QISKit usage."""
 
+import os
 import qiskit._compiler
 from qiskit import QISKitError
 from qiskit.backends.ibmq.ibmqprovider import IBMQProvider
 from qiskit.wrapper.defaultqiskitprovider import DefaultQISKitProvider
 from qiskit import QuantumJob
+from qiskit.qasm import Qasm
+from qiskit.unroll import Unroller, CircuitBackend
+
 
 # Default provider used by the rest of the functions on this module. Please
 # note that this is a global object.
@@ -202,3 +206,52 @@ def execute(circuits, backend,
     q_job = QuantumJob(qobj, backend=backend, preformatted=True, resources={
         'max_credits': qobj['config']['max_credits']})
     return backend.run(q_job)
+
+
+# Functions for importing qasm
+
+
+def load_qasm_text(qasm_string, name=None,
+                   basis_gates="id,u0,u1,u2,u3,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
+                               "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx,cswap"):
+    """Construct a quantum circuit from a qasm representation (string).
+
+    Args:
+        qasm (str): a string of qasm, or a filename containing qasm.
+        basis_gates (str): basis gates for the quantum circuit.
+        name (str or None): the name of the quantum circuit after loading qasm
+            text into it. If no name given, assign automatically.
+    Returns:
+        QuantumCircuit: circuit constructed from qasm.
+    """
+    node_circuit = Qasm(data=qasm_string).parse()
+    unrolled_circuit = Unroller(node_circuit, CircuitBackend(basis_gates.split(",")))
+    circuit_unrolled = unrolled_circuit.execute()
+    return circuit_unrolled
+
+
+def load_qasm_file(qasm_file, name=None,
+                   basis_gates="id,u0,u1,u2,u3,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
+                               "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx,cswap"):
+    """Construct a quantum circuit from a qasm representation (file).
+
+    Args:
+        qasm_file (str): a string for the filename including its location.
+        name (str or None): the name of the quantum circuit after
+            loading qasm text into it. If no name is give the name is of
+            the text file.
+        basis_gates (str): basis gates for the quantum circuit.
+    Returns:
+        str: Adds a quantum circuit with the gates given in the qasm file to the
+        quantum program and returns the name to be used to get this circuit
+    Raises:
+        QISKitError: if the file cannot be read.
+    """    
+    if not os.path.exists(qasm_file):
+        raise QISKitError('qasm file "{0}" not found'.format(qasm_file))
+    if not name:
+        name = os.path.splitext(os.path.basename(qasm_file))[0]
+    node_circuit = Qasm(filename=qasm_file).parse()
+    unrolled_circuit = Unroller(node_circuit, CircuitBackend(basis_gates.split(",")))
+    circuit_unrolled = unrolled_circuit.execute()
+    return name

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -31,7 +31,7 @@ from qiskit.unroll import Unroller, CircuitBackend
 _DEFAULT_PROVIDER = DefaultQISKitProvider()
 
 
-def register(token, url,
+def register(token, url='https://quantumexperience.ng.bluemix.net/api',
              hub=None, group=None, project=None, proxies=None, verify=True,
              provider_name='ibmq'):
     """
@@ -211,13 +211,13 @@ def execute(circuits, backend,
 # Functions for importing qasm
 
 
-def load_qasm_text(qasm_string, name=None,
-                   basis_gates="id,u0,u1,u2,u3,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
-                               "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx,cswap"):
+def load_qasm_string(qasm_string, name=None,
+                     basis_gates="id,u0,u1,u2,u3,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
+                                 "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx,cswap"):
     """Construct a quantum circuit from a qasm representation (string).
 
     Args:
-        qasm (str): a string of qasm, or a filename containing qasm.
+        qasm_string (str): a string of qasm, or a filename containing qasm.
         basis_gates (str): basis gates for the quantum circuit.
         name (str or None): the name of the quantum circuit after loading qasm
             text into it. If no name given, assign automatically.
@@ -248,7 +248,7 @@ def load_qasm_file(qasm_file, name=None,
         quantum program and returns the name to be used to get this circuit
     Raises:
         QISKitError: if the file cannot be read.
-    """    
+    """
     if not os.path.exists(qasm_file):
         raise QISKitError('qasm file "{0}" not found'.format(qasm_file))
     if not name:

--- a/test/python/test_load_qasm.py
+++ b/test/python/test_load_qasm.py
@@ -83,17 +83,17 @@ measure b[3] -> d[3];
                           load_qasm_file, "", name=None)
 
     def test_fail_load_qasm_string(self):
-            """Test fail_load_qasm_string.
+        """Test fail_load_qasm_string.
 
-            If all is correct we should get a QISKitError
+        If all is correct we should get a QISKitError
 
-            Previously:
-                Libraries:
-                    from qiskit import QISKitError
-                    from qiskit.wrapper import load_qasm_string
-            """
-            self.assertRaises(QISKitError,
-                              load_qasm_string, "", name=None)
+        Previously:
+            Libraries:
+                from qiskit import QISKitError
+                from qiskit.wrapper import load_qasm_string
+        """
+        self.assertRaises(QISKitError,
+                          load_qasm_string, "", name=None)
 
     def test_load_qasm_text(self):
         """Test load_qasm_text and get_circuit.

--- a/test/python/test_load_qasm.py
+++ b/test/python/test_load_qasm.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
+#
+# Copyright 2017 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+from qiskit import QISKitError
+from qiskit.wrapper import load_qasm_file, load_qasm_string
+from .common import QiskitTestCase, Path
+
+
+class LoadQasmTest(QiskitTestCase):
+    """Test load_qasm_* set of methods."""
+
+    def setUp(self):
+        self.QASM_FILE_NAME = 'entangled_registers.qasm'
+        self.QASM_FILE_PATH = self._get_resource_path(
+            'qasm/' + self.QASM_FILE_NAME, Path.EXAMPLES)
+
+    def test_load_qasm_file(self):
+        """Test load_qasm_file and get_circuit.
+
+        If all is correct we should get the qasm file loaded in QASM_FILE_PATH
+
+        Previously:
+            Libraries:
+                from qiskit.wrapper import load_qasm_file
+        """
+        q_circuit = load_qasm_file(self.QASM_FILE_PATH)
+        qasm_string = q_circuit.qasm()
+        self.log.info(qasm_string)
+        expected_qasm_string = """\
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg a[4];
+qreg b[4];
+creg c[4];
+creg d[4];
+h a[0];
+h a[1];
+h a[2];
+h a[3];
+cx a[0],b[0];
+cx a[1],b[1];
+cx a[2],b[2];
+cx a[3],b[3];
+barrier a[0],a[1],a[2],a[3];
+barrier b[0],b[1],b[2],b[3];
+measure a[0] -> c[0];
+measure a[1] -> c[1];
+measure a[2] -> c[2];
+measure a[3] -> c[3];
+measure b[0] -> d[0];
+measure b[1] -> d[1];
+measure b[2] -> d[2];
+measure b[3] -> d[3];
+"""
+        self.assertEqual(qasm_string, expected_qasm_string)
+
+    def test_fail_load_qasm_file(self):
+        """Test fail_load_qasm_file.
+
+        If all is correct we should get a QISKitError
+
+        Previously:
+            Libraries:
+                from qiskit import QISKitError
+                from qiskit.wrapper import load_qasm_file
+        """
+        self.assertRaises(QISKitError,
+                          load_qasm_file, "", name=None)
+
+    def test_fail_load_qasm_string(self):
+            """Test fail_load_qasm_string.
+
+            If all is correct we should get a QISKitError
+
+            Previously:
+                Libraries:
+                    from qiskit import QISKitError
+                    from qiskit.wrapper import load_qasm_string
+            """
+            self.assertRaises(QISKitError,
+                              load_qasm_string, "", name=None)
+
+    def test_load_qasm_text(self):
+        """Test load_qasm_text and get_circuit.
+
+        If all is correct we should get the qasm file loaded from the string
+
+        Previously:
+            Libraries:
+                from qiskit import QuantumProgram
+        """
+        qasm_string = "// A simple 8 qubit example\nOPENQASM 2.0;\n"
+        qasm_string += "include \"qelib1.inc\";\nqreg a[4];\n"
+        qasm_string += "qreg b[4];\ncreg c[4];\ncreg d[4];\nh a;\ncx a, b;\n"
+        qasm_string += "barrier a;\nbarrier b;\nmeasure a[0]->c[0];\n"
+        qasm_string += "measure a[1]->c[1];\nmeasure a[2]->c[2];\n"
+        qasm_string += "measure a[3]->c[3];\nmeasure b[0]->d[0];\n"
+        qasm_string += "measure b[1]->d[1];\nmeasure b[2]->d[2];\n"
+        qasm_string += "measure b[3]->d[3];"
+        q_circuit = load_qasm_string(qasm_string)
+        qasm_data_string = q_circuit.qasm()
+        self.log.info(qasm_data_string)
+        expected_qasm_data_string = """\
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg a[4];
+qreg b[4];
+creg c[4];
+creg d[4];
+h a[0];
+h a[1];
+h a[2];
+h a[3];
+cx a[0],b[0];
+cx a[1],b[1];
+cx a[2],b[2];
+cx a[3],b[3];
+barrier a[0],a[1],a[2],a[3];
+barrier b[0],b[1],b[2],b[3];
+measure a[0] -> c[0];
+measure a[1] -> c[1];
+measure a[2] -> c[2];
+measure a[3] -> c[3];
+measure b[0] -> d[0];
+measure b[1] -> d[1];
+measure b[2] -> d[2];
+measure b[3] -> d[3];
+"""
+        self.assertEqual(qasm_data_string, expected_qasm_data_string)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds a few conveniences to the wrapper:

- ability to load a qasm string/file, and get a corresponding QuantumCircuit object. This function existed in QuantumProgram, and here we move further towards deprecating it.

- Passes the default quantum experience url to the _wrapper.register method, to make it easier to register just by your token.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.