### PR TITLE
Remove -march=native from compiler flags

### DIFF
--- a/cmake/defaults.cmake
+++ b/cmake/defaults.cmake
@@ -3,10 +3,21 @@
 #     out$ cmake -DSTATIC_LINKING=True ..
 #
 
+# Set the build type: Release or Debug
 set(CMAKE_BUILD_TYPE "Release")
+
+# Set the type of linking we want to make for native code. Static builds are
+# great for distributing. Apple doesn't allow full static linking, so only user
+# libraries will be included in the final binary.
 set(STATIC_LINKING False CACHE BOOL "Static linking of executables")
+
+# Enable or disable CMake targets that depends on native code.
 set(ENABLE_TARGETS_NON_PYTHON True CACHE BOOL "Enable targets for non Python code")
+
+# Enable or disable CMake targets for Q&A: tests/linter/style
 set(ENABLE_TARGETS_QA True CACHE BOOL "Enable targets for QA targets")
+
+# Detect platform bit size
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(ARCH64 True CACHE BOOL "We are on a 64 bits platform")
 elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)

--- a/src/qasm-simulator-cpp/CMakeLists.txt
+++ b/src/qasm-simulator-cpp/CMakeLists.txt
@@ -60,7 +60,6 @@ endif()
 if(NOT MSVC)
 	# Compiler flags
 	enable_cxx_compiler_flag_if_supported("-O3")
-	enable_cxx_compiler_flag_if_supported("-march=native")
 	# Warnings and Errors
 	enable_cxx_compiler_flag_if_supported("-pedantic")
 	enable_cxx_compiler_flag_if_supported("-Wall")


### PR DESCRIPTION
As the code it was generating was not 100% compatible with all CPUs of the same
architecture. The loss of performance is negligible.

## Motivation and Context
There are reports of CPP simulator not working on certain CPUs.

## How Has This Been Tested?
It works in one of the problematic machines.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)