### PR TITLE
Bug fix in the C++ simulator: density matrix and probabilities are sometimes erroneous

### DIFF
--- a/src/qasm-simulator-cpp/src/engines/vector_engine.hpp
+++ b/src/qasm-simulator-cpp/src/engines/vector_engine.hpp
@@ -172,10 +172,14 @@ void VectorEngine::execute(const Circuit &prog, BaseBackend<QubitVector> *be,
   // Check to see if circuit is ideal and allows for measurement optimization
   if (prog.opt_meas && prog.noise.ideal) {
 
+    // This optimization replaces the shots by a single shot + sampling
+    // We need to subtract the additional shots added by BaseEngine class
+    total_shots -= (nshots-1);
+
     // Find position of first measurement operation
     uint_t pos = 0;
-    while (prog.operations[pos].id != gate_t::Measure &&
-           pos < prog.operations.size()) {
+    while (pos < prog.operations.size() &&
+           prog.operations[pos].id != gate_t::Measure) {
       pos++;
     }
     // Execute operations before measurements

--- a/test/python/qobj/cpp_measure_opt.json
+++ b/test/python/qobj/cpp_measure_opt.json
@@ -3,7 +3,8 @@
     "config": {
         "shots": 2000,
         "seed": 1,
-        "backend_name": "local_qasm_simulator_cpp"
+        "backend_name": "local_qasm_simulator_cpp",
+	"data" : ["density_matrix", "probabilities"]
     },
     "circuits": [
         {

--- a/test/python/qobj/cpp_measure_opt.json
+++ b/test/python/qobj/cpp_measure_opt.json
@@ -4,7 +4,7 @@
         "shots": 2000,
         "seed": 1,
         "backend_name": "local_qasm_simulator_cpp",
-	"data" : ["density_matrix", "probabilities"]
+        "data" : ["density_matrix", "probabilities"]
     },
     "circuits": [
         {

--- a/test/python/test_qasm_simulator_cpp.py
+++ b/test/python/test_qasm_simulator_cpp.py
@@ -17,6 +17,8 @@
 
 # =============================================================================
 
+from test.python.common import QiskitTestCase
+
 import json
 import unittest
 import numpy as np
@@ -31,7 +33,6 @@ from qiskit import QuantumRegister
 from qiskit.backends.local.qasm_simulator_cpp import (QasmSimulatorCpp,
                                                       cx_error_matrix,
                                                       x90_error_matrix)
-from .common import QiskitTestCase
 
 
 class TestLocalQasmSimulatorCpp(QiskitTestCase):
@@ -205,13 +206,17 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
             snapshots = result.get_snapshots(name)
             self.assertEqual(set(snapshots), {'0'},
                              msg=name + ' snapshot keys')
-            self.assertEqual(len(snapshots['0']), 1,
+            self.assertEqual(len(snapshots['0']), 3,
                              msg=name + ' snapshot length')
             state = snapshots['0']['statevector'][0]
             expected_state = expected_data[name]['statevector']
             fidelity = np.abs(expected_state.dot(state.conj())) ** 2
             self.assertAlmostEqual(fidelity, 1.0, places=10,
                                    msg=name + ' snapshot fidelity')
+            rho = snapshots['0']['density_matrix']
+            self.assertAlmostEqual(np.trace(rho), 1)
+            prob = snapshots['0']['probabilities']
+            self.assertAlmostEqual(np.sum(prob), 1)
 
     def test_qobj_measure_opt_flag(self):
         filename = self._get_resource_path('qobj/cpp_measure_opt_flag.json')


### PR DESCRIPTION
Thanks to Guy Szweigman and Mohammad Heeb, who noticed that the C++ simulator does not always display correct density matrix and probabilities vector. 

This happens in the presence of an optimization, which applies to no-noise circuits where all measurements are located at the end. The optimization replaces the shots by a single shot + sampling. However in the calculation of the density matrix and probabilities vector there is a normalization by the number of shots. This results in a density matrix whose trace is 1/(number of shots), and a probabilities vector whose sum is 1/(number of shots).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I fixed the number of shots when the optimization is applied.

Independently of this pull request, it should be revised whether it is correct to normalize by total_shots. Looks like there is an infrastructure to allow, in the future, that total_shots will be the accumulation of number of shots in executions on different engines. What happens if one of the engines does not support density_matrix?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I updated test_qasm_simulator_cpp.py
Note: test__simulator_online_size in test_quantumprogram fails in the system.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
       test__simulator_online_size in test_quantumprogram fails in the system.