### PR TITLE
Fix tests for IBM Q network backends

### DIFF
--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -32,7 +32,7 @@ from .common import requires_qe_access, QiskitTestCase, Path
 
 class TestQuantumProgram(QiskitTestCase):
     """QISKit QuantumProgram Object Tests."""
-
+    
     def setUp(self):
         self.QASM_FILE_PATH = self._get_resource_path(
             'qasm/entangled_registers.qasm', Path.EXAMPLES)
@@ -663,7 +663,10 @@ class TestQuantumProgram(QiskitTestCase):
                        'coupling_map', 'basis_gates'}
         qp.set_api(QE_TOKEN, QE_URL, hub, group, project)
         backend_list = qp.available_backends()
-        backend_list.remove('ibmq_qasm_simulator')
+        if 'q-console' in QE_URL:
+            backend_list.remove('ibmqx_qasm_simulator')
+        else:
+            backend_list.remove('ibmq_qasm_simulator')
         if backend_list:
             backend = backend_list[0]
         backend_config = qp.get_backend_configuration(backend)
@@ -1144,7 +1147,10 @@ class TestQuantumProgram(QiskitTestCase):
         qc.measure(qr[0], cr[0])
         shots = 1024
         q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
-        backend = 'ibmq_qasm_simulator'
+        if 'q-console' in QE_URL:
+            backend = 'ibmqx_qasm_simulator'
+        else:
+            backend = 'ibmq_qasm_simulator'
         result = q_program.execute(['qc'], backend=backend,
                                    shots=shots, max_credits=3,
                                    seed=73846087)
@@ -1160,7 +1166,10 @@ class TestQuantumProgram(QiskitTestCase):
 
         If all correct should return the data.
         """
-        backend_name = 'ibmq_qasm_simulator'
+        if 'q-console' in QE_URL:
+            backend_name = 'ibmqx_qasm_simulator'
+        else:
+            backend_name = 'ibmq_qasm_simulator'
         q_program = QuantumProgram()
         qr = q_program.create_quantum_register("q", 31)
         cr = q_program.create_classical_register("c", 31)
@@ -1195,7 +1204,10 @@ class TestQuantumProgram(QiskitTestCase):
         circuits = ['qc1', 'qc2']
         shots = 1024
         q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
-        backend = 'ibmq_qasm_simulator'
+        if 'q-console' in QE_URL:
+            backend = 'ibmqx_qasm_simulator'
+        else:
+            backend = 'ibmq_qasm_simulator'
         result = q_program.execute(circuits, backend=backend, shots=shots,
                                    max_credits=3, seed=1287126141)
         counts1 = result.get_counts('qc1')
@@ -1221,7 +1233,10 @@ class TestQuantumProgram(QiskitTestCase):
         qc.h(qr)
         qc.measure(qr[0], cr[0])
         q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
-        backend = 'ibmq_qasm_simulator'
+        if 'q-console' in QE_URL:
+            backend = 'ibmqx_qasm_simulator'
+        else:
+            backend = 'ibmq_qasm_simulator'
         shots = 1
         status = q_program.get_backend_status(backend)
         if not status.get('available', False):
@@ -1294,7 +1309,10 @@ class TestQuantumProgram(QiskitTestCase):
         circuits = ['qc1', 'qc2']
         shots = 1024
         q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
-        backend = 'ibmq_qasm_simulator'
+        if 'q-console' in QE_URL:
+            backend = 'ibmqx_qasm_simulator'
+        else:
+            backend = 'ibmq_qasm_simulator'
         result = q_program.execute(circuits, backend=backend, shots=shots,
                                    seed=8458)
         result1 = result.get_counts('qc1')
@@ -1770,7 +1788,10 @@ class TestQuantumProgram(QiskitTestCase):
         qc2.measure(qr, cr)
         circuits = ['qc2']
         shots = 1
-        backend = 'ibmq_qasm_simulator'
+        if 'q-console' in QE_URL:
+            backend = 'ibmqx_qasm_simulator'
+        else:
+            backend = 'ibmq_qasm_simulator'
         q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
         qobj = q_program.compile(circuits, backend=backend, shots=shots,
                                  seed=88,
@@ -1795,7 +1816,10 @@ class TestQuantumProgram(QiskitTestCase):
         qc2.measure(qr, cr)
         circuits = ['qc2']
         shots = 1
-        backend = 'ibmq_qasm_simulator'
+        if 'q-console' in QE_URL:
+            backend = 'ibmqx_qasm_simulator'
+        else:
+            backend = 'ibmq_qasm_simulator'
         q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
         self.assertRaises(QISKitError, q_program.compile, circuits,
                           backend=backend, shots=shots, seed=88,

--- a/test/python/test_simulator_interfaces.py
+++ b/test/python/test_simulator_interfaces.py
@@ -73,7 +73,10 @@ class TestCrossSimulation(QiskitTestCase):
 
         sim_cpp = 'local_qasm_simulator_cpp'
         sim_py = 'local_qasm_simulator_py'
-        sim_ibmq = 'ibmq_qasm_simulator'
+        if 'q-console' in QE_URL:
+            sim_ibmq = 'ibmqx_qasm_simulator'
+        else:
+            sim_ibmq = 'ibmq_qasm_simulator'
         shots = 2000
         result_cpp = execute(circ, sim_cpp, shots=shots).result()
         result_py = execute(circ, sim_py, shots=shots).result()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We had a collection of tests that failed on Q network setups due to name mismatches between `ibmq`  and `ibmqx`.  This PR changes the backend name depending on the `QE_URL`.

## Motivation and Context
Want tests to pass on Q network setups as well.

## How Has This Been Tested?
Tests pass against Q network.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.